### PR TITLE
fix: scope quota notifications by account identity

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -424,8 +424,14 @@ fn notify_usage_thresholds(
             if snapshot.error.is_none()
                 && let Some(&provider) = cli_map.get(snapshot.provider_id.as_str())
             {
+                let token_account_id = token_accounts
+                    .get(&provider)
+                    .and_then(ProviderAccountData::active_account)
+                    .map(|account| account.id);
+                let account = quota_notification_account_identity(snapshot, token_account_id);
                 guard.notification_manager.check_and_notify(
                     provider,
+                    &account,
                     "session",
                     snapshot.primary.used_percent,
                     settings,
@@ -433,6 +439,7 @@ fn notify_usage_thresholds(
                 if let Some(weekly) = &snapshot.secondary {
                     guard.notification_manager.check_and_notify(
                         provider,
+                        &account,
                         "weekly",
                         weekly.used_percent,
                         settings,
@@ -440,6 +447,7 @@ fn notify_usage_thresholds(
                 }
                 guard.notification_manager.check_session_transition(
                     provider,
+                    &account,
                     snapshot.primary.used_percent,
                     settings,
                 );
@@ -453,6 +461,42 @@ fn notify_usage_thresholds(
             }
         }
     }
+}
+
+/// Stable account discriminator for threshold/session toast dedupe.
+/// Prefer token-account id, then email, org, plan; empty for single-account lanes.
+fn quota_notification_account_identity(
+    snapshot: &ProviderUsageSnapshot,
+    token_account_id: Option<uuid::Uuid>,
+) -> String {
+    if let Some(id) = token_account_id {
+        return format!("token-account:{}", id.as_hyphenated());
+    }
+    if let Some(email) = snapshot
+        .account_email
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return email.to_ascii_lowercase();
+    }
+    if let Some(org) = snapshot
+        .account_organization
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return format!("org:{}", org.to_ascii_lowercase());
+    }
+    if let Some(plan) = snapshot
+        .plan_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return format!("plan:{}", plan.to_ascii_lowercase());
+    }
+    String::new()
 }
 
 fn notify_predictive_pace(
@@ -621,5 +665,45 @@ mod predictive_warning_tests {
             predictive_warning_identity(ProviderId::Codex, "cli", Some("  "), None),
             None
         );
+    }
+
+    fn empty_snapshot() -> ProviderUsageSnapshot {
+        let metadata = codexbar::core::instantiate_provider(ProviderId::Claude)
+            .metadata()
+            .clone();
+        ProviderUsageSnapshot::from_error(ProviderId::Claude, &metadata, "unused".to_string())
+    }
+
+    #[test]
+    fn quota_notification_account_identity_prefers_token_then_email() {
+        let account_id = uuid::Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
+        let mut snapshot = empty_snapshot();
+        snapshot.account_email = Some("Person@Example.com".to_string());
+        snapshot.account_organization = Some("Acme Org".to_string());
+        snapshot.plan_name = Some("Pro".to_string());
+
+        assert_eq!(
+            quota_notification_account_identity(&snapshot, Some(account_id)),
+            "token-account:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        );
+        assert_eq!(
+            quota_notification_account_identity(&snapshot, None),
+            "person@example.com"
+        );
+
+        snapshot.account_email = None;
+        assert_eq!(
+            quota_notification_account_identity(&snapshot, None),
+            "org:acme org"
+        );
+
+        snapshot.account_organization = None;
+        assert_eq!(
+            quota_notification_account_identity(&snapshot, None),
+            "plan:pro"
+        );
+
+        snapshot.plan_name = None;
+        assert_eq!(quota_notification_account_identity(&snapshot, None), "");
     }
 }

--- a/rust/src/notifications.rs
+++ b/rust/src/notifications.rs
@@ -107,16 +107,26 @@ impl NotificationType {
     }
 }
 
