### PR TITLE
Fix predicted exhaustion time display

### DIFF
--- a/apps/desktop-tauri/src/components/MenuCard.test.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.test.tsx
@@ -104,6 +104,7 @@ describe("MenuCard", () => {
     tauriMocks.getLocaleStrings.mockResolvedValue(
       buildBundle({
         ActionCopyError: "Copy error",
+        DetailPaceRunsOutIn: "Runs out in",
         PanelEstimatedFromLocalLogs: "Estimated from local logs",
         PanelLeftSuffix: "left",
         PanelNow: "now",
@@ -264,6 +265,26 @@ describe("MenuCard", () => {
 
     await waitFor(() => {
       expect(onLayoutChange).toHaveBeenCalled();
+    });
+  });
+
+  it("shows the formatted predicted exhaustion time", async () => {
+    const snapshot = provider(null, 40);
+    snapshot.pace = {
+      stage: "far_ahead",
+      deltaPercent: 20,
+      expectedUsedPercent: 20,
+      actualUsedPercent: 40,
+      etaSeconds: 90 * 60,
+      willLastToReset: false,
+    };
+
+    const { container } = renderCard(snapshot);
+
+    await waitFor(() => {
+      expect(container.querySelector(".menu-card__pace-eta")).toHaveTextContent(
+        "⚠ Runs out in 2h",
+      );
     });
   });
 

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -11,6 +11,7 @@ import { getProviderChartData } from "../lib/tauri";
 import { useLocale } from "../hooks/useLocale";
 import { useFormattedResetTime } from "../hooks/useFormattedResetTime";
 import { formatRelativeUpdated } from "../lib/relativeTime";
+import { formatEta } from "../lib/formatEta";
 import type { LocaleKey } from "../i18n/keys";
 import { paceCategory } from "../surfaces/tray/paceCategory";
 import { SimpleBarChart, StackedBarChart } from "./MiniBarChart";
@@ -662,10 +663,7 @@ export default function MenuCard({
               {provider.pace.etaSeconds != null && !provider.pace.willLastToReset && (
                 <div className="menu-card__pace-eta">
                   ⚠{" "}
-                  {t("DetailPaceRunsOutIn").replace(
-                    "{}",
-                    String(Math.round(provider.pace.etaSeconds / 3600)),
-                  )}
+                  {t("DetailPaceRunsOutIn")} {formatEta(provider.pace.etaSeconds)}
                 </div>
               )}
               {provider.pace.willLastToReset && (

--- a/apps/desktop-tauri/src/lib/formatEta.test.ts
+++ b/apps/desktop-tauri/src/lib/formatEta.test.ts
@@ -10,6 +10,13 @@ describe("formatEta", () => {
     expect(formatEta(24 * 60 * 60)).toBe("1d");
   });
 
+  it("selects units before rounding at boundaries", () => {
+    expect(formatEta(59 * 60 + 30)).toBe("60m");
+    expect(formatEta(60 * 60)).toBe("1h");
+    expect(formatEta(23 * 60 * 60 + 30 * 60)).toBe("24h");
+    expect(formatEta(24 * 60 * 60)).toBe("1d");
+  });
+
   it("clamps negative durations to zero", () => {
     expect(formatEta(-60)).toBe("0m");
   });

--- a/apps/desktop-tauri/src/lib/formatEta.test.ts
+++ b/apps/desktop-tauri/src/lib/formatEta.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { formatEta } from "./formatEta";
+
+describe("formatEta", () => {
+  it("formats durations using minutes, hours, and days", () => {
+    expect(formatEta(0)).toBe("0m");
+    expect(formatEta(30 * 60)).toBe("30m");
+    expect(formatEta(60 * 60)).toBe("1h");
+    expect(formatEta(23 * 60 * 60)).toBe("23h");
+    expect(formatEta(24 * 60 * 60)).toBe("1d");
+  });
+
+  it("clamps negative durations to zero", () => {
+    expect(formatEta(-60)).toBe("0m");
+  });
+});

--- a/apps/desktop-tauri/src/lib/formatEta.ts
+++ b/apps/desktop-tauri/src/lib/formatEta.ts
@@ -1,0 +1,9 @@
+export function formatEta(seconds: number): string {
+  const minutes = Math.max(0, Math.round(seconds / 60));
+  if (minutes < 60) return `${minutes}m`;
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+
+  return `${Math.round(hours / 24)}d`;
+}

--- a/apps/desktop-tauri/src/lib/formatEta.ts
+++ b/apps/desktop-tauri/src/lib/formatEta.ts
@@ -1,9 +1,10 @@
 export function formatEta(seconds: number): string {
-  const minutes = Math.max(0, Math.round(seconds / 60));
-  if (minutes < 60) return `${minutes}m`;
+  const totalSeconds = Math.max(0, seconds);
+  if (totalSeconds < 60 * 60) return `${Math.round(totalSeconds / 60)}m`;
 
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours}h`;
+  if (totalSeconds < 24 * 60 * 60) {
+    return `${Math.round(totalSeconds / 60 / 60)}h`;
+  }
 
-  return `${Math.round(hours / 24)}d`;
+  return `${Math.round(totalSeconds / 60 / 60 / 24)}d`;
 }

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/PaceSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/PaceSection.tsx
@@ -1,5 +1,6 @@
 import type { PaceSnapshot } from "../../../../types/bridge";
 import type { LocaleKey } from "../../../../i18n/keys";
+import { formatEta } from "../../../../lib/formatEta";
 
 interface Props {
   pace: PaceSnapshot | null;
@@ -16,10 +17,7 @@ const STAGE_TO_KEY: Record<PaceSnapshot["stage"], LocaleKey> = {
   far_behind: "DetailPaceFarBehind",
 };
 
-/**
- * Pace stage + auxiliary copy. Port of the pace rows in
- * `rust/src/native_ui/preferences.rs::render_provider_detail_panel`.
- */
+/** 展示配额节奏状态及其辅助说明。 */
 export function PaceSection({ pace, t }: Props) {
   if (!pace) return null;
 
@@ -39,12 +37,4 @@ export function PaceSection({ pace, t }: Props) {
       {aux && <div className="provider-detail-pace__aux">{aux}</div>}
     </section>
   );
-}
-
-function formatEta(seconds: number): string {
-  const mins = Math.max(0, Math.round(seconds / 60));
-  if (mins < 60) return `${mins}m`;
-  const hrs = Math.round(mins / 60);
-  if (hrs < 24) return `${hrs}h`;
-  return `${Math.round(hrs / 24)}d`;
 }


### PR DESCRIPTION
## Summary

The predicted exhaustion warning now shows the formatted remaining duration instead of only the warning icon and localized label.

## Related issue

None.

## Affected areas

Check every area this PR changes or could affect:

- [x] Tray panel
- [x] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## What changed

- Render the localized `DetailPaceRunsOutIn` label together with a formatted ETA.
- Extract the existing minute/hour/day formatting into a shared `formatEta` helper so the card and Settings use one canonical implementation.
- Add focused tests for ETA formatting and the rendered warning text.

## Root cause and impact

The card tried to replace a `{}` placeholder in `DetailPaceRunsOutIn`, but none of the six locale values contains that placeholder. As a result, the duration was discarded in every language. The warning now consistently renders values such as `30m`, `2h`, or `1d` after the localized label.

## Validation

There is no hosted CI right now. The relevant local checks were run on the final commit.

- [x] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -Frontend` — 32 test files and 155/155 tests passed; locale drift check reported 668 matching keys; TypeScript and the Vite production build passed.
- [ ] For full pre-release validation: `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>` — not applicable to this frontend-only fix.
- [ ] For installer/release changes: `powershell.exe -File scripts\windows-release-build.ps1 -Ref <ref> -SmokeInstall` — not applicable.
- [x] Thermo-nuclear code quality review completed before submitting: https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md
- [x] Other: focused `ProvidersSidebar.test.tsx` rerun passed after one unrelated timing-sensitive failure in the first full run.

## UI / tray proof

For UI, tray, settings, or visual behavior changes, use CUA Driver for visual proof. If CUA Driver cannot be used, explain why and attach equivalent manual proof.

- [ ] Not applicable
- [ ] CUA Driver visual proof attached
- [x] CUA Driver could not be used in this environment; equivalent automated component proof asserts the rendered warning is `⚠ Runs out in 2h`.

## Notes for reviewers

The formatter intentionally keeps the existing compact, locale-neutral units (`m`, `h`, and `d`) already used by the Settings pace section. No locale strings or backend behavior changed.