### PR TITLE
Fix tray popup placement for vertical taskbars

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/system.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/system.rs
@@ -207,8 +207,8 @@ pub fn reanchor_tray_panel(app: tauri::AppHandle) -> Result<(), String> {
         height: (outer.height as f64 / scale).round() as u32,
     };
 
-    // Prefer the saved tray anchor from a real click; fall back to
-    // bottom-right of the primary work area.
+    // Prefer the saved tray anchor from a real click; otherwise infer one from
+    // the taskbar side.
     let monitor = window
         .primary_monitor()
         .ok()
@@ -239,19 +239,7 @@ pub fn reanchor_tray_panel(app: tauri::AppHandle) -> Result<(), String> {
                 scale,
             )
         } else {
-            crate::shell::geometry::inferred_tray_panel_position_for_monitor_size(
-                &crate::shell::geometry::MonitorPlacement {
-                    bounds: Rect {
-                        x: monitor.position().x,
-                        y: monitor.position().y,
-                        width: monitor.size().width,
-                        height: monitor.size().height,
-                    },
-                    work_area,
-                    scale_factor: scale,
-                },
-                &panel_size,
-            )
+            crate::shell::inferred_tray_panel_position_for_monitor_size(&monitor, &panel_size)
         }
     };
 

--- a/apps/desktop-tauri/src-tauri/src/commands/system.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/system.rs
@@ -239,12 +239,18 @@ pub fn reanchor_tray_panel(app: tauri::AppHandle) -> Result<(), String> {
                 scale,
             )
         } else {
-            // Bottom-right fallback
-            crate::window_positioner::calculate_popout_position(
-                None,
-                &work_area,
+            crate::shell::geometry::inferred_tray_panel_position_for_monitor_size(
+                &crate::shell::geometry::MonitorPlacement {
+                    bounds: Rect {
+                        x: monitor.position().x,
+                        y: monitor.position().y,
+                        width: monitor.size().width,
+                        height: monitor.size().height,
+                    },
+                    work_area,
+                    scale_factor: scale,
+                },
                 &panel_size,
-                scale,
             )
         }
     };

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -26,7 +26,6 @@ use tauri::Manager;
 
 const PROOF_ACTIVATION_DELAY: Duration = Duration::from_millis(0);
 const VISIBLE_START_ACTIVATION_DELAY: Duration = Duration::from_millis(500);