-/// Dedupe identity for threshold toasts. `window` is the rate window id
-/// (`"session"`, `"weekly"`, …) so session and weekly budgets arm independently.
-type ThresholdKey = (ProviderId, String, NotificationType);
+/// Dedupe identity for threshold toasts.
+/// - `account`: stable per-account discriminator (email, token-account id, …).
+///   Empty string is the legacy single-account lane.
+/// - `window`: rate window id (`"session"`, `"weekly"`, …) so budgets arm independently.
+type ThresholdKey = (
+    ProviderId,
+    String, /* account */
+    String, /* window */
+    NotificationType,
+);
+
+/// Session-transition tracking key: provider + account identity.
+type SessionTransitionKey = (ProviderId, String /* account */);
 
 /// Notification manager
 pub struct NotificationManager {
     /// Track which notifications have been sent to avoid spam
     sent_notifications: std::collections::HashSet<ThresholdKey>,
-    /// Track previous session percent for depleted/restored transitions
-    previous_session_percent: std::collections::HashMap<ProviderId, f64>,
+    /// Track previous session percent for depleted/restored transitions (per account)
+    previous_session_percent: std::collections::HashMap<SessionTransitionKey, f64>,
     predictive_warning_keys: std::collections::HashSet<PredictiveWarningKey>,
 }
 
@@ -229,10 +239,14 @@ impl NotificationManager {
         play_alert(AlertSound::Warning, settings);
     }
 
