### PR TITLE
fix: parse --https_server_port for Antigravity 2.0 detection

### DIFF
--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -24,6 +24,12 @@ pub struct AntigravityProvider {
     metadata: ProviderMetadata,
 }
 
+/// Return a regex that matches `--<flag> <value>` or `--<flag>=<value>`.
+fn flag_re(flag: &str) -> Regex {
+    Regex::new(&format!(r"--{f}(?:\s+|\s*=\s*)(\S+)", f = flag))
+        .expect("valid flag pattern")
+}
+
 impl AntigravityProvider {
     pub fn new() -> Self {
         Self {
@@ -73,21 +79,11 @@ impl AntigravityProvider {
     }
 
     fn parse_process_info(stdout: &str) -> Option<ProcessInfo> {
-        // Parse command line for CSRF token and port — compiled once
-        static CSRF_RE: OnceLock<Regex> = OnceLock::new();
-        static EXT_CSRF_RE: OnceLock<Regex> = OnceLock::new();
-        static PORT_RE: OnceLock<Regex> = OnceLock::new();
-        static HTTPS_PORT_RE: OnceLock<Regex> = OnceLock::new();
-        let csrf_regex = CSRF_RE
-            .get_or_init(|| Regex::new(r"--csrf_token\s+([a-f0-9-]+)").expect("valid regex"));
-        let ext_csrf_regex = EXT_CSRF_RE.get_or_init(|| {
-            Regex::new(r"--extension_server_csrf_token\s+([a-f0-9-]+)").expect("valid regex")
-        });
-        let port_regex = PORT_RE
-            .get_or_init(|| Regex::new(r"--extension_server_port\s+(\d+)").expect("valid regex"));
-        let https_port_regex = HTTPS_PORT_RE.get_or_init(|| {
-            Regex::new(r"--https_server_port\s+(\d+)").expect("valid regex")
-        });
+        // Shared argument parser: handles `--flag value` and `--flag=value` forms
+        let csrf_re = flag_re("csrf_token");
+        let ext_csrf_re = flag_re("extension_server_csrf_token");
+        let port_re = flag_re("extension_server_port");
+        let https_port_re = flag_re("https_server_port");
 
         for line in stdout.lines() {
             if line.contains("--csrf_token") {
@@ -98,22 +94,22 @@ impl AntigravityProvider {
                     None => (None, line),
                 };
 
-                let csrf_token = csrf_regex
+                let csrf_token = csrf_re
                     .captures(line)
                     .and_then(|c| c.get(1))
                     .map(|m| m.as_str().to_string());
 
-                let ext_csrf_token = ext_csrf_regex
+                let ext_csrf_token = ext_csrf_re
                     .captures(line)
                     .and_then(|c| c.get(1))
                     .map(|m| m.as_str().to_string());
 
-                let port = port_regex
+                let port = port_re
                     .captures(line)
                     .and_then(|c| c.get(1))
                     .and_then(|m| m.as_str().parse::<u16>().ok())
                     .or_else(|| {
-                        https_port_regex
+                        https_port_re
                             .captures(line)
                             .and_then(|c| c.get(1))
                             .and_then(|m| m.as_str().parse::<u16>().ok())
@@ -743,6 +739,18 @@ mod tests {
         assert_eq!(process.pid, Some(34564));
         assert_eq!(process.extension_port, None);
         assert_eq!(process.csrf_token, "aabbccdd-1122-3344-5566-778899001122");
+    }
+
+    #[test]
+    fn parses_equals_form_args() {
+        let output = "34564\tC:\\Users\\test\\AppData\\Local\\Programs\\Antigravity\\resources\\bin\\language_server.exe --csrf_token=68dda2fb-6b26-40c0-aeef-b9a628615714 --https_server_port=61999";
+
+        let process = AntigravityProvider::parse_process_info(output)
+            .expect("process info should be detected");
+
+        assert_eq!(process.pid, Some(34564));
+        assert_eq!(process.extension_port, Some(61999));
+        assert_eq!(process.csrf_token, "68dda2fb-6b26-40c0-aeef-b9a628615714");
     }
 
     fn make_response(models: Vec<(&str, f64)>) -> UserStatusResponse {

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -77,6 +77,7 @@ impl AntigravityProvider {
         static CSRF_RE: OnceLock<Regex> = OnceLock::new();
         static EXT_CSRF_RE: OnceLock<Regex> = OnceLock::new();
         static PORT_RE: OnceLock<Regex> = OnceLock::new();
+        static HTTPS_PORT_RE: OnceLock<Regex> = OnceLock::new();
         let csrf_regex = CSRF_RE
             .get_or_init(|| Regex::new(r"--csrf_token\s+([a-f0-9-]+)").expect("valid regex"));
         let ext_csrf_regex = EXT_CSRF_RE.get_or_init(|| {
@@ -84,6 +85,9 @@ impl AntigravityProvider {
         });
         let port_regex = PORT_RE
             .get_or_init(|| Regex::new(r"--extension_server_port\s+(\d+)").expect("valid regex"));
+        let https_port_regex = HTTPS_PORT_RE.get_or_init(|| {
+            Regex::new(r"--https_server_port\s+(\d+)").expect("valid regex")
+        });
 
         for line in stdout.lines() {
             if line.contains("--csrf_token") {
@@ -107,13 +111,19 @@ impl AntigravityProvider {
                 let port = port_regex
                     .captures(line)
                     .and_then(|c| c.get(1))
-                    .and_then(|m| m.as_str().parse::<u16>().ok());
+                    .and_then(|m| m.as_str().parse::<u16>().ok())
+                    .or_else(|| {
+                        https_port_regex
+                            .captures(line)
+                            .and_then(|c| c.get(1))
+                            .and_then(|m| m.as_str().parse::<u16>().ok())
+                    });
 
-                if let (Some(token), Some(p)) = (csrf_token, port) {
+                if let Some(token) = csrf_token {
                     return Some(ProcessInfo {
                         csrf_token: token,
                         extension_server_csrf_token: ext_csrf_token,
-                        extension_port: p,
+                        extension_port: port,
                         pid,
                     });
                 }
@@ -124,7 +134,7 @@ impl AntigravityProvider {
     }
 
     /// Find the actual API port by probing the language server's candidate ports.
-    async fn find_api_port(extension_port: u16, pid: Option<u32>) -> Result<u16, ProviderError> {
+    async fn find_api_port(extension_port: Option<u16>, pid: Option<u32>) -> Result<u16, ProviderError> {
         // The language server binds a RANDOM localhost port at startup; --extension_server_port
         // is only a reference point (and belongs to a separate HTTP extension server), so the
         // real gRPC/Connect API port is not guaranteed to be within a small window above it.
@@ -149,7 +159,9 @@ impl AntigravityProvider {
         if let Some(pid) = pid {
             candidates.extend(Self::listening_ports_for_pid(pid));
         }
-        candidates.extend((0..20u16).map(|offset| extension_port.saturating_add(offset)));
+        if let Some(ep) = extension_port.filter(|&p| p > 0) {
+            candidates.extend((0..20u16).map(|offset| ep.saturating_add(offset)));
+        }
         candidates.extend([53835, 53836, 53837, 53838, 53845, 53849]);
 
         let mut probed: Vec<u16> = Vec::new();
@@ -445,7 +457,7 @@ impl Provider for AntigravityProvider {
 struct ProcessInfo {
     csrf_token: String,
     extension_server_csrf_token: Option<String>,
-    extension_port: u16,
+    extension_port: Option<u16>,
     pid: Option<u32>,
 }
 
@@ -702,8 +714,35 @@ mod tests {
         let process = AntigravityProvider::parse_process_info(output).expect("process info");
 
         assert_eq!(process.pid, Some(4242));
-        assert_eq!(process.extension_port, 54123);
+        assert_eq!(process.extension_port, Some(54123));
         assert_eq!(process.csrf_token, "11111111-2222-3333-4444-555555555555");
+    }
+
+    #[test]
+    fn parses_language_server_without_extension_server_port() {
+        let output = "34564\tC:\\Users\\test\\AppData\\Local\\Programs\\Antigravity\\resources\\bin\\language_server.exe --standalone --override_ide_name antigravity --subclient_type hub --override_ide_version 2.0.11 --https_server_port 0 --csrf_token 68dda2fb-6b26-40c0-aeef-b9a628615714 --app_data_dir antigravity";
+
+        let process = AntigravityProvider::parse_process_info(output)
+            .expect("process info should be detected");
+
+        assert_eq!(process.pid, Some(34564));
+        assert_eq!(process.extension_port, Some(0));
+        assert_eq!(
+            process.csrf_token,
+            "68dda2fb-6b26-40c0-aeef-b9a628615714"
+        );
+    }
+
+    #[test]
+    fn parses_language_server_without_any_port_arg() {
+        let output = "34564\tC:\\Users\\test\\AppData\\Local\\Programs\\Antigravity\\resources\\bin\\language_server.exe --standalone --csrf_token aabbccdd-1122-3344-5566-778899001122 --app_data_dir antigravity";
+
+        let process = AntigravityProvider::parse_process_info(output)
+            .expect("process info should be detected");
+
+        assert_eq!(process.pid, Some(34564));
+        assert_eq!(process.extension_port, None);
+        assert_eq!(process.csrf_token, "aabbccdd-1122-3344-5566-778899001122");
     }
 
     fn make_response(models: Vec<(&str, f64)>) -> UserStatusResponse {


### PR DESCRIPTION
## Summary

Parse `--https_server_port` in addition to `--extension_server_port`
when detecting the Antigravity language server process.

Antigravity 2.0 no longer passes `--extension_server_port` — it uses
`--https_server_port 0` instead. The old regex only matched the former,
causing process detection to fail even though the server is running
and has valid CSRF tokens.

## Changes

- Added `HTTPS_PORT_RE` fallback regex for `--https_server_port`
- Made `extension_port` optional (`Option<u16>`)
- Updated `find_api_port` to skip heuristic window when port is `None` or `0`
- All existing tests updated; 2 new tests added

**Fixes #192**

## Validation

- `cargo test -p codexbar antigravity` — 9 passed
- `cargo test -p codexbar` — 590 passed, 1 pre-existing failure (PTY env, unrelated)
- `cargo tauri build` — success
- Live: `codexbar diagnose --provider antigravity` → auth.configured: true, 11 model windows
- Live: `codexbar usage --provider antigravity` → Plan: Pro, usage tracking works

Assisted by AI
<img width="277" height="521" alt="image" src="https://github.com/user-attachments/assets/4174f03f-2b86-4571-a7dd-23a6f93f9085" />