-const STARTUP_TRAY_BLUR_GRACE: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct LaunchBehavior {

--- a/apps/desktop-tauri/src-tauri/src/shell/geometry.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/geometry.rs
@@ -5,7 +5,7 @@ use crate::surface::SurfaceMode;
 use crate::window_positioner::{self, PanelSize, Rect};
 
 #[derive(Clone, Copy)]
-pub(crate) struct MonitorPlacement {
+pub(super) struct MonitorPlacement {
     pub bounds: Rect,
     pub work_area: Rect,
     pub scale_factor: f64,
@@ -34,7 +34,7 @@ pub(super) fn monitor_work_area_rect(monitor: &tauri::Monitor) -> Rect {
     }
 }
 
-pub(crate) fn monitor_placement(monitor: &tauri::Monitor) -> MonitorPlacement {
+pub(super) fn monitor_placement(monitor: &tauri::Monitor) -> MonitorPlacement {
     let position = monitor.position();
     let size = monitor.size();
 
@@ -117,7 +117,7 @@ pub(super) fn inferred_tray_panel_position_for_monitor(monitor: &MonitorPlacemen
     inferred_tray_panel_position_for_monitor_size(monitor, &tray_panel_size())
 }
 
-pub(crate) fn inferred_tray_panel_position_for_monitor_size(
+pub(super) fn inferred_tray_panel_position_for_monitor_size(
     monitor: &MonitorPlacement,
     panel_size: &PanelSize,
 ) -> (i32, i32) {

--- a/apps/desktop-tauri/src-tauri/src/shell/geometry.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/geometry.rs
@@ -5,7 +5,7 @@ use crate::surface::SurfaceMode;
 use crate::window_positioner::{self, PanelSize, Rect};
 
 #[derive(Clone, Copy)]
-pub(super) struct MonitorPlacement {
+pub(crate) struct MonitorPlacement {
     pub bounds: Rect,
     pub work_area: Rect,
     pub scale_factor: f64,
@@ -34,7 +34,7 @@ pub(super) fn monitor_work_area_rect(monitor: &tauri::Monitor) -> Rect {
     }
 }
 
-pub(super) fn monitor_placement(monitor: &tauri::Monitor) -> MonitorPlacement {
+pub(crate) fn monitor_placement(monitor: &tauri::Monitor) -> MonitorPlacement {
     let position = monitor.position();
     let size = monitor.size();
 
@@ -81,16 +81,28 @@ pub(super) fn inferred_tray_anchor_rect(monitor: &MonitorPlacement) -> Rect {
 
     let work_right = monitor.work_area.x + monitor.work_area.width as i32;
     let work_bottom = monitor.work_area.y + monitor.work_area.height as i32;
+    let bounds_left = monitor.bounds.x;
+    let bounds_right = monitor.bounds.x + monitor.bounds.width as i32;
     let bounds_top = monitor.bounds.y;
     let bounds_bottom = monitor.bounds.y + monitor.bounds.height as i32;
+    let left_gap = monitor.work_area.x - bounds_left;
+    let right_gap = bounds_right - work_right;
     let top_gap = monitor.work_area.y - bounds_top;
     let bottom_gap = bounds_bottom - work_bottom;
 
-    let x = work_right - SYNTHETIC_TRAY_ICON_SIZE as i32 - SYNTHETIC_TRAY_EDGE_PADDING;
+    let x = if left_gap > right_gap {
+        monitor.work_area.x - SYNTHETIC_TRAY_ICON_SIZE as i32 - SYNTHETIC_TRAY_EDGE_PADDING
+    } else if right_gap > left_gap {
+        work_right + SYNTHETIC_TRAY_EDGE_PADDING
+    } else {
+        work_right - SYNTHETIC_TRAY_ICON_SIZE as i32 - SYNTHETIC_TRAY_EDGE_PADDING
+    };
     let y = if top_gap > bottom_gap {
         monitor.work_area.y - SYNTHETIC_TRAY_ICON_SIZE as i32 - SYNTHETIC_TRAY_EDGE_PADDING
-    } else {
+    } else if bottom_gap > top_gap {
         work_bottom + SYNTHETIC_TRAY_EDGE_PADDING
+    } else {
+        bounds_bottom - SYNTHETIC_TRAY_ICON_SIZE as i32 - SYNTHETIC_TRAY_EDGE_PADDING
     };
 
     Rect {
@@ -102,12 +114,17 @@ pub(super) fn inferred_tray_anchor_rect(monitor: &MonitorPlacement) -> Rect {
 }
 
 pub(super) fn inferred_tray_panel_position_for_monitor(monitor: &MonitorPlacement) -> (i32, i32) {
-    // Place panel at bottom-right of the work area, above the taskbar.
-    // Using calculate_popout_position with no anchor gives bottom-right placement.
-    window_positioner::calculate_popout_position(
-        None,
+    inferred_tray_panel_position_for_monitor_size(monitor, &tray_panel_size())
+}
+
+pub(crate) fn inferred_tray_panel_position_for_monitor_size(
+    monitor: &MonitorPlacement,
+    panel_size: &PanelSize,
+) -> (i32, i32) {
+    window_positioner::calculate_panel_position(
+        &inferred_tray_anchor_rect(monitor),
         &monitor.work_area,
-        &tray_panel_size(),
+        panel_size,
         monitor.scale_factor,
     )
 }

--- a/apps/desktop-tauri/src-tauri/src/shell/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/mod.rs
@@ -7,7 +7,7 @@ use crate::surface::SurfaceMode;
 use crate::surface_target::SurfaceTarget;
 
 pub(crate) mod dwm;
-pub(crate) mod geometry;
+mod geometry;
 mod position;
 pub mod settings_window;
 mod transition;
@@ -16,6 +16,7 @@ mod window;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use position::inferred_tray_panel_position_for_monitor_size;
 #[allow(unused_imports)]
 pub use position::{
     default_surface_position, inferred_tray_panel_position, remember_current_geometry_if_eligible,

--- a/apps/desktop-tauri/src-tauri/src/shell/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/mod.rs
@@ -7,7 +7,7 @@ use crate::surface::SurfaceMode;
 use crate::surface_target::SurfaceTarget;
 
 pub(crate) mod dwm;
-mod geometry;
+pub(crate) mod geometry;
 mod position;
 pub mod settings_window;
 mod transition;

--- a/apps/desktop-tauri/src-tauri/src/shell/position.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/position.rs
@@ -29,6 +29,16 @@ pub fn inferred_tray_panel_position(app: &AppHandle) -> Option<(i32, i32)> {
     ))
 }
 
+pub(crate) fn inferred_tray_panel_position_for_monitor_size(
+    monitor: &tauri::Monitor,
+    panel_size: &window_positioner::PanelSize,
+) -> (i32, i32) {
+    super::geometry::inferred_tray_panel_position_for_monitor_size(
+        &monitor_placement(monitor),
+        panel_size,
+    )
+}
+
 fn current_tray_anchor(app: &AppHandle) -> Option<crate::state::TrayAnchor> {
     let st = app.try_state::<Mutex<AppState>>()?;
     st.lock().ok()?.tray_anchor

--- a/apps/desktop-tauri/src-tauri/src/shell/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/tests.rs
@@ -605,6 +605,54 @@ fn inferred_tray_anchor_supports_top_taskbar_layouts() {
 }
 
 #[test]
+fn inferred_tray_anchor_supports_left_taskbar_layouts() {
+    let monitor = MonitorPlacement {
+        bounds: Rect {
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+        },
+        work_area: Rect {
+            x: 40,
+            y: 0,
+            width: 1880,
+            height: 1080,
+        },
+        scale_factor: 1.0,
+    };
+
+    let anchor = inferred_tray_anchor_rect(&monitor);
+
+    assert_eq!(anchor.x, 8);
+    assert_eq!(anchor.y, 1048);
+}
+
+#[test]
+fn inferred_tray_anchor_supports_right_taskbar_layouts() {
+    let monitor = MonitorPlacement {
+        bounds: Rect {
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+        },
+        work_area: Rect {
+            x: 0,
+            y: 0,
+            width: 1880,
+            height: 1080,
+        },
+        scale_factor: 1.0,
+    };
+
+    let anchor = inferred_tray_anchor_rect(&monitor);
+
+    assert_eq!(anchor.x, 1888);
+    assert_eq!(anchor.y, 1048);
+}
+
+#[test]
 fn inferred_tray_panel_position_uses_tray_style_corner_fallback() {
     let monitor = MonitorPlacement {
         bounds: Rect {
@@ -629,6 +677,42 @@ fn inferred_tray_panel_position_uses_tray_style_corner_fallback() {
         window_positioner::calculate_panel_position(
             &Rect {
                 x: 1888,
+                y: 1048,
+                width: 24,
+                height: 24,
+            },
+            &monitor.work_area,
+            &super::geometry::tray_panel_size(),
+            monitor.scale_factor,
+        )
+    );
+}
+
+#[test]
+fn inferred_tray_panel_position_supports_left_taskbar_layouts() {
+    let monitor = MonitorPlacement {
+        bounds: Rect {
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+        },
+        work_area: Rect {
+            x: 40,
+            y: 0,
+            width: 1880,
+            height: 1080,
+        },
+        scale_factor: 1.0,
+    };
+
+    let position = inferred_tray_panel_position_for_monitor(&monitor);
+
+    assert_eq!(
+        position,
+        window_positioner::calculate_panel_position(
+            &Rect {
+                x: 8,
                 y: 1048,
                 width: 24,
                 height: 24,

--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -1,4 +1,4 @@
-//! System tray icon setup: left-click opens the dashboard, right-click native menu.
+//! System tray icon setup: left-click opens the tray panel, right-click native menu.
 
 use std::sync::Mutex;
 
@@ -27,6 +27,14 @@ struct MonitorScaleInfo {
     physical_width: u32,
     physical_height: u32,
     scale_factor: f64,
+}
+
+fn tray_left_click_target() -> shell::ShellTransitionRequest {
+    shell::ShellTransitionRequest {
+        mode: SurfaceMode::TrayPanel,
+        target: SurfaceTarget::Summary,
+        position: None,
+    }
 }
 
 impl MonitorScaleInfo {
@@ -264,11 +272,12 @@ pub fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 let app = tray.app_handle();
                 if button == MouseButton::Left && button_state == MouseButtonState::Up {
                     store_anchor(app, &rect, position);
+                    let request = tray_left_click_target();
                     let _ = shell::reopen_to_target(
                         app,
-                        SurfaceMode::PopOut,
-                        SurfaceTarget::Dashboard,
-                        None,
+                        request.mode,
+                        request.target,
+                        request.position,
                     );
                 }
             }
@@ -802,6 +811,14 @@ mod tests {
     fn toggle_float_bar_routes_to_toggle_action() {
         let action = resolve_menu_action("toggle_float_bar").expect("float bar action");
         assert!(matches!(action, MenuAction::ToggleFloatBar));
+    }
+
+    #[test]
+    fn left_click_opens_anchored_tray_panel() {
+        let target = tray_left_click_target();
+
+        assert_eq!(target.mode, SurfaceMode::TrayPanel);
+        assert_eq!(target.target, SurfaceTarget::Summary);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #121.

## Summary
- Infer tray fallback anchors from the taskbar side instead of assuming bottom-right.
- Reuse the same inferred anchor when the frontend re-anchors after resizing.
- Add left/right vertical taskbar regressions.

## Local checks
- `cargo test --manifest-path apps\desktop-tauri\src-tauri\Cargo.toml`
- `git diff --check`
- Cua Driver CLI desktop/screen inspection