### PR TITLE
Add GPT-5.6 pricing

### DIFF
--- a/rust/src/codex_costs.rs
+++ b/rust/src/codex_costs.rs
@@ -3,13 +3,10 @@
 #[cfg(test)]
 use chrono::Local;
 use chrono::{Duration, NaiveDate};
-use std::collections::HashMap;
 use std::path::Path;
 
-use crate::core::{CostUsageDayRange, CostUsagePricing, JsonlScanner};
+use crate::core::{CodexUsageRecord, CostUsageDayRange, CostUsagePricing, JsonlScanner};
 use crate::cost_scanner::{CostSummary, ModelTokenCounts};
-
-pub(crate) type CodexDays = HashMap<String, HashMap<String, Vec<i32>>>;
 
 pub(crate) fn codex_period_start(today: NaiveDate, days: u32) -> NaiveDate {
     today - Duration::days(days.saturating_sub(1) as i64)
@@ -30,47 +27,21 @@ pub(crate) fn codex_scan_dates(range: &CostUsageDayRange) -> Vec<NaiveDate> {
     dates
 }
 
-pub(crate) fn add_codex_days_to_summary(
+pub(crate) fn add_codex_records_to_summary(
     summary: &mut CostSummary,
-    days: &CodexDays,
+    records: &[CodexUsageRecord],
     range: &CostUsageDayRange,
 ) -> (f64, bool) {
     let mut total_cost = 0.0;
     let mut has_tokens = false;
 
-    for models in codex_days_in_range(days, range) {
-        for (model, packed) in models {
-            let tokens = CodexTokenCounts::from_packed(packed);
-            if tokens.is_empty() {
-                continue;
-            }
-
-            let cost = codex_cost_usd(model, tokens.input, tokens.cached, tokens.output);
+    for record in records.iter().filter(|record| {
+        CostUsageDayRange::is_in_range(&record.day_key, &range.since_key, &range.until_key)
+    }) {
+        let tokens = CodexTokenCounts::from_values(record.input, record.cached, record.output);
+        if let Some(cost) = add_codex_tokens_to_summary(summary, &record.model, tokens) {
             total_cost += cost;
             has_tokens = true;
-
-            summary.input_tokens += tokens.input;
-            summary.cached_tokens += tokens.cached;
-            summary.output_tokens += tokens.output;
-            *summary.by_model.entry(model.clone()).or_insert(0.0) += cost;
-
-            let speed_bucket = codex_speed_bucket(model);
-            *summary
-                .by_speed
-                .entry(speed_bucket.to_string())
-                .or_insert(0.0) += cost;
-
-            add_tokens(
-                summary.by_model_tokens.entry(model.clone()).or_default(),
-                tokens,
-            );
-            add_tokens(
-                summary
-                    .by_speed_tokens
-                    .entry(speed_bucket.to_string())
-                    .or_default(),
-                tokens,
-            );
         }
     }
 
@@ -83,7 +54,7 @@ pub(crate) fn scan_codex_file_cost_for_range(path: &Path, range: &CostUsageDayRa
         Err(_) => return 0.0,
     };
 
-    codex_days_cost(&parse_result.days, range)
+    codex_records_cost(&parse_result.records, range)
 }
 
 #[cfg(test)]
@@ -101,12 +72,12 @@ struct CodexTokenCounts {
 }
 
 impl CodexTokenCounts {
-    fn from_packed(packed: &[i32]) -> Self {
-        let input = packed.first().copied().unwrap_or(0).max(0) as u64;
+    fn from_values(input: i32, cached: i32, output: i32) -> Self {
+        let input = input.max(0) as u64;
         Self {
             input,
-            cached: (packed.get(1).copied().unwrap_or(0).max(0) as u64).min(input),
-            output: packed.get(2).copied().unwrap_or(0).max(0) as u64,
+            cached: (cached.max(0) as u64).min(input),
+            output: output.max(0) as u64,
         }
     }
 
@@ -121,32 +92,56 @@ fn add_tokens(summary: &mut ModelTokenCounts, tokens: CodexTokenCounts) {
     summary.cached_tokens += tokens.cached;
 }
 
-fn codex_days_cost(days: &CodexDays, range: &CostUsageDayRange) -> f64 {
+fn add_codex_tokens_to_summary(
+    summary: &mut CostSummary,
+    model: &str,
+    tokens: CodexTokenCounts,
+) -> Option<f64> {
+    if tokens.is_empty() {
+        return None;
+    }
+
+    let cost = codex_cost_usd(model, tokens.input, tokens.cached, tokens.output);
+    summary.input_tokens += tokens.input;
+    summary.cached_tokens += tokens.cached;
+    summary.output_tokens += tokens.output;
+    *summary.by_model.entry(model.to_string()).or_insert(0.0) += cost;
+
+    let speed_bucket = codex_speed_bucket(model);
+    *summary
+        .by_speed
+        .entry(speed_bucket.to_string())
+        .or_insert(0.0) += cost;
+    add_tokens(
+        summary
+            .by_model_tokens
+            .entry(model.to_string())
+            .or_default(),
+        tokens,
+    );
+    add_tokens(
+        summary
+            .by_speed_tokens
+            .entry(speed_bucket.to_string())
+            .or_default(),
+        tokens,
+    );
+    Some(cost)
+}
+
+fn codex_records_cost(records: &[CodexUsageRecord], range: &CostUsageDayRange) -> f64 {
     let mut total_cost = 0.0;
 
-    for models in codex_days_in_range(days, range) {
-        for (model, packed) in models {
-            let tokens = CodexTokenCounts::from_packed(packed);
-            if tokens.is_empty() {
-                continue;
-            }
-
-            total_cost += codex_cost_usd(model, tokens.input, tokens.cached, tokens.output);
+    for record in records.iter().filter(|record| {
+        CostUsageDayRange::is_in_range(&record.day_key, &range.since_key, &range.until_key)
+    }) {
+        let tokens = CodexTokenCounts::from_values(record.input, record.cached, record.output);
+        if !tokens.is_empty() {
+            total_cost += codex_cost_usd(&record.model, tokens.input, tokens.cached, tokens.output);
         }
     }
 
     total_cost
-}
-
-fn codex_days_in_range<'a>(
-    days: &'a CodexDays,
-    range: &'a CostUsageDayRange,
-) -> impl Iterator<Item = &'a HashMap<String, Vec<i32>>> + 'a {
-    days.iter()
-        .filter(move |(day_key, _)| {
-            CostUsageDayRange::is_in_range(day_key, &range.since_key, &range.until_key)
-        })
-        .map(|(_, models)| models)
 }
 
 fn codex_speed_bucket(model: &str) -> &'static str {
@@ -189,6 +184,7 @@ fn codex_cost_usd(model: &str, input: u64, cached: u64, output: u64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::CodexUsageRecord;
 
     #[test]
     fn test_codex_pricing() {
@@ -208,52 +204,45 @@ mod tests {
     }
 
     #[test]
+    fn codex_summary_prices_gpt56_usage_records_individually() {
+        let target = NaiveDate::from_ymd_opt(2026, 5, 31).unwrap();
+        let range = CostUsageDayRange::new(target, target);
+        let records = vec![
+            CodexUsageRecord {
+                day_key: "2026-05-31".to_string(),
+                model: "gpt-5.6-sol".to_string(),
+                input: 200_000,
+                cached: 0,
+                output: 0,
+            },
+            CodexUsageRecord {
+                day_key: "2026-05-31".to_string(),
+                model: "gpt-5.6-sol".to_string(),
+                input: 200_000,
+                cached: 0,
+                output: 0,
+            },
+            CodexUsageRecord {
+                day_key: "2026-05-30".to_string(),
+                model: "gpt-5.6-sol".to_string(),
+                input: 200_000,
+                cached: 0,
+                output: 0,
+            },
+        ];
+        let mut summary = CostSummary::default();
+
+        let (cost, has_tokens) = add_codex_records_to_summary(&mut summary, &records, &range);
+
+        assert!(has_tokens);
+        assert_eq!(summary.input_tokens, 400_000);
+        assert!((cost - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
     fn test_codex_speed_bucket() {
         assert_eq!(codex_speed_bucket("gpt-5.5-fast"), "fast");
         assert_eq!(codex_speed_bucket("gpt-5.3-codex-spark"), "fast");
         assert_eq!(codex_speed_bucket("gpt-5-codex"), "standard");
-    }
-
-    #[test]
-    fn codex_summary_filters_expanded_scan_days_to_requested_range() {
-        let target = NaiveDate::from_ymd_opt(2026, 5, 31).unwrap();
-        let range = CostUsageDayRange::new(target, target);
-        let mut days = CodexDays::new();
-        for (day, input) in [
-            ("2026-05-30", 1_000),
-            ("2026-05-31", 2_000),
-            ("2026-06-01", 4_000),
-        ] {
-            days.entry(day.to_string())
-                .or_default()
-                .insert("gpt-5".to_string(), vec![input, 0, 0]);
-        }
-
-        let mut summary = CostSummary::default();
-        let (cost, has_tokens) = add_codex_days_to_summary(&mut summary, &days, &range);
-
-        let expected = codex_cost_usd("gpt-5", 2_000, 0, 0);
-        assert!(has_tokens);
-        assert_eq!(summary.input_tokens, 2_000);
-        assert_eq!(summary.output_tokens, 0);
-        assert!((cost - expected).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn codex_daily_cost_filters_adjacent_scan_padding_days() {
-        let target = NaiveDate::from_ymd_opt(2026, 5, 31).unwrap();
-        let range = CostUsageDayRange::new(target, target);
-        let mut days = CodexDays::new();
-        days.entry("2026-05-30".to_string())
-            .or_default()
-            .insert("gpt-5".to_string(), vec![1_000, 0, 0]);
-        days.entry("2026-05-31".to_string())
-            .or_default()
-            .insert("gpt-5".to_string(), vec![2_000, 0, 0]);
-
-        let cost = codex_days_cost(&days, &range);
-        let expected = codex_cost_usd("gpt-5", 2_000, 0, 0);
-
-        assert!((cost - expected).abs() < f64::EPSILON);
     }
 }

--- a/rust/src/core/cost_pricing.rs
+++ b/rust/src/core/cost_pricing.rs
@@ -264,9 +264,72 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             display_label: None,
         },
     );
+    m.insert(
+        "gpt-5.6-sol",
+        CodexPricing {
+            input_cost_per_token: 5e-6,
+            output_cost_per_token: 3e-5,
+            cache_read_input_cost_per_token: 5e-7,
+            display_label: None,
+        },
+    );
+    m.insert(
+        "gpt-5.6-terra",
+        CodexPricing {
+            input_cost_per_token: 2.5e-6,
+            output_cost_per_token: 1.5e-5,
+            cache_read_input_cost_per_token: 2.5e-7,
+            display_label: None,
+        },
+    );
+    m.insert(
+        "gpt-5.6-luna",
+        CodexPricing {
+            input_cost_per_token: 1e-6,
+            output_cost_per_token: 6e-6,
+            cache_read_input_cost_per_token: 1e-7,
+            display_label: None,
+        },
+    );
 
     m
 });
+
+const CODEX_LONG_CONTEXT_THRESHOLD: u64 = 272_000;
+
+/// Codex rates that apply to the entire request above the model's context threshold.
+static CODEX_LONG_CONTEXT_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> =
+    LazyLock::new(|| {
+        let mut m = HashMap::new();
+        m.insert(
+            "gpt-5.6-sol",
+            CodexPricing {
+                input_cost_per_token: 1e-5,
+                output_cost_per_token: 4.5e-5,
+                cache_read_input_cost_per_token: 1e-6,
+                display_label: None,
+            },
+        );
+        m.insert(
+            "gpt-5.6-terra",
+            CodexPricing {
+                input_cost_per_token: 5e-6,
+                output_cost_per_token: 2.25e-5,
+                cache_read_input_cost_per_token: 5e-7,
+                display_label: None,
+            },
+        );
+        m.insert(
+            "gpt-5.6-luna",
+            CodexPricing {
+                input_cost_per_token: 2e-6,
+                output_cost_per_token: 9e-6,
+                cache_read_input_cost_per_token: 2e-7,
+                display_label: None,
+            },
+        );
+        m
+    });
 
 /// Claude model pricing table
 static CLAUDE_PRICING: LazyLock<HashMap<&'static str, ClaudePricing>> = LazyLock::new(|| {
@@ -518,11 +581,18 @@ impl CostUsagePricing {
             trimmed = rest.to_string();
         }
 
+        if trimmed == "gpt-5.6" {
+            return "gpt-5.6-sol".to_string();
+        }
+
         // Check if base model (without -codex suffix) exists in pricing
         if let Some(idx) = trimmed.find("-codex") {
             let base = &trimmed[..idx];
             if CODEX_PRICING.contains_key(base) {
                 return base.to_string();
+            }
+            if base == "gpt-5.6" {
+                return "gpt-5.6-sol".to_string();
             }
         }
 
@@ -531,6 +601,9 @@ impl CostUsagePricing {
             let base = &trimmed[..mat.start()];
             if CODEX_PRICING.contains_key(base) {
                 return base.to_string();
+            }
+            if base == "gpt-5.6" {
+                return "gpt-5.6-sol".to_string();
             }
         }
 
@@ -588,7 +661,13 @@ impl CostUsagePricing {
         output_tokens: u64,
     ) -> Option<f64> {
         let key = Self::normalize_codex_model(model);
-        let pricing = CODEX_PRICING.get(key.as_str())?;
+        let pricing = if input_tokens > CODEX_LONG_CONTEXT_THRESHOLD {
+            CODEX_LONG_CONTEXT_PRICING
+                .get(key.as_str())
+                .or_else(|| CODEX_PRICING.get(key.as_str()))?
+        } else {
+            CODEX_PRICING.get(key.as_str())?
+        };
 
         let cached = cached_input_tokens.min(input_tokens);
         let non_cached = input_tokens.saturating_sub(cached);
@@ -863,6 +942,58 @@ mod tests {
         assert!(cost.is_some());
         // 1000 * 1.5e-5 + 500 * 1.2e-4 = 0.015 + 0.06 = 0.075
         assert!((cost.unwrap() - 0.075).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_gpt56_standard_pricing() {
+        for (model, expected) in [
+            ("gpt-5.6-sol", 0.0332),
+            ("gpt-5.6-terra", 0.0166),
+            ("gpt-5.6-luna", 0.00664),
+        ] {
+            let cost = CostUsagePricing::codex_cost_usd(model, 1_000, 400, 1_000);
+            assert!((cost.unwrap() - expected).abs() < 1e-10, "{model}");
+        }
+    }
+
+    #[test]
+    fn test_gpt56_long_context_pricing() {
+        for (model, expected) in [
+            ("gpt-5.6-sol", 45.272001),
+            ("gpt-5.6-terra", 22.6360005),
+            ("gpt-5.6-luna", 9.0544002),
+        ] {
+            let cost = CostUsagePricing::codex_cost_usd(model, 272_001, 272_001, 1_000_000);
+            assert!((cost.unwrap() - expected).abs() < 1e-10, "{model}");
+        }
+    }
+
+    #[test]
+    fn test_gpt56_context_threshold_is_exclusive() {
+        for (model, expected) in [
+            ("gpt-5.6-sol", 0.136),
+            ("gpt-5.6-terra", 0.068),
+            ("gpt-5.6-luna", 0.0272),
+        ] {
+            let cost = CostUsagePricing::codex_cost_usd(model, 272_000, 272_000, 0);
+            assert!((cost.unwrap() - expected).abs() < 1e-10, "{model}");
+        }
+    }
+
+    #[test]
+    fn test_normalize_gpt56_aliases() {
+        for model in [
+            "gpt-5.6",
+            "openai/gpt-5.6",
+            "gpt-5.6-codex",
+            "gpt-5.6-2099-01-01",
+        ] {
+            assert_eq!(
+                CostUsagePricing::normalize_codex_model(model),
+                "gpt-5.6-sol",
+                "{model}"
+            );
+        }
     }
 
     #[test]

--- a/rust/src/core/cost_pricing.rs
+++ b/rust/src/core/cost_pricing.rs
@@ -8,6 +8,14 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+/// Whole-request Codex rates for input above the model context threshold.
+#[derive(Debug, Clone, Copy)]
+pub struct CodexLongContextRates {
+    pub input_cost_per_token: f64,
+    pub output_cost_per_token: f64,
+    pub cache_read_input_cost_per_token: f64,
+}
+
 /// Codex (OpenAI) model pricing
 #[derive(Debug, Clone, Copy)]
 pub struct CodexPricing {
@@ -19,6 +27,8 @@ pub struct CodexPricing {
     pub cache_read_input_cost_per_token: f64,
     /// Optional display label override (e.g. "Research Preview")
     pub display_label: Option<&'static str>,
+    /// Whole-request rates above the Codex long-context threshold.
+    pub long_context: Option<CodexLongContextRates>,
 }
 
 /// Claude (Anthropic) model pricing with optional tiered pricing
@@ -56,6 +66,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1e-5,
             cache_read_input_cost_per_token: 1.25e-7,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -65,6 +76,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1e-5,
             cache_read_input_cost_per_token: 1.25e-7,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -74,6 +86,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 2e-6,
             cache_read_input_cost_per_token: 2.5e-8,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -83,6 +96,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 4e-7,
             cache_read_input_cost_per_token: 5e-9,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -92,6 +106,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.2e-4,
             cache_read_input_cost_per_token: 1.5e-5,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -101,6 +116,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1e-5,
             cache_read_input_cost_per_token: 1.25e-7,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -110,6 +126,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1e-5,
             cache_read_input_cost_per_token: 1.25e-7,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -119,6 +136,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1e-5,
             cache_read_input_cost_per_token: 1.25e-7,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -128,6 +146,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 2e-6,
             cache_read_input_cost_per_token: 2.5e-8,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -137,6 +156,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.4e-5,
             cache_read_input_cost_per_token: 1.75e-7,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -146,6 +166,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.4e-5,
             cache_read_input_cost_per_token: 1.75e-7,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -155,6 +176,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.68e-4,
             cache_read_input_cost_per_token: 2.1e-5,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -164,6 +186,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.4e-5,
             cache_read_input_cost_per_token: 1.75e-7,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -173,6 +196,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 0.0,
             cache_read_input_cost_per_token: 0.0,
             display_label: Some("Research Preview"),
+            long_context: None,
         },
     );
 
@@ -184,6 +208,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.5e-5,
             cache_read_input_cost_per_token: 2.5e-7,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -193,6 +218,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.5e-5,
             cache_read_input_cost_per_token: 2.5e-7,
             display_label: None,
+            long_context: None,
         },
     );
 
@@ -204,6 +230,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 4.5e-6,
             cache_read_input_cost_per_token: 7.5e-8,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -213,6 +240,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 4.5e-6,
             cache_read_input_cost_per_token: 7.5e-8,
             display_label: None,
+            long_context: None,
         },
     );
 
@@ -224,6 +252,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.25e-6,
             cache_read_input_cost_per_token: 2e-8,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -233,6 +262,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.25e-6,
             cache_read_input_cost_per_token: 2e-8,
             display_label: None,
+            long_context: None,
         },
     );
 
@@ -244,6 +274,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.8e-4,
             cache_read_input_cost_per_token: 3e-5,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -253,6 +284,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 3e-5,
             cache_read_input_cost_per_token: 5e-7,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -262,6 +294,7 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.8e-4,
             cache_read_input_cost_per_token: 3e-5,
             display_label: None,
+            long_context: None,
         },
     );
     m.insert(
@@ -271,6 +304,11 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 3e-5,
             cache_read_input_cost_per_token: 5e-7,
             display_label: None,
+            long_context: Some(CodexLongContextRates {
+                input_cost_per_token: 1e-5,
+                output_cost_per_token: 4.5e-5,
+                cache_read_input_cost_per_token: 1e-6,
+            }),
         },
     );
     m.insert(
@@ -280,6 +318,11 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 1.5e-5,
             cache_read_input_cost_per_token: 2.5e-7,
             display_label: None,
+            long_context: Some(CodexLongContextRates {
+                input_cost_per_token: 5e-6,
+                output_cost_per_token: 2.25e-5,
+                cache_read_input_cost_per_token: 5e-7,
+            }),
         },
     );
     m.insert(
@@ -289,6 +332,11 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
             output_cost_per_token: 6e-6,
             cache_read_input_cost_per_token: 1e-7,
             display_label: None,
+            long_context: Some(CodexLongContextRates {
+                input_cost_per_token: 2e-6,
+                output_cost_per_token: 9e-6,
+                cache_read_input_cost_per_token: 2e-7,
+            }),
         },
     );
 
@@ -296,40 +344,6 @@ static CODEX_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> = LazyLock::
 });
 
 const CODEX_LONG_CONTEXT_THRESHOLD: u64 = 272_000;