-    /// Check usage and send notifications if thresholds are crossed
+    /// Check usage and send notifications if thresholds are crossed.
+    ///
+    /// `account` is a stable account discriminator (email, token-account id, …).
+    /// Pass `""` for single-account providers when no identity is available.
     pub fn check_and_notify(
         &mut self,
         provider: ProviderId,
+        account: &str,
         window: &str,
         used_percent: f64,
         settings: &Settings,
@@ -249,15 +263,22 @@ impl NotificationManager {
         } else if used_percent >= thresholds.high {
             Some(NotificationType::HighUsage)
         } else {
-            // Clear only this window's threshold toasts so a cool session cannot
-            // re-arm a still-hot weekly (or vice versa) on the next poll.
-            self.sent_notifications
-                .retain(|(p, w, t)| *p != provider || w != window || !t.is_threshold_toast());
+            // Clear only this provider+account+window's threshold toasts so a cool
+            // session on one account cannot re-arm another account's weekly (or
+            // another window on the same account) on the next poll.
+            self.sent_notifications.retain(|(p, a, w, t)| {
+                *p != provider || a != account || w != window || !t.is_threshold_toast()
+            });
             None
         };
 
         if let Some(notif_type) = notification_type {
-            let key = (provider, window.to_string(), notif_type);
+            let key = (
+                provider,
+                account.to_string(),
+                window.to_string(),
+                notif_type,
+            );
             if !self.sent_notifications.contains(&key) {
                 self.send_notification(provider, window, used_percent, notif_type, settings);
                 self.sent_notifications.insert(key);
@@ -272,7 +293,12 @@ impl NotificationManager {
         description: &str,
         settings: &Settings,
     ) {
-        let key = (provider, String::new(), NotificationType::StatusIssue);
+        let key = (
+            provider,
+            String::new(),
+            String::new(),
+            NotificationType::StatusIssue,
+        );
         if !self.sent_notifications.contains(&key) {
             self.send_status_notification(provider, description, settings);
             self.sent_notifications.insert(key);
@@ -281,15 +307,23 @@ impl NotificationManager {
 
     /// Clear status issue notification (when resolved)
     pub fn clear_status_issue(&mut self, provider: ProviderId) {
-        self.sent_notifications
-            .remove(&(provider, String::new(), NotificationType::StatusIssue));
+        self.sent_notifications.remove(&(
+            provider,
+            String::new(),
+            String::new(),
+            NotificationType::StatusIssue,
+        ));
     }
 
     /// Check session quota transitions (depleted/restored)
-    /// Call this with each usage update to detect transitions
+    /// Call this with each usage update to detect transitions.
+    ///
+    /// `account` scopes depleted/restored state so multi-account providers do not
+    /// cross-arm session transitions.
     pub fn check_session_transition(
         &mut self,
         provider: ProviderId,
+        account: &str,
         current_percent: f64,
         settings: &Settings,
     ) {
@@ -299,9 +333,10 @@ impl NotificationManager {
 
         const DEPLETED_THRESHOLD: f64 = 99.99; // Consider depleted at 99.99%+
 
+        let transition_key: SessionTransitionKey = (provider, account.to_string());
         let previous_percent = self
             .previous_session_percent
-            .get(&provider)
+            .get(&transition_key)
             .copied()
             .unwrap_or(0.0);
 
@@ -316,6 +351,7 @@ impl NotificationManager {
             play_alert(AlertSound::Error, settings);
             self.sent_notifications.insert((
                 provider,
+                account.to_string(),
                 "session".to_string(),
                 NotificationType::SessionDepleted,
             ));
@@ -325,6 +361,7 @@ impl NotificationManager {
             // Only notify restored if we previously sent a depleted notification
             let depleted_key = (
                 provider,
+                account.to_string(),
                 "session".to_string(),
                 NotificationType::SessionDepleted,
             );
@@ -340,9 +377,9 @@ impl NotificationManager {
             }
         }
 
-        // Update the tracked previous percent
+        // Update the tracked previous percent for this account
         self.previous_session_percent
-            .insert(provider, current_percent);
+            .insert(transition_key, current_percent);
     }
 
     /// Send a Windows toast notification with sound
@@ -389,9 +426,7 @@ impl NotificationManager {
                 )
             }
             NotificationType::Exhausted => {
-                format!(
-                    "{provider_name} {window_label} usage limit exhausted ({used_percent:.0}%)"
-                )
+                format!("{provider_name} {window_label} usage limit exhausted ({used_percent:.0}%)")
             }
             NotificationType::StatusIssue => format!("{provider_name} is experiencing issues"),
             NotificationType::SessionDepleted => {
@@ -733,20 +768,22 @@ mod tests {
         assert!(settings.show_notifications);
         assert!((settings.high_usage_threshold - 70.0).abs() < f64::EPSILON);
 
+        let account = "";
         let weekly_key = (
             ProviderId::Claude,
+            account.to_string(),
             "weekly".to_string(),
             NotificationType::HighUsage,
         );
 
-        manager.check_and_notify(ProviderId::Claude, "session", 20.0, &settings);
-        manager.check_and_notify(ProviderId::Claude, "weekly", 76.0, &settings);
+        manager.check_and_notify(ProviderId::Claude, account, "session", 20.0, &settings);
+        manager.check_and_notify(ProviderId::Claude, account, "weekly", 76.0, &settings);
         assert!(manager.sent_notifications.contains(&weekly_key));
 
         // Simulate several refresh cycles: session still cool, weekly still hot.
         for _ in 0..5 {
-            manager.check_and_notify(ProviderId::Claude, "session", 20.0, &settings);
-            manager.check_and_notify(ProviderId::Claude, "weekly", 76.0, &settings);
+            manager.check_and_notify(ProviderId::Claude, account, "session", 20.0, &settings);
+            manager.check_and_notify(ProviderId::Claude, account, "weekly", 76.0, &settings);
         }
         assert_eq!(
             manager
@@ -759,9 +796,9 @@ mod tests {
         );
 
         // Drop weekly below high → re-arm allowed on next climb.
-        manager.check_and_notify(ProviderId::Claude, "weekly", 50.0, &settings);
+        manager.check_and_notify(ProviderId::Claude, account, "weekly", 50.0, &settings);
         assert!(!manager.sent_notifications.contains(&weekly_key));
-        manager.check_and_notify(ProviderId::Claude, "weekly", 76.0, &settings);
+        manager.check_and_notify(ProviderId::Claude, account, "weekly", 76.0, &settings);
         assert!(manager.sent_notifications.contains(&weekly_key));
     }
 
@@ -769,30 +806,35 @@ mod tests {
     fn threshold_keys_isolate_session_and_weekly() {
         let mut manager = NotificationManager::new();
         let settings = Settings::default();
+        let account = "";
 
-        manager.check_and_notify(ProviderId::Claude, "session", 75.0, &settings);
-        manager.check_and_notify(ProviderId::Claude, "weekly", 75.0, &settings);
+        manager.check_and_notify(ProviderId::Claude, account, "session", 75.0, &settings);
+        manager.check_and_notify(ProviderId::Claude, account, "weekly", 75.0, &settings);
 
         assert!(manager.sent_notifications.contains(&(
             ProviderId::Claude,
+            account.to_string(),
             "session".to_string(),
             NotificationType::HighUsage,
         )));
         assert!(manager.sent_notifications.contains(&(
             ProviderId::Claude,
+            account.to_string(),
             "weekly".to_string(),
             NotificationType::HighUsage,
         )));
 
         // Cool only session; weekly stays armed.
-        manager.check_and_notify(ProviderId::Claude, "session", 10.0, &settings);
+        manager.check_and_notify(ProviderId::Claude, account, "session", 10.0, &settings);
         assert!(!manager.sent_notifications.contains(&(
             ProviderId::Claude,
+            account.to_string(),
             "session".to_string(),
             NotificationType::HighUsage,
         )));
         assert!(manager.sent_notifications.contains(&(
             ProviderId::Claude,
+            account.to_string(),
             "weekly".to_string(),
             NotificationType::HighUsage,
         )));
@@ -804,8 +846,10 @@ mod tests {
     fn refresh_loop_session_cool_weekly_hot_toasts_once() {
         let mut manager = NotificationManager::new();
         let settings = Settings::default();
+        let account = "";
         let weekly_high = (
             ProviderId::Claude,
+            account.to_string(),
             "weekly".to_string(),
             NotificationType::HighUsage,
         );
@@ -814,8 +858,8 @@ mod tests {
         for _ in 0..30 {
             let before = manager.sent_notifications.contains(&weekly_high);
             // Same order as apps/desktop-tauri/.../providers.rs
-            manager.check_and_notify(ProviderId::Claude, "session", 20.0, &settings);
-            manager.check_and_notify(ProviderId::Claude, "weekly", 76.0, &settings);
+            manager.check_and_notify(ProviderId::Claude, account, "session", 20.0, &settings);
+            manager.check_and_notify(ProviderId::Claude, account, "weekly", 76.0, &settings);
             let after = manager.sent_notifications.contains(&weekly_high);
             if after && !before {
                 weekly_fires += 1;
@@ -830,8 +874,110 @@ mod tests {
         // Session never armed high while cool.
         assert!(!manager.sent_notifications.contains(&(
             ProviderId::Claude,
+            account.to_string(),
             "session".to_string(),
             NotificationType::HighUsage,
         )));
+    }
+
+    #[test]
+    fn threshold_keys_isolate_accounts_on_same_provider() {
+        // Two accounts on the same provider can each fire High once for weekly.
+        let mut manager = NotificationManager::new();
+        let settings = Settings::default();
+
+        let key_a = (
+            ProviderId::Claude,
+            "account-a".to_string(),
+            "weekly".to_string(),
+            NotificationType::HighUsage,
+        );
+        let key_b = (
+            ProviderId::Claude,
+            "account-b".to_string(),
+            "weekly".to_string(),
+            NotificationType::HighUsage,
+        );
+
+        manager.check_and_notify(ProviderId::Claude, "account-a", "weekly", 80.0, &settings);
+        manager.check_and_notify(ProviderId::Claude, "account-b", "weekly", 80.0, &settings);
+
+        assert!(manager.sent_notifications.contains(&key_a));
+        assert!(manager.sent_notifications.contains(&key_b));
+
+        // Re-poll both still hot: neither re-fires (still armed, no second insert).
+        manager.check_and_notify(ProviderId::Claude, "account-a", "weekly", 80.0, &settings);
+        manager.check_and_notify(ProviderId::Claude, "account-b", "weekly", 80.0, &settings);
+        assert_eq!(
+            manager
+                .sent_notifications
+                .iter()
+                .filter(|k| k.0 == ProviderId::Claude
+                    && k.2 == "weekly"
+                    && k.3 == NotificationType::HighUsage)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn account_a_session_cool_does_not_clear_account_b_weekly() {
+        let mut manager = NotificationManager::new();
+        let settings = Settings::default();
+
+        let key_b_weekly = (
+            ProviderId::Claude,
+            "account-b".to_string(),
+            "weekly".to_string(),
+            NotificationType::HighUsage,
+        );
+
+        manager.check_and_notify(ProviderId::Claude, "account-b", "weekly", 80.0, &settings);
+        assert!(manager.sent_notifications.contains(&key_b_weekly));
+
+        // Account A session cool must not clear account B weekly armed state.
+        manager.check_and_notify(ProviderId::Claude, "account-a", "session", 10.0, &settings);
+        assert!(
+            manager.sent_notifications.contains(&key_b_weekly),
+            "account A session cool must not clear account B weekly threshold key"
+        );
+
+        // Account A weekly cool must also not clear account B.
+        manager.check_and_notify(ProviderId::Claude, "account-a", "weekly", 10.0, &settings);
+        assert!(manager.sent_notifications.contains(&key_b_weekly));
+    }
+
+    #[test]
+    fn session_transition_isolates_accounts() {
+        let mut manager = NotificationManager::new();
+        let settings = Settings::default();
+
+        let depleted_a = (
+            ProviderId::Claude,
+            "account-a".to_string(),
+            "session".to_string(),
+            NotificationType::SessionDepleted,
+        );
+        let depleted_b = (
+            ProviderId::Claude,
+            "account-b".to_string(),
+            "session".to_string(),
+            NotificationType::SessionDepleted,
+        );
+
+        manager.check_session_transition(ProviderId::Claude, "account-a", 50.0, &settings);
+        manager.check_session_transition(ProviderId::Claude, "account-a", 100.0, &settings);
+        assert!(manager.sent_notifications.contains(&depleted_a));
+        assert!(!manager.sent_notifications.contains(&depleted_b));
+
+        // Account B still has quota; restoring A must not affect B's lane.
+        manager.check_session_transition(ProviderId::Claude, "account-b", 40.0, &settings);
+        manager.check_session_transition(ProviderId::Claude, "account-a", 20.0, &settings);
+        assert!(!manager.sent_notifications.contains(&depleted_a));
+        assert!(!manager.sent_notifications.contains(&depleted_b));
+
+        // Account B can still fire depleted independently.
+        manager.check_session_transition(ProviderId::Claude, "account-b", 100.0, &settings);
+        assert!(manager.sent_notifications.contains(&depleted_b));
     }
 }


### PR DESCRIPTION
## Summary

Port of **upstream CodexBar 0.43.0 PR B**: account-scoped quota threshold notifications.

High / Critical / Exhausted toast dedupe (and session depleted/restored transitions) are now keyed by **provider + account + window**, so one account cannot arm, clear, or suppress another account's notifications on the same provider.

## Changes

### `rust/src/notifications.rs`
- `ThresholdKey` is now `(ProviderId, account, window, NotificationType)` (empty account = single-account lane).
- `check_and_notify` takes `account: &str`; cool-down clears only matching provider+account+window threshold keys.
- `check_session_transition` is also account-scoped (`previous_session_percent` and depleted keys).

### `apps/desktop-tauri/.../providers.rs`
- `notify_usage_thresholds` builds a stable account discriminator via `quota_notification_account_identity`:
  token-account id → email → org → plan → `""`.
- Predictive pace identity path unchanged.

## Tests
- Two accounts same provider: weekly 80% on A then B → both fire once.
- Account A session cool does not clear account B weekly.
- Session transition isolation across accounts.
- Existing #198 multi-cycle tests updated for the new signature (empty account).

### Commands run
- `cargo test --manifest-path rust/Cargo.toml notifications` — **10 passed**
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml predictive_warning_tests` — **3 passed** (includes `quota_notification_account_identity`)
- `cargo fmt` on changed files

## Out of scope
- No version bump to 0.43.0
- No Factory / cost / sub2api changes
