### PR TITLE
Harden CLI binary resolution against CWD hijacking

### DIFF
--- a/rust/src/cli/tty_runner.rs
+++ b/rust/src/cli/tty_runner.rs
@@ -265,6 +265,11 @@ impl TtyCommandRunner {
         Some(PathBuf::from(first_line))
     }
 
+    fn is_explicit_binary_path(binary: &str) -> bool {
+        let path = std::path::Path::new(binary);
+        path.is_absolute() || path.components().count() > 1
+    }
+
     /// Run a command and capture its output
     ///
     /// This is a simplified version for Windows that doesn't use PTY.
@@ -276,8 +281,13 @@ impl TtyCommandRunner {
         options: TtyCommandOptions,
     ) -> Result<TtyCommandResult, TtyCommandError> {
         // Resolve the binary path
-        let resolved = if std::path::Path::new(binary).exists() {
-            PathBuf::from(binary)
+        let resolved = if Self::is_explicit_binary_path(binary) {
+            let path = PathBuf::from(binary);
+            if path.exists() {
+                path
+            } else {
+                return Err(TtyCommandError::BinaryNotFound(binary.to_string()));
+            }
         } else if let Some(path) = Self::which(binary) {
             path
         } else {

--- a/rust/src/host/command_runner.rs
+++ b/rust/src/host/command_runner.rs
@@ -127,6 +127,11 @@ impl CommandRunner {
         which::which(binary).ok()
     }
 
+    fn is_explicit_binary_path(binary: &str) -> bool {
+        let path = std::path::Path::new(binary);
+        path.is_absolute() || path.components().count() > 1
+    }
+
     /// Run a command and capture output
     pub fn run(
         &self,
@@ -135,8 +140,13 @@ impl CommandRunner {
         options: &CommandOptions,
     ) -> Result<CommandResult, CommandError> {
         // Find the binary
-        let binary_path = if std::path::Path::new(binary).exists() {
-            PathBuf::from(binary)
+        let binary_path = if Self::is_explicit_binary_path(binary) {
+            let path = PathBuf::from(binary);
+            if path.exists() {
+                path
+            } else {
+                return Err(CommandError::BinaryNotFound(binary.to_string()));
+            }
         } else {
             Self::which(binary).ok_or_else(|| CommandError::BinaryNotFound(binary.to_string()))?
         };


### PR DESCRIPTION
### Motivation

- The previous resolution order allowed a bare command name (e.g. `claude`/`codex`) to resolve to an executable in the current working directory, enabling local binary hijacking.
- This change restricts filesystem execution to explicit paths so that bare names are resolved strictly via PATH, restoring safe lookup semantics.

### Description

- Added `is_explicit_binary_path` helper to `rust/src/cli/tty_runner.rs` and `rust/src/host/command_runner.rs` to detect explicit filesystem paths (absolute or multi-component).
- Updated binary resolution in both runners so an explicit path is required to execute a file directly, otherwise the code uses `which`/`where` to resolve the command name via PATH.
- Preserved existing behavior for explicit paths and the `which`-based fallbacks; changes are localized to `TtyCommandRunner::run` and `CommandRunner::run`.

### Testing

- Ran `cargo fmt --all` successfully to format changes.
- Attempted `cargo test`, but tests could not be completed in this environment because the Windows target toolchain `x86_64-pc-windows-msvc` is not installed (build failed with target-not-installed errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d0022454f083318afe71506669abc5)