-
-/// Codex rates that apply to the entire request above the model's context threshold.
-static CODEX_LONG_CONTEXT_PRICING: LazyLock<HashMap<&'static str, CodexPricing>> =
-    LazyLock::new(|| {
-        let mut m = HashMap::new();
-        m.insert(
-            "gpt-5.6-sol",
-            CodexPricing {
-                input_cost_per_token: 1e-5,
-                output_cost_per_token: 4.5e-5,
-                cache_read_input_cost_per_token: 1e-6,
-                display_label: None,
-            },
-        );
-        m.insert(
-            "gpt-5.6-terra",
-            CodexPricing {
-                input_cost_per_token: 5e-6,
-                output_cost_per_token: 2.25e-5,
-                cache_read_input_cost_per_token: 5e-7,
-                display_label: None,
-            },
-        );
-        m.insert(
-            "gpt-5.6-luna",
-            CodexPricing {
-                input_cost_per_token: 2e-6,
-                output_cost_per_token: 9e-6,
-                cache_read_input_cost_per_token: 2e-7,
-                display_label: None,
-            },
-        );
-        m
-    });
 
 /// Claude model pricing table
 static CLAUDE_PRICING: LazyLock<HashMap<&'static str, ClaudePricing>> = LazyLock::new(|| {
@@ -581,30 +595,24 @@ impl CostUsagePricing {
             trimmed = rest.to_string();
         }
 
