### PR TITLE
Verify VC++ runtime before packaging

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -49,9 +49,20 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force rust\target\installer-deps | Out-Null
+          $vcRedistPath = "rust\target\installer-deps\vc_redist.x64.exe"
           Invoke-WebRequest `
             -Uri "https://aka.ms/vc14/vc_redist.x64.exe" `
-            -OutFile "rust\target\installer-deps\vc_redist.x64.exe"
+            -OutFile $vcRedistPath
+
+          $signature = Get-AuthenticodeSignature -FilePath $vcRedistPath
+          if ($signature.Status -ne 'Valid') {
+            throw "vc_redist.x64.exe signature is not valid. Status: $($signature.Status)"
+          }
+
+          $subject = $signature.SignerCertificate.Subject
+          if ($subject -notlike '*Microsoft Corporation*') {
+            throw "vc_redist.x64.exe signer is unexpected: $subject"
+          }
 
       - name: Build installer
         shell: pwsh

--- a/rust/scripts/build-installer.sh
+++ b/rust/scripts/build-installer.sh
@@ -14,6 +14,7 @@ INNO_IMAGE="${INNO_SETUP_IMAGE:-amake/innosetup}"
 CONTAINER_NAME="codexbar-inno-${VERSION//./-}-$$"
 VC_REDIST_URL="${VC_REDIST_URL:-https://aka.ms/vc14/vc_redist.x64.exe}"
 VC_REDIST_PATH="$INSTALLER_DEPS_DIR/vc_redist.x64.exe"
+VC_REDIST_SHA256="${VC_REDIST_SHA256:-}"
 
 for required_file in "$TARGET_BIN_DIR/codexbar.exe" "$RUST_DIR/icons/icon.ico"; do
   if [[ ! -f "$required_file" ]]; then
@@ -27,6 +28,31 @@ mkdir -p "$OUTPUT_DIR"
 mkdir -p "$INSTALLER_DEPS_DIR"
 
 curl -L "$VC_REDIST_URL" -o "$VC_REDIST_PATH"
+
+if [[ -z "$VC_REDIST_SHA256" ]]; then
+  cat >&2 <<'EOF'
+VC_REDIST_SHA256 is required to verify vc_redist.x64.exe.
+Set VC_REDIST_SHA256 to the expected SHA-256 hash from a trusted source.
+EOF
+  exit 1
+fi
+
+expected_sha256="$(printf '%s' "$VC_REDIST_SHA256" | tr '[:upper:]' '[:lower:]')"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_sha256="$(sha256sum "$VC_REDIST_PATH" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_sha256="$(shasum -a 256 "$VC_REDIST_PATH" | awk '{print $1}')"
+else
+  echo "Missing SHA-256 tool (sha256sum or shasum) required for vc_redist verification." >&2
+  exit 1
+fi
+
+if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+  echo "vc_redist.x64.exe checksum mismatch." >&2
+  echo "Expected: $expected_sha256" >&2
+  echo "Actual:   $actual_sha256" >&2
+  exit 1
+fi
 
 cleanup() {
   docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true


### PR DESCRIPTION
### Motivation
- The release workflow and local installer script previously downloaded `vc_redist.x64.exe` and embedded it into the installer without any integrity or signature checks, creating a supply-chain risk of arbitrary code execution during install. 
- The installer executes the bundled runtime, so a tampered download could run on end-user machines. 
- The change enforces explicit verification to ensure the runtime artifact is trusted before packaging.

### Description
- Add Authenticode verification in `.github/workflows/release-windows.yml` by calling `Get-AuthenticodeSignature` on the downloaded `vc_redist.x64.exe`, requiring a `Status` of `Valid` and that the signer subject contains `Microsoft Corporation` before proceeding. 
- Require an explicit `VC_REDIST_SHA256` environment variable in `rust/scripts/build-installer.sh` and verify the downloaded file's SHA-256 against this expected value using `sha256sum` or `shasum` before bundling. 
- Fail fast with clear error messages when signature or checksum verification is missing or does not match to prevent packaging untrusted binaries.

### Testing
- Ran a shell syntax check with `bash -n rust/scripts/build-installer.sh`, which completed successfully. 
- Performed local diffs and sanity checks (`git diff` / commit) to validate the changes were applied as intended; no automated unit tests were modified or required for this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cfe4ff82848331953ad637109b242b)