-        if trimmed == "gpt-5.6" {
-            return "gpt-5.6-sol".to_string();
-        }
-
         // Check if base model (without -codex suffix) exists in pricing
         if let Some(idx) = trimmed.find("-codex") {
             let base = &trimmed[..idx];
-            if CODEX_PRICING.contains_key(base) {
-                return base.to_string();
-            }
-            if base == "gpt-5.6" {
-                return "gpt-5.6-sol".to_string();
+            if CODEX_PRICING.contains_key(base) || base == "gpt-5.6" {
+                trimmed = base.to_string();
             }
         }
 
         let date_pattern = regex_lite::Regex::new(r"-\d{4}-\d{2}-\d{2}$").unwrap();
         if let Some(mat) = date_pattern.find(&trimmed) {
             let base = &trimmed[..mat.start()];
-            if CODEX_PRICING.contains_key(base) {
-                return base.to_string();
+            if CODEX_PRICING.contains_key(base) || base == "gpt-5.6" {
+                trimmed = base.to_string();
             }
-            if base == "gpt-5.6" {
-                return "gpt-5.6-sol".to_string();
-            }
+        }
+
+        if trimmed == "gpt-5.6" {
+            return "gpt-5.6-sol".to_string();
         }
 
         trimmed
@@ -661,20 +669,36 @@ impl CostUsagePricing {
         output_tokens: u64,
     ) -> Option<f64> {
         let key = Self::normalize_codex_model(model);
-        let pricing = if input_tokens > CODEX_LONG_CONTEXT_THRESHOLD {
-            CODEX_LONG_CONTEXT_PRICING
-                .get(key.as_str())
-                .or_else(|| CODEX_PRICING.get(key.as_str()))?
-        } else {
-            CODEX_PRICING.get(key.as_str())?
-        };
+        let pricing = CODEX_PRICING.get(key.as_str())?;
+        let (input_rate, cache_read_rate, output_rate) =
+            if input_tokens > CODEX_LONG_CONTEXT_THRESHOLD {
+                if let Some(long_context) = pricing.long_context {
+                    (
+                        long_context.input_cost_per_token,
+                        long_context.cache_read_input_cost_per_token,
+                        long_context.output_cost_per_token,
+                    )
+                } else {
+                    (
+                        pricing.input_cost_per_token,
+                        pricing.cache_read_input_cost_per_token,
+                        pricing.output_cost_per_token,
+                    )
+                }
+            } else {
+                (
+                    pricing.input_cost_per_token,
+                    pricing.cache_read_input_cost_per_token,
+                    pricing.output_cost_per_token,
+                )
+            };
 
         let cached = cached_input_tokens.min(input_tokens);
         let non_cached = input_tokens.saturating_sub(cached);
 
-        let cost = (non_cached as f64) * pricing.input_cost_per_token
-            + (cached as f64) * pricing.cache_read_input_cost_per_token
-            + (output_tokens as f64) * pricing.output_cost_per_token;
+        let cost = (non_cached as f64) * input_rate
+            + (cached as f64) * cache_read_rate
+            + (output_tokens as f64) * output_rate;
 
         Some(cost)
     }
@@ -987,6 +1011,7 @@ mod tests {
             "openai/gpt-5.6",
             "gpt-5.6-codex",
             "gpt-5.6-2099-01-01",
+            "openai/gpt-5.6-codex-2099-01-01",
         ] {
             assert_eq!(
                 CostUsagePricing::normalize_codex_model(model),

--- a/rust/src/core/jsonl_scanner.rs
+++ b/rust/src/core/jsonl_scanner.rs
@@ -53,8 +53,6 @@ pub struct CodexTotals {
 /// Result of parsing a Codex file
 #[derive(Debug)]
 pub struct CodexParseResult {
-    /// Daily usage: day_key -> model -> [input, cached, output]
-    pub days: HashMap<String, HashMap<String, Vec<i32>>>,
     /// Individual token-count deltas used for per-request pricing.
     pub records: Vec<CodexUsageRecord>,
     /// Bytes parsed
@@ -115,7 +113,6 @@ pub struct JsonlScanner;
 struct CodexParserState {
     current_model: Option<String>,
     previous_totals: Option<CodexTotals>,
-    days: HashMap<String, HashMap<String, Vec<i32>>>,
     records: Vec<CodexUsageRecord>,
 }
 
@@ -192,7 +189,6 @@ impl CodexParserState {
         Self {
             current_model: initial_model,
             previous_totals: initial_totals,
-            days: HashMap::new(),
             records: Vec::new(),
         }
     }
@@ -274,24 +270,7 @@ impl CodexParserState {
 
         let info = payload.get("info");
         let model = self.token_model(info, payload, obj);
-        let norm_model = CostUsagePricing::normalize_codex_model(&model);
-        self.records.push(CodexUsageRecord {
-            day_key: day_key.clone(),
-            model: norm_model.clone(),
-            input: delta_input,
-            cached: delta_cached.min(delta_input),
-            output: delta_output,
-        });
-        let packed = self
-            .days
-            .entry(day_key)
-            .or_default()
-            .entry(norm_model)
-            .or_insert_with(|| vec![0, 0, 0]);
-
-        packed[0] += delta_input;
-        packed[1] += delta_cached.min(delta_input);
-        packed[2] += delta_output;
+        self.record_usage(day_key, &model, delta_input, delta_cached, delta_output);
     }
 
     fn record_fast_token_count(&mut self, payload: CodexFastPayload<'_>, day_key: String) {
@@ -309,25 +288,19 @@ impl CodexParserState {
             .and_then(|info| info.model.or(info.model_name))
             .or(payload.model)
             .or(self.current_model.as_deref())
-            .unwrap_or("gpt-5");
-        let norm_model = CostUsagePricing::normalize_codex_model(model);
-        self.records.push(CodexUsageRecord {
-            day_key: day_key.clone(),
-            model: norm_model.clone(),
-            input: delta_input,
-            cached: delta_cached.min(delta_input),
-            output: delta_output,
-        });
-        let packed = self
-            .days
-            .entry(day_key)
-            .or_default()
-            .entry(norm_model)
-            .or_insert_with(|| vec![0, 0, 0]);
+            .unwrap_or("gpt-5")
+            .to_string();
+        self.record_usage(day_key, &model, delta_input, delta_cached, delta_output);
+    }
 
-        packed[0] += delta_input;
-        packed[1] += delta_cached.min(delta_input);
-        packed[2] += delta_output;
+    fn record_usage(&mut self, day_key: String, model: &str, input: i32, cached: i32, output: i32) {
+        self.records.push(CodexUsageRecord {
+            day_key,
+            model: CostUsagePricing::normalize_codex_model(model),
+            input,
+            cached: cached.min(input),
+            output,
+        });
     }
 
     fn token_model(&self, info: Option<&Value>, payload: &Value, obj: &Value) -> String {
@@ -635,7 +608,6 @@ impl JsonlScanner {
         }
 
         Ok(CodexParseResult {
-            days: parser.days,
             records: parser.records,
             parsed_bytes: file_size.max(parsed_bytes),
             last_model: parser.current_model,
@@ -761,9 +733,11 @@ mod tests {
             &range,
         );
 
-        let day = parser.days.get("2026-05-31").expect("day usage");
-        let usage = day.get("gpt-5.5").expect("model usage");
-        assert_eq!(usage, &vec![120, 40, 9]);
+        assert_eq!(parser.records.len(), 1);
+        let record = &parser.records[0];
+        assert_eq!(record.day_key, "2026-05-31");
+        assert_eq!(record.model, "gpt-5.5");
+        assert_eq!((record.input, record.cached, record.output), (120, 40, 9));
         assert_eq!(parser.current_model.as_deref(), Some("gpt-5.5"));
     }
 
@@ -784,9 +758,15 @@ mod tests {
             &range,
         );
 
-        let day = parser.days.get("2026-05-31").expect("day usage");
-        let usage = day.get("gpt-5").expect("model usage");
-        assert_eq!(usage, &vec![1250, 260, 90]);
+        assert_eq!(parser.records.len(), 2);
+        assert_eq!(
+            parser
+                .records
+                .iter()
+                .map(|record| (record.input, record.cached, record.output))
+                .collect::<Vec<_>>(),
+            vec![(1_000, 200, 50), (250, 60, 40)]
+        );
         let totals = parser.previous_totals.expect("last totals");
         assert_eq!(totals.input, 1250);
         assert_eq!(totals.cached, 260);
@@ -806,9 +786,10 @@ mod tests {
             &range,
         );
 
-        let day = parser.days.get("2026-05-31").expect("day usage");
-        let usage = day.get("gpt-5").expect("model usage");
-        assert_eq!(usage, &vec![20, 5, 3]);
+        assert_eq!(parser.records.len(), 1);
+        let record = &parser.records[0];
+        assert_eq!(record.model, "gpt-5");
+        assert_eq!((record.input, record.cached, record.output), (20, 5, 3));
     }
 
     #[test]
@@ -833,9 +814,6 @@ mod tests {
             JsonlScanner::parse_codex_file(file.path(), &range, 0, None, None).expect("parse");
 
         assert_eq!(parsed.last_model.as_deref(), Some("gpt-5.5"));
-        let day = parsed.days.get("2026-05-31").expect("day usage");
-        let usage = day.get("gpt-5.5").expect("model usage");
-        assert_eq!(usage, &vec![45, 12, 8]);
         assert_eq!(parsed.records.len(), 1);
         let record = &parsed.records[0];
         assert_eq!(record.day_key, "2026-05-31");

--- a/rust/src/core/jsonl_scanner.rs
+++ b/rust/src/core/jsonl_scanner.rs
@@ -55,12 +55,24 @@ pub struct CodexTotals {
 pub struct CodexParseResult {
     /// Daily usage: day_key -> model -> [input, cached, output]
     pub days: HashMap<String, HashMap<String, Vec<i32>>>,
+    /// Individual token-count deltas used for per-request pricing.
+    pub records: Vec<CodexUsageRecord>,
     /// Bytes parsed
     pub parsed_bytes: i64,
     /// Last model seen
     pub last_model: Option<String>,
     /// Last totals seen
     pub last_totals: Option<CodexTotals>,
+}
+
+/// A billable Codex token-count delta.
+#[derive(Debug, Clone)]
+pub struct CodexUsageRecord {
+    pub day_key: String,
+    pub model: String,
+    pub input: i32,
+    pub cached: i32,
+    pub output: i32,
 }
 
 /// Day range for scanning
@@ -104,6 +116,7 @@ struct CodexParserState {
     current_model: Option<String>,
     previous_totals: Option<CodexTotals>,
     days: HashMap<String, HashMap<String, Vec<i32>>>,
+    records: Vec<CodexUsageRecord>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -180,6 +193,7 @@ impl CodexParserState {
             current_model: initial_model,
             previous_totals: initial_totals,
             days: HashMap::new(),
+            records: Vec::new(),
         }
     }
 
@@ -261,6 +275,13 @@ impl CodexParserState {
         let info = payload.get("info");
         let model = self.token_model(info, payload, obj);
         let norm_model = CostUsagePricing::normalize_codex_model(&model);
+        self.records.push(CodexUsageRecord {
+            day_key: day_key.clone(),
+            model: norm_model.clone(),
+            input: delta_input,
+            cached: delta_cached.min(delta_input),
+            output: delta_output,
+        });
         let packed = self
             .days
             .entry(day_key)
@@ -290,6 +311,13 @@ impl CodexParserState {
             .or(self.current_model.as_deref())
             .unwrap_or("gpt-5");
         let norm_model = CostUsagePricing::normalize_codex_model(model);
+        self.records.push(CodexUsageRecord {
+            day_key: day_key.clone(),
+            model: norm_model.clone(),
+            input: delta_input,
+            cached: delta_cached.min(delta_input),
+            output: delta_output,
+        });
         let packed = self
             .days
             .entry(day_key)
@@ -608,6 +636,7 @@ impl JsonlScanner {
 
         Ok(CodexParseResult {
             days: parser.days,
+            records: parser.records,
             parsed_bytes: file_size.max(parsed_bytes),
             last_model: parser.current_model,
             last_totals: parser.previous_totals,
@@ -807,5 +836,10 @@ mod tests {
         let day = parsed.days.get("2026-05-31").expect("day usage");
         let usage = day.get("gpt-5.5").expect("model usage");
         assert_eq!(usage, &vec![45, 12, 8]);
+        assert_eq!(parsed.records.len(), 1);
+        let record = &parsed.records[0];
+        assert_eq!(record.day_key, "2026-05-31");
+        assert_eq!(record.model, "gpt-5.5");
+        assert_eq!((record.input, record.cached, record.output), (45, 12, 8));
     }
 }

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -13,7 +13,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(test)]
 use crate::codex_costs::scan_codex_file_cost;
 use crate::codex_costs::{
-    add_codex_days_to_summary, codex_period_start, codex_scan_dates, scan_codex_file_cost_for_range,
+    add_codex_records_to_summary, codex_period_start, codex_scan_dates,
+    scan_codex_file_cost_for_range,
 };
 use crate::codex_sessions::{codex_sessions_dir_candidates, default_wsl_roots};
 use crate::core::{CostUsageDayRange, CostUsagePricing, JsonlScanner};
@@ -371,7 +372,7 @@ impl CostScanner {
         };
 
         let (session_cost, has_tokens) =
-            add_codex_days_to_summary(summary, &parse_result.days, &range);
+            add_codex_records_to_summary(summary, &parse_result.records, &range);
 
         if has_tokens {
             summary.total_cost_usd += session_cost;


### PR DESCRIPTION
## Summary
- Ports upstream `aa40f1eb4` GPT-5.6 Sol, Terra, and Luna standard rates plus `>272,000` whole-request long-context rates into the canonical `CostUsagePricing` map.
- Normalizes `gpt-5.6`, `openai/gpt-5.6`, supported Codex suffixes, and dated aliases to `gpt-5.6-sol` through one final alias application.
- Preserves per-token-count JSONL records through `CodexUsageRecord`, so multiple short requests do not become one incorrectly long-context-priced daily aggregate.

## Upstream mapping
| Upstream behavior | Win-CodexBar implementation/tests |
| --- | --- |
| `aa40f1eb4`: Sol/Terra/Luna standard input, cache-read, output rates | `CODEX_PRICING`; `test_gpt56_standard_pricing` |
| `aa40f1eb4`: whole-request long-context rates over 272k | Optional `CodexLongContextRates` on the same canonical model entry; long-context and threshold tests |
| `aa40f1eb4`: `gpt-5.6` aliases resolve to Sol | Alias tests include combined OpenAI/Codex/date form |
| Per-request long-context accounting | JSONL records retain token-count deltas; two 200k Sol requests total $2.00 instead of one false 400k long-context request |
| `501e95150`: stabilization | No numeric GPT-5.6 rate change. Models.dev pricing-key and Pi cache invalidation are non-applicable: this port has neither subsystem. |

## Structural follow-up
- Retired unused packed day/model state from `CodexParseResult` and `CodexParserState`; all four parser tests assert records.
- Consolidated both parser record appends in `record_usage`.
- Long-context rates now live on their canonical model entry. Models with no optional tier explicitly retain standard rates above the threshold.

## Unsupported dimensions
- Cache-write: current Codex JSONL records contain only input, cached-read, and output.
- Priority: upstream derives it from separate SQLite trace metadata (`service_tier` and turn IDs); this port has no such scanner or record fields.
- Pi repricing: no Pi scanner/cache exists under `rust/src`.
- No zero-cost fallback was added; usage remains visible when pricing is unavailable.

## Validation
- RED/GREEN: initial GPT-5.6 rate and alias tests failed before implementation; the final-alias path failed during the structural refactor until suffix normalization retained `gpt-5.6` for final aliasing.
- Focused: `cargo test --manifest-path rust/Cargo.toml gpt56 --lib` (5); `cargo test --manifest-path rust/Cargo.toml 'core::jsonl_scanner::tests' --lib` (8).
- Full shared: fmt check; `cargo test --manifest-path rust/Cargo.toml` (536 library + 1 binary); clippy `-D warnings`.
- Full Tauri: fmt check; `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` (303); clippy `-D warnings`.
- `git diff --check` passed. Frontend validation is not applicable because no frontend or bridge file changed.