### PR TITLE
fix: thermo-nuclear follow-ups for 0.43.0 ports

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -49,6 +49,9 @@ pub(crate) fn build_fetch_context(
             "off" if has_kimi_code_api_key && usage_source == SourceMode::Auto => {
                 (SourceMode::Auto, None)
             }
+            // Droid/Factory: cookie-off must never scrape browser cookies. Map to
+            // Cli (API-only in the provider) so Auto does not fall through to web.
+            "off" if id == ProviderId::Factory => (SourceMode::Cli, None),
             "off" => (SourceMode::Cli, None),
             "manual" => {
                 let cookie_header = active_token_cookie.or(stored_cookie);
@@ -163,12 +166,18 @@ pub(crate) fn prune_provider_cache_to_enabled(
 }
 
 /// Invalidate in-flight publish work and remove disabled providers from cache.
+///
+/// Also clears the refresh lock so a follow-up force refresh can start immediately
+/// (otherwise `begin_provider_refresh` no-ops while a superseded batch still holds
+/// `is_refreshing`, and newly enabled providers never get a replacement run).
 pub(crate) fn invalidate_provider_refresh_and_prune_disabled(
     state: &tauri::State<'_, Mutex<AppState>>,
     enabled_ids: &[ProviderId],
 ) -> Result<(), String> {
     let mut guard = state.lock().map_err(|e| e.to_string())?;
     guard.provider_refresh_generation = guard.provider_refresh_generation.wrapping_add(1);
+    guard.is_refreshing = false;
+    guard.provider_refresh_started_at = None;
     prune_provider_cache_to_enabled(&mut guard.provider_cache, enabled_ids);
     // Drop transient-failure counters for providers that left the enabled set.
     guard
@@ -221,7 +230,11 @@ async fn do_refresh_providers_with_policy(
     let handles = spawn_provider_refreshes(app, &inputs, generation);
     await_provider_refreshes(handles).await;
 
-    let error_count = finish_provider_refresh(&state, generation)?;
+    let Some(error_count) = finish_provider_refresh(&state, generation)? else {
+        // Superseded by a newer generation (or invalidate). Do not clear UI
+        // "refreshing" for a dead batch or stamp tray from incomplete work.
+        return Ok(());
+    };
     update_tray_and_notifications(app, &state, &inputs.settings, &inputs.token_accounts)?;
 
     events::emit_refresh_complete(app, enabled_count, error_count);
@@ -443,35 +456,29 @@ async fn await_provider_refreshes(handles: Vec<tokio::task::JoinHandle<()>>) {
     }
 }
 
+/// Finish a refresh batch. Returns `None` when `generation` was superseded
+/// (do not emit complete / tray updates for dead work). Returns `Some(error_count)`
+/// when this batch still owns the generation and the lock was released.
 fn finish_provider_refresh(
     state: &tauri::State<'_, Mutex<AppState>>,
     generation: u64,
-) -> Result<usize, String> {
+) -> Result<Option<usize>, String> {
     let mut guard = state.lock().map_err(|e| e.to_string())?;
-    // Always release the refresh lock when this batch ends so a later
-    // invalidate (enablement change) cannot leave is_refreshing stuck.
-    if guard.is_refreshing
-        && (is_current_provider_refresh_generation(&guard, generation)
-            || guard.provider_refresh_started_at.is_some())
-    {
-        // Only clear the lock if we still own it or no newer refresh has begun
-        // (newer begin bumps generation AND sets is_refreshing under the same
-        // ownership — currently concurrent begin is blocked).
-        if is_current_provider_refresh_generation(&guard, generation) {
-            guard.is_refreshing = false;
-            guard.provider_refresh_started_at = None;
-            guard.provider_cache_updated_at = Some(std::time::Instant::now());
-        } else {
-            // Superseded: release lock without stamping a "fresh" cache time.
-            guard.is_refreshing = false;
-            guard.provider_refresh_started_at = None;
-        }
+    if !is_current_provider_refresh_generation(&guard, generation) {
+        // A newer begin or invalidate owns the lock/generation. Do not clear
+        // is_refreshing — that would race a live successor batch.
+        return Ok(None);
     }
-    Ok(guard
-        .provider_cache
-        .iter()
-        .filter(|s| s.error.is_some())
-        .count())
+    guard.is_refreshing = false;
+    guard.provider_refresh_started_at = None;
+    guard.provider_cache_updated_at = Some(std::time::Instant::now());
+    Ok(Some(
+        guard
+            .provider_cache
+            .iter()
+            .filter(|s| s.error.is_some())
+            .count(),
+    ))
 }
 
 fn update_tray_and_notifications(
@@ -572,14 +579,8 @@ fn quota_notification_account_identity(
     {
         return format!("org:{}", org.to_ascii_lowercase());
     }
-    if let Some(plan) = snapshot
-        .plan_name
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
-        return format!("plan:{}", plan.to_ascii_lowercase());
-    }
+    // Do not fall back to plan_name/login_method — those are display tiers and
+    // flicker across refreshes, re-arming still-hot windows for a new identity.
     String::new()
 }
 
@@ -785,10 +786,8 @@ mod predictive_warning_tests {
         );
 
         snapshot.account_organization = None;
-        assert_eq!(
-            quota_notification_account_identity(&snapshot, None),
-            "plan:pro"
-        );
+        // plan_name/login_method is not a stable ownership key — fall through to "".
+        assert_eq!(quota_notification_account_identity(&snapshot, None), "");
 
         snapshot.plan_name = None;
         assert_eq!(quota_notification_account_identity(&snapshot, None), "");

--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -629,23 +629,33 @@ fn selected_metric_percent(
 ) -> Option<f64> {
     match preference {
         MetricPreference::Automatic => automatic_metric_percent(snapshot, provider),
+        // Informational primaries (e.g. Claude null five_hour placeholder) must
+        // not paint a phantom session percent; fall through to Automatic.
+        MetricPreference::Session if snapshot.primary.is_informational => None,
         MetricPreference::Session => Some(snapshot.primary.used_percent),
         MetricPreference::Weekly => snapshot
             .secondary
             .as_ref()
+            .filter(|w| !w.is_informational)
             .map(|w| w.used_percent)
-            .or(Some(snapshot.primary.used_percent)),
+            .or_else(|| {
+                (!snapshot.primary.is_informational).then_some(snapshot.primary.used_percent)
+            }),
         MetricPreference::Model => snapshot
             .model_specific
             .as_ref()
             .map(|w| w.used_percent)
-            .or(Some(snapshot.primary.used_percent)),
+            .or_else(|| {
+                (!snapshot.primary.is_informational).then_some(snapshot.primary.used_percent)
+            }),
         MetricPreference::Tertiary => snapshot
             .tertiary
             .as_ref()
             .map(|w| w.used_percent)
             .or_else(|| snapshot.secondary.as_ref().map(|w| w.used_percent))
-            .or(Some(snapshot.primary.used_percent)),
+            .or_else(|| {
+                (!snapshot.primary.is_informational).then_some(snapshot.primary.used_percent)
+            }),
         MetricPreference::Credits => cost_metric_percent(snapshot),
         MetricPreference::ExtraUsage => {
             extra_rate_window_percent(snapshot).or_else(|| cost_metric_percent(snapshot))
@@ -673,20 +683,27 @@ fn automatic_metric_percent(
         Some(ProviderId::Factory) | Some(ProviderId::Kimi) => snapshot
             .secondary
             .as_ref()
+            .filter(|w| !w.is_informational)
             .map(|w| w.used_percent)
-            .or(Some(snapshot.primary.used_percent)),
+            .or_else(|| {
+                (!snapshot.primary.is_informational).then_some(snapshot.primary.used_percent)
+            }),
         Some(ProviderId::Copilot) => max_metric_percent([
-            Some(snapshot.primary.used_percent),
-            snapshot.secondary.as_ref().map(|w| w.used_percent),
+            (!snapshot.primary.is_informational).then_some(snapshot.primary.used_percent),
+            snapshot
+                .secondary
+                .as_ref()
+                .filter(|w| !w.is_informational)
+                .map(|w| w.used_percent),
             extra_rate_window_percent(snapshot),
         ]),
-        // Claude web may emit an informational 5h 0% placeholder when five_hour is null;
-        // prefer the weekly lane so the tray does not show a phantom session.
-        Some(ProviderId::Claude) if snapshot.primary.is_informational => snapshot
+        // Informational primary (e.g. Claude null five_hour) is not a real quota —
+        // prefer secondary / non-informational signals for every provider.
+        _ if snapshot.primary.is_informational => snapshot
             .secondary
             .as_ref()
-            .map(|w| w.used_percent)
-            .or(Some(snapshot.primary.used_percent)),
+            .filter(|w| !w.is_informational)
+            .map(|w| w.used_percent),
         _ => Some(snapshot.primary.used_percent),
     }
 }
@@ -1397,5 +1414,34 @@ mod tests {
         let (primary, _) = selected_tray_percents(&snapshot, &settings);
 
         assert_eq!(primary, 72.0);
+    }
+
+    #[test]
+    fn informational_primary_skips_session_and_automatic_phantom_zero() {
+        let mut settings = Settings::default();
+        settings.set_provider_metric(ProviderId::Claude, MetricPreference::Session);
+        let mut snapshot = fake_snapshot_with("claude", "Claude", 0.0, Some(42.0), None, None);
+        snapshot.primary.is_informational = true;
+
+        // Session preference must not paint the synthetic 0% primary;
+        // it falls through to Automatic which prefers weekly (42%).
+        let (primary, _) = selected_tray_percents(&snapshot, &settings);
+        assert_eq!(primary, 42.0);
+        assert_ne!(primary, 0.0);
+
+        // Automatic also prefers weekly over informational primary.
+        settings.set_provider_metric(ProviderId::Claude, MetricPreference::Automatic);
+        let (primary, _) = selected_tray_percents(&snapshot, &settings);
+        assert_eq!(primary, 42.0);
+
+        // Direct Session arm returns None when primary is informational.
+        assert_eq!(
+            selected_metric_percent(
+                &snapshot,
+                Some(ProviderId::Claude),
+                MetricPreference::Session
+            ),
+            None
+        );
     }
 }

--- a/rust/src/core/jsonl_scanner.rs
+++ b/rust/src/core/jsonl_scanner.rs
@@ -20,12 +20,13 @@ const CODEX_JSONL_MAX_LINE_BYTES: usize = 256 * 1024;
 /// Default scanner-side refresh debounce (upstream CostUsageScanner).
 pub const DEFAULT_COST_SCAN_REFRESH_MIN_INTERVAL_SECS: u64 = 60;
 
-/// Options for a cost scan pass.
+/// Options for a cost scan pass (disk-cache-backed full inspections).
 ///
-/// App-driven callers (Tauri refresh / menu open) already own their own TTL, so
-/// they use [`CostScanOptions::app_driven`] to bypass the scanner debounce and
-/// avoid pinning a stale disk-cache snapshot for the full token-cost TTL
-/// (upstream issue #2089).
+/// **Windows note:** the production [`crate::cost_scanner::CostScanner`] path
+/// does not load/save [`CostUsageCache`] today — it always full-walks sessions.
+/// These options are ready for the cache path (and unit-tested) so app-driven
+/// callers can pass [`CostScanOptions::app_driven`] once that path is wired
+/// (upstream issue #2089). Until then they do not change runtime freshness.
 #[derive(Debug, Clone, Copy)]
 pub struct CostScanOptions {
     /// Minimum seconds between disk-cache-backed full inspections.
@@ -514,9 +515,12 @@ fn contained_total_delta(
 
     let component = |water: i32, counted: i32, current: i32| -> i32 {
         if current >= water {
+            // Only growth above the historical high watermark counts.
             (current - water.max(counted)).max(0)
         } else {
-            (current - counted).max(0)
+            // Below watermark: rewind / interleaved lineage — do not re-add
+            // mid-range climbs that would inflate totals after a fork reset.
+            0
         }
     };
 
@@ -1173,6 +1177,36 @@ mod tests {
         assert!(
             total_output <= 21,
             "output inflated to {total_output}, expected <= 21"
+        );
+    }
+
+    #[test]
+    fn interleaved_lineage_mid_range_climb_below_watermark_does_not_readd() {
+        // 100 → 5 (rewind) → 80 (mid-range below water) → 101 (above water).
+        // Phase-1 containment: do not re-add the 5→80 climb; only growth above
+        // the historical high watermark counts.
+        let day = NaiveDate::from_ymd_opt(2026, 5, 31).unwrap();
+        let range = CostUsageDayRange::new(day, day);
+        let mut parser = CodexParserState::new(Some("gpt-5.6-sol".to_string()), None);
+
+        for (input, output) in [(100, 20), (5, 1), (80, 10), (101, 21)] {
+            parser.process_line(
+                &format!(
+                    r#"{{"timestamp":"2026-05-31T10:00:0{input}Z","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":{input},"cached_input_tokens":0,"output_tokens":{output}}}}}}}"#
+                ),
+                &range,
+            );
+        }
+
+        let total_input: i32 = parser.records.iter().map(|r| r.input).sum();
+        let total_output: i32 = parser.records.iter().map(|r| r.output).sum();
+        assert!(
+            total_input <= 101,
+            "mid-range climb re-added input to {total_input}, expected <= 101"
+        );
+        assert!(
+            total_output <= 21,
+            "mid-range climb re-added output to {total_output}, expected <= 21"
         );
     }
 

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -1,6 +1,10 @@
 //! Local cost-usage scanner for Codex and Claude
 //!
-//! Scans local JSONL log files to aggregate token usage and calculate costs
+//! Scans local JSONL log files to aggregate token usage and calculate costs.
+//!
+//! Note: this path always full-walks session files. The disk-cache /
+//! [`crate::core::CostScanOptions`] debounce API in `jsonl_scanner` is not
+//! wired here yet (upstream #2089); app-level TTL still owns refresh pacing.
 
 use chrono::{DateTime, Duration, Local, NaiveDate, Utc};
 use serde::Deserialize;

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -616,7 +616,12 @@ impl ClaudeWebApiFetcher {
 ///
 /// A genuine idle session (object present, 0% used) is NOT marked informational.
 fn synthetic_no_session_primary() -> RateWindow {
-    let mut window = RateWindow::with_details(0.0, Some(300), None, None);
+    let mut window = RateWindow::with_details(
+        0.0,
+        Some(300),
+        None,
+        Some("No active 5h session".to_string()),
+    );
     window.is_informational = true;
     window
 }
@@ -679,6 +684,10 @@ mod tests {
         assert!(placeholder.is_informational);
         assert_eq!(placeholder.window_minutes, Some(300));
         assert!((placeholder.used_percent - 0.0).abs() < f64::EPSILON);
+        assert_eq!(
+            placeholder.reset_description.as_deref(),
+            Some("No active 5h session")
+        );
 
         // Real idle session (object present at 0%) stays unflagged.
         let idle = ClaudeWebApiFetcher::new().to_rate_window(

--- a/rust/src/providers/factory/mod.rs
+++ b/rust/src/providers/factory/mod.rs
@@ -276,7 +276,10 @@ pub(crate) fn parse_factory_dotenv_key(contents: &str) -> Option<String> {
         if key.trim() != FACTORY_API_KEY_ENV {
             continue;
         }
-        return clean_factory_secret(Some(value));
+        // Empty assignment (`FACTORY_API_KEY=`) must not short-circuit a later real key.
+        if let Some(secret) = clean_factory_secret(Some(value)) {
+            return Some(secret);
+        }
     }
     None
 }
@@ -577,8 +580,11 @@ impl FactoryProvider {
     }
 
     fn usage_snapshot_from_response(usage_data: &FactoryUsageResponse) -> UsageSnapshot {
-        // Prefer nested upstream `usage` block when present.
-        if let Some(nested) = &usage_data.usage {
+        // Prefer nested upstream `usage` only when it carries usable data.
+        // An empty `usage: {}` must not suppress populated top-level windows.
+        if let Some(nested) = &usage_data.usage
+            && nested_usage_has_data(nested)
+        {
             let standard_percent = nested
                 .standard
                 .as_ref()
@@ -656,10 +662,10 @@ impl FactoryProvider {
     }
 
     async fn fetch_auto(&self, ctx: &FetchContext) -> Result<ProviderFetchResult, ProviderError> {
-        // API-first only when a key is resolvable (upstream Auto strategy).
-        if resolve_factory_api_key(ctx.api_key.as_deref()).is_some() {
-            match self.fetch_api_result(ctx).await {
-                Ok(result) => return Ok(result),
+        // Resolve once — do not double-load store/dotenv for the API branch.
+        if let Some(api_key) = resolve_factory_api_key(ctx.api_key.as_deref()) {
+            match self.fetch_via_api(&api_key).await {
+                Ok(usage) => return Ok(ProviderFetchResult::new(usage, "api")),
                 Err(err) if factory_api_error_is_recoverable(&err) => {
                     tracing::debug!(
                         "Droid API path failed ({}); falling back to web cookies",
@@ -671,6 +677,16 @@ impl FactoryProvider {
         }
         self.fetch_web_result(ctx).await
     }
+}
+
+fn nested_usage_has_data(nested: &FactoryUsageNested) -> bool {
+    let window_has = |w: &FactoryTokenUsage| {
+        w.user_tokens.is_some()
+            || w.total_allowance.is_some()
+            || w.used_ratio.is_some_and(|r| r.is_finite())
+    };
+    nested.standard.as_ref().is_some_and(window_has)
+        || nested.premium.as_ref().is_some_and(window_has)
 }
 
 fn snapshot_from_billing_limits(
@@ -736,8 +752,11 @@ impl Provider for FactoryProvider {
         tracing::debug!("Fetching Droid (Factory) usage");
 
         match ctx.source_mode {
-            // Auto + legacy Cli alias: API key first, then web cookies.
-            SourceMode::Auto | SourceMode::Cli => self.fetch_auto(ctx).await,
+            // Auto: API key first, then web cookies (when cookie path is allowed).
+            SourceMode::Auto => self.fetch_auto(ctx).await,
+            // Cli = cookie-off / no-browser path from the shell: API key only.
+            // Never fall through to browser cookie scrape.
+            SourceMode::Cli => self.fetch_api_result(ctx).await,
             // Win maps explicit API-token sources to OAuth (sub2api pattern).
             SourceMode::OAuth => self.fetch_api_result(ctx).await,
             SourceMode::Web => self.fetch_web_result(ctx).await,
@@ -754,7 +773,7 @@ impl Provider for FactoryProvider {
     }
 
     fn supports_cli(&self) -> bool {
-        // Upstream treats legacy cli as Auto; keep available for persisted configs.
+        // Shell maps cookie-source "off" to Cli; Factory treats Cli as API-only.
         true
     }
 }
@@ -799,6 +818,16 @@ mod tests {
             )
             .as_deref(),
             Some("fk-quoted")
+        );
+        // Empty assignment must not short-circuit a later real key.
+        assert_eq!(
+            parse_factory_dotenv_key("FACTORY_API_KEY=\nFACTORY_API_KEY=fk-real\n").as_deref(),
+            Some("fk-real")
+        );
+        assert_eq!(
+            parse_factory_dotenv_key("FACTORY_API_KEY=\"\"\nFACTORY_API_KEY='fk-later'\n")
+                .as_deref(),
+            Some("fk-later")
         );
     }
 
@@ -898,6 +927,28 @@ mod tests {
         let snap = FactoryProvider::usage_snapshot_from_response(&parsed);
         assert!((snap.primary.used_percent - 30.0).abs() < f64::EPSILON);
         assert!((snap.secondary.unwrap().used_percent - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn empty_nested_usage_falls_through_to_top_level() {
+        let body = r#"{
+          "usage": {},
+          "standard": { "used": 40.0, "allowance": 100.0 },
+          "premium": { "used": 5.0, "allowance": 50.0 }
+        }"#;
+        let parsed: FactoryUsageResponse = serde_json::from_str(body).unwrap();
+        let snap = FactoryProvider::usage_snapshot_from_response(&parsed);
+        assert!((snap.primary.used_percent - 40.0).abs() < f64::EPSILON);
+        assert!((snap.secondary.unwrap().used_percent - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn available_sources_do_not_advertise_cli() {
+        let sources = FactoryProvider::new().available_sources();
+        assert!(!sources.contains(&SourceMode::Cli));
+        assert!(sources.contains(&SourceMode::Auto));
+        assert!(sources.contains(&SourceMode::OAuth));
+        assert!(sources.contains(&SourceMode::Web));
     }
 
     #[test]

--- a/rust/src/providers/kimi/mod.rs
+++ b/rust/src/providers/kimi/mod.rs
@@ -327,21 +327,25 @@ impl KimiProvider {
     }
 
     fn kimi_code_cli_identity_headers(home: &Path) -> Vec<(&'static str, String)> {
-        let device_id =
-            read_kimi_code_device_id(home).unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        // Only send device id when the CLI file exists — never mint a fresh UUID
+        // per fetch (unstable fingerprinting toward Moonshot).
+        let device_id = read_kimi_code_device_id(home);
         let version = env!("CARGO_PKG_VERSION").to_string();
         let os_name = std::env::consts::OS;
         let arch = std::env::consts::ARCH;
         let model = format!("{os_name} {arch}");
-        vec![
+        let mut headers = vec![
             ("User-Agent", format!("CodexBar/{version}")),
             ("X-Msh-Platform", KIMI_CODE_CLI_PLATFORM.to_string()),
             ("X-Msh-Version", version),
             ("X-Msh-Device-Name", "codexbar".to_string()),
             ("X-Msh-Device-Model", ascii_header_value(&model)),
             ("X-Msh-Os-Version", ascii_header_value(os_name)),
-            ("X-Msh-Device-Id", device_id),
-        ]
+        ];
+        if let Some(device_id) = device_id {
+            headers.push(("X-Msh-Device-Id", device_id));
+        }
+        headers
     }
 
     fn code_api_usage_endpoint(base_url: &Url) -> Result<Url, ProviderError> {
@@ -735,7 +739,6 @@ fn timestamp_from_number(raw: i64) -> Option<DateTime<Utc>> {
     DateTime::from_timestamp(seconds, 0)
 }
 
-
 fn cleaned_env(key: &str) -> Option<String> {
     std::env::var(key).ok().and_then(cleaned_owned)
 }
@@ -750,11 +753,7 @@ fn cleaned_owned(raw: impl AsRef<str>) -> Option<String> {
     if quoted {
         value = value[1..value.len().saturating_sub(1)].trim().to_string();
     }
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
-    }
+    if value.is_empty() { None } else { Some(value) }
 }
 
 #[derive(Debug, Deserialize)]

--- a/rust/src/providers/sub2api/mod.rs
+++ b/rust/src/providers/sub2api/mod.rs
@@ -29,6 +29,8 @@ struct ParsedUsage {
     plan_name: Option<String>,
     unit: String,
     balance: Option<f64>,
+    /// Top-level remaining (wallet-ish) when balance/quota are absent.
+    remaining: Option<f64>,
     quota: Option<ParsedQuota>,
     rate_limits: Vec<ParsedRateLimit>,
     subscription: Option<ParsedSubscription>,
@@ -77,11 +79,9 @@ struct UsageResponse {
     mode: Option<String>,
     #[serde(rename = "isValid", default)]
     is_valid: Option<bool>,
-    #[allow(dead_code)]
-    status: Option<String>,
     #[serde(rename = "planName")]
     plan_name: Option<String>,
-    #[allow(dead_code)]
+    /// Wallet-ish remaining when balance/quota are absent.
     remaining: Option<f64>,
     unit: Option<String>,
     balance: Option<f64>,
@@ -153,7 +153,7 @@ impl Sub2ApiProvider {
                 display_name: "sub2api",
                 session_label: "Quota",
                 weekly_label: "Weekly quota",
-                supports_opus: true,
+                supports_opus: false,
                 supports_credits: false,
                 default_enabled: false,
                 is_primary: false,
@@ -338,7 +338,7 @@ pub(crate) fn validated_sub2api_base_url(raw: &str) -> Result<Url, ProviderError
 
 fn is_loopback_host(host: &str) -> bool {
     let normalized = host.trim_end_matches('.').to_ascii_lowercase();
-    if normalized == "localhost" || normalized == "localhost." {
+    if normalized == "localhost" {
         return true;
     }
     let ip_candidate = normalized
@@ -414,6 +414,7 @@ fn parse_usage_response(response: UsageResponse) -> ParsedUsage {
         plan_name: response.plan_name,
         unit: unit.clone(),
         balance: response.balance,
+        remaining: response.remaining.filter(|r| r.is_finite()),
         quota: response.quota.map(|q| ParsedQuota {
             limit: q.limit,
             used: q.used,
@@ -472,53 +473,101 @@ fn parse_date(raw: Option<&str>) -> Option<DateTime<Utc>> {
 }
 
 fn snapshot_from_parsed(parsed: ParsedUsage) -> ProviderFetchResult {
-    let kind = if parsed.subscription.is_some() {
-        Kind::Subscription
-    } else if parsed.quota.is_some() || !parsed.rate_limits.is_empty() {
-        Kind::KeyQuota
-    } else if parsed.balance.is_some() {
-        Kind::Wallet
-    } else {
-        Kind::Unknown
-    };
-
+    let kind = classify_usage_kind(&parsed);
     let mut cost: Option<CostSnapshot> = None;
-    let mut primary: Option<RateWindow> = None;
-    let mut secondary: Option<RateWindow> = None;
-    let mut tertiary: Option<RateWindow> = None;
 
-    if let Some(sub) = &parsed.subscription {
-        primary = rate_window_from_usage(
-            sub.daily_usage_usd,
-            sub.daily_limit_usd,
-            Some(24 * 60),
-            &parsed.unit,
-        );
-        secondary = rate_window_from_usage(
-            sub.weekly_usage_usd,
-            sub.weekly_limit_usd,
-            Some(7 * 24 * 60),
-            &parsed.unit,
-        );
-        tertiary = rate_window_from_usage(
-            sub.monthly_usage_usd,
-            sub.monthly_limit_usd,
-            Some(30 * 24 * 60),
-            &parsed.unit,
-        );
-    } else if let Some(quota) = &parsed.quota {
-        primary = Some(RateWindow::with_details(
-            used_percent(quota.used, quota.limit),
-            None,
-            None,
-            Some(amount_description(quota.used, quota.limit, &quota.unit)),
-        ));
-    }
+    let mut snapshot = match kind {
+        Kind::Subscription => {
+            let sub = parsed
+                .subscription
+                .as_ref()
+                .expect("subscription kind requires subscription payload");
+            let primary = rate_window_from_usage(
+                sub.daily_usage_usd,
+                sub.daily_limit_usd,
+                Some(24 * 60),
+                &parsed.unit,
+            )
+            .or_else(|| informational_usage_window(sub.daily_usage_usd, "day", &parsed.unit));
+            let secondary = rate_window_from_usage(
+                sub.weekly_usage_usd,
+                sub.weekly_limit_usd,
+                Some(7 * 24 * 60),
+                &parsed.unit,
+            )
+            .or_else(|| informational_usage_window(sub.weekly_usage_usd, "week", &parsed.unit));
+            let tertiary = rate_window_from_usage(
+                sub.monthly_usage_usd,
+                sub.monthly_limit_usd,
+                Some(30 * 24 * 60),
+                &parsed.unit,
+            )
+            .or_else(|| informational_usage_window(sub.monthly_usage_usd, "month", &parsed.unit));
 
-    let mut snapshot = match primary {
-        Some(window) => UsageSnapshot::new(window),
-        None if kind == Kind::Wallet => {
-            let balance = parsed.balance.unwrap_or(0.0);
+            let mut snap = UsageSnapshot::new(
+                primary.unwrap_or_else(|| RateWindow::informational("Subscription active")),
+            );
+            if let Some(secondary) = secondary {
+                snap = snap.with_secondary(secondary);
+            }
+            if let Some(tertiary) = tertiary {
+                snap = snap.with_tertiary(tertiary);
+            }
+            // Surface wallet balance alongside subscription when present.
+            if let Some(balance) = parsed.balance {
+                cost = Some(
+                    CostSnapshot::new(0.0, normalize_currency(&parsed.unit), "balance")
+                        .with_limit(balance.max(0.0)),
+                );
+            }
+            snap
+        }
+        Kind::KeyQuota => {
+            let mut snap = if let Some(quota) = &parsed.quota {
+                UsageSnapshot::new(RateWindow::with_details(
+                    used_percent(quota.used, quota.limit),
+                    None,
+                    None,
+                    Some(amount_description(quota.used, quota.limit, &quota.unit)),
+                ))
+            } else if let Some(first) = parsed.rate_limits.first() {
+                // Rate-limit-only payload: promote the first window to primary.
+                UsageSnapshot::new(RateWindow::with_details(
+                    used_percent(first.used, first.limit),
+                    window_minutes(&first.window),
+                    first.reset_at,
+                    Some(amount_description(first.used, first.limit, &parsed.unit)),
+                ))
+            } else {
+                UsageSnapshot::new(RateWindow::informational("Key quota"))
+            };
+            let skip_first_rate_limit = parsed.quota.is_none() && !parsed.rate_limits.is_empty();
+            for (idx, rate_limit) in parsed.rate_limits.iter().enumerate() {
+                if skip_first_rate_limit && idx == 0 {
+                    continue;
+                }
+                snap = snap.with_extra_rate_window(
+                    rate_limit.window.clone(),
+                    rate_limit_title(&rate_limit.window),
+                    RateWindow::with_details(
+                        used_percent(rate_limit.used, rate_limit.limit),
+                        window_minutes(&rate_limit.window),
+                        rate_limit.reset_at,
+                        Some(amount_description(
+                            rate_limit.used,
+                            rate_limit.limit,
+                            &parsed.unit,
+                        )),
+                    ),
+                );
+            }
+            snap
+        }
+        Kind::Wallet => {
+            let balance = parsed
+                .balance
+                .or_else(|| wallet_remaining(&parsed))
+                .unwrap_or(0.0);
             let description = format!("{} balance", currency_string(balance, &parsed.unit));
             cost = Some(
                 CostSnapshot::new(0.0, normalize_currency(&parsed.unit), "balance")
@@ -526,39 +575,59 @@ fn snapshot_from_parsed(parsed: ParsedUsage) -> ProviderFetchResult {
             );
             UsageSnapshot::new(RateWindow::informational(description))
         }
-        None => UsageSnapshot::new(RateWindow::informational("No quota data")),
+        Kind::Unknown => {
+            // Prefer any totals over a blank "No quota data" row.
+            if let Some(today) = &parsed.today {
+                UsageSnapshot::new(RateWindow::informational(totals_description(
+                    today,
+                    &parsed.unit,
+                )))
+            } else if let Some(total) = &parsed.total {
+                UsageSnapshot::new(RateWindow::informational(totals_description(
+                    total,
+                    &parsed.unit,
+                )))
+            } else {
+                UsageSnapshot::new(RateWindow::informational("No quota data"))
+            }
+        }
     };
 
-    if let Some(secondary) = secondary {
-        snapshot = snapshot.with_secondary(secondary);
-    }
-    if let Some(tertiary) = tertiary {
-        snapshot = snapshot.with_tertiary(tertiary);
-    }
-
-    for rate_limit in &parsed.rate_limits {
-        snapshot = snapshot.with_extra_rate_window(
-            rate_limit.window.clone(),
-            rate_limit_title(&rate_limit.window),
-            RateWindow::with_details(
-                used_percent(rate_limit.used, rate_limit.limit),
-                window_minutes(&rate_limit.window),
-                rate_limit.reset_at,
-                Some(amount_description(
-                    rate_limit.used,
-                    rate_limit.limit,
-                    &parsed.unit,
-                )),
-            ),
-        );
+    // Rate-limit extras for subscription/wallet kinds that also ship them.
+    if kind != Kind::KeyQuota {
+        for rate_limit in &parsed.rate_limits {
+            snapshot = snapshot.with_extra_rate_window(
+                rate_limit.window.clone(),
+                rate_limit_title(&rate_limit.window),
+                RateWindow::with_details(
+                    used_percent(rate_limit.used, rate_limit.limit),
+                    window_minutes(&rate_limit.window),
+                    rate_limit.reset_at,
+                    Some(amount_description(
+                        rate_limit.used,
+                        rate_limit.limit,
+                        &parsed.unit,
+                    )),
+                ),
+            );
+        }
     }
 
     if let Some(today) = &parsed.today {
-        snapshot = snapshot.with_extra_rate_window(
-            "today",
-            "Today",
-            RateWindow::informational(totals_description(today, &parsed.unit)),
-        );
+        // Avoid duplicating the primary informational totals row.
+        let already_primary = kind == Kind::Unknown
+            && snapshot
+                .primary
+                .reset_description
+                .as_deref()
+                .is_some_and(|d| d == totals_description(today, &parsed.unit));
+        if !already_primary {
+            snapshot = snapshot.with_extra_rate_window(
+                "today",
+                "Today",
+                RateWindow::informational(totals_description(today, &parsed.unit)),
+            );
+        }
     }
     if let Some(total) = &parsed.total {
         snapshot = snapshot.with_extra_rate_window(
@@ -568,10 +637,18 @@ fn snapshot_from_parsed(parsed: ParsedUsage) -> ProviderFetchResult {
         );
     }
 
+    // Plan is a tier/login label, not organization identity.
     if let Some(plan) = parsed.plan_name.as_ref().filter(|p| !p.trim().is_empty()) {
-        snapshot = snapshot
-            .with_organization(plan.clone())
-            .with_login_method(plan.clone());
+        let mut login = plan.clone();
+        if !parsed.mode.is_empty()
+            && parsed.mode != "unknown"
+            && !plan.eq_ignore_ascii_case(&parsed.mode)
+        {
+            login = format!("{plan} ({})", parsed.mode);
+        }
+        snapshot = snapshot.with_login_method(login);
+    } else if !parsed.mode.is_empty() && parsed.mode != "unknown" {
+        snapshot = snapshot.with_login_method(parsed.mode.clone());
     }
 
     let expires = parsed
@@ -592,14 +669,41 @@ fn snapshot_from_parsed(parsed: ParsedUsage) -> ProviderFetchResult {
         );
     }
 
-    // Surface mode/kind lightly without a dedicated schema field.
-    let _ = (kind, parsed.mode);
-
     let mut result = ProviderFetchResult::new(snapshot, "api");
     if let Some(cost) = cost {
         result = result.with_cost(cost);
     }
     result
+}
+
+fn classify_usage_kind(parsed: &ParsedUsage) -> Kind {
+    if parsed.subscription.is_some() {
+        Kind::Subscription
+    } else if parsed.quota.is_some() || !parsed.rate_limits.is_empty() {
+        Kind::KeyQuota
+    } else if parsed.balance.is_some() || wallet_remaining(parsed).is_some() {
+        Kind::Wallet
+    } else {
+        Kind::Unknown
+    }
+}
+
+/// Top-level remaining as a wallet signal only when quota/subscription are absent.
+fn wallet_remaining(parsed: &ParsedUsage) -> Option<f64> {
+    if parsed.quota.is_some() || parsed.subscription.is_some() {
+        return None;
+    }
+    parsed.remaining.filter(|r| r.is_finite())
+}
+
+fn informational_usage_window(usage: f64, period: &str, unit: &str) -> Option<RateWindow> {
+    if !usage.is_finite() {
+        return None;
+    }
+    Some(RateWindow::informational(format!(
+        "{} used / {period}",
+        currency_string(usage, unit)
+    )))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -794,17 +898,54 @@ mod tests {
             (result.usage.secondary.as_ref().unwrap().used_percent - 25.0).abs() < f64::EPSILON
         );
         assert!((result.usage.tertiary.as_ref().unwrap().used_percent - 30.0).abs() < f64::EPSILON);
+        assert!(result.usage.account_organization.is_none());
         assert_eq!(
-            result.usage.account_organization.as_deref(),
-            Some("Claude Team")
+            result.usage.login_method.as_deref(),
+            Some("Claude Team (unrestricted)")
         );
-        assert_eq!(result.usage.login_method.as_deref(), Some("Claude Team"));
         assert!(
             result
                 .usage
                 .extra_rate_windows
                 .iter()
                 .any(|w| w.id == "expires")
+        );
+    }
+
+    #[test]
+    fn subscription_without_limits_shows_usage_not_empty() {
+        let json = r#"
+        {
+          "mode": "unrestricted",
+          "planName": "Soft plan",
+          "unit": "USD",
+          "subscription": {
+            "daily_usage_usd": 2.5,
+            "weekly_usage_usd": 10,
+            "monthly_usage_usd": 30
+          },
+          "balance": 12.0
+        }
+        "#;
+        let result = snapshot_from_parsed(parse_usage_body(json).unwrap());
+        assert!(result.usage.primary.is_informational);
+        assert!(
+            result
+                .usage
+                .primary
+                .reset_description
+                .as_deref()
+                .is_some_and(|d| d.contains("$2.50") && d.contains("day"))
+        );
+        assert!(result.cost.is_some());
+        assert_eq!(result.cost.as_ref().unwrap().limit, Some(12.0));
+        assert!(result.usage.account_organization.is_none());
+        assert!(
+            result
+                .usage
+                .login_method
+                .as_deref()
+                .is_some_and(|m| m.starts_with("Soft plan"))
         );
     }
 
@@ -864,7 +1005,10 @@ mod tests {
             result.usage.primary.reset_description.as_deref(),
             Some("$42.50 balance")
         );
-        assert_eq!(result.usage.login_method.as_deref(), Some("Wallet plan"));
+        assert_eq!(
+            result.usage.login_method.as_deref(),
+            Some("Wallet plan (unrestricted)")
+        );
         let cost = result.cost.unwrap();
         assert_eq!(cost.limit, Some(42.5));
         assert_eq!(cost.period, "balance");

--- a/rust/src/settings/api_keys.rs
+++ b/rust/src/settings/api_keys.rs
@@ -463,7 +463,7 @@ pub fn get_api_key_providers() -> Vec<ProviderConfigInfo> {
             id: ProviderId::Sub2Api,
             name: "sub2api",
             requires_api_key: true,
-            api_key_env_var: Some("SUB2API_API_KEY + SUB2API_BASE_URL"),
+            api_key_env_var: Some("SUB2API_API_KEY"),
             api_key_help: Some(
                 "Paste a group API key and set the base URL in provider extras or SUB2API_BASE_URL. HTTPS required (loopback HTTP allowed for local dev).",
             ),


### PR DESCRIPTION
## Summary
Closes thermo-nuclear FOLLOW_UP findings from merged 0.43.0 port PRs **#202–#207** (skip #205 Blacksmith).

### P0 / correctness
- **#207 refresh race:** `invalidate_provider_refresh_and_prune_disabled` clears `is_refreshing`; superseded `finish_provider_refresh` returns `None` and skips tray / `refresh-complete` / enrichment.
- **#206 Factory cookie-off:** `SourceMode::Cli` is API-only (no browser scrape). Empty dotenv no longer short-circuits a later key. Empty nested `usage: {}` falls through to top-level windows. Resolve API key once per Auto fetch.
- **#207 watermark:** below-watermark mid-range climbs no longer re-add totals (+ regression test).

### P1
- **#202 sub2api:** `Kind` drives snapshot construction (limit-less subscription shows usage, not empty quota; balance surfaces with subscription). Plan goes to `login_method` only (not organization). `supports_opus: false`. Mode attached to login when meaningful.
- **#203 notifications:** drop unstable `plan:` ownership fallback.
- **#204 tray:** informational primary treated as absent for Session and all Automatic/fallback arms; Claude synthetic placeholder gets "No active 5h session".
- **Kimi:** omit `X-Msh-Device-Id` when CLI file missing (no per-fetch UUID churn).

### P2 / hygiene
- Document that `CostScanOptions` is not wired into production `CostScanner` yet (disk-cache path).
- sub2api settings env label is `SUB2API_API_KEY` only.

## Deferred (not in this PR)
- Factory megafile split (`models` / `credentials` / `http`)
- Full disk-cache wiring for `CostScanOptions` in `CostScanner`
- Identity flicker migration (token ↔ email) beyond dropping plan fallback

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --lib -- factory sub2api interleaved_lineage cost_scan_options kimi claude::web_api`
- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml -- informational_primary quota_notification`
- [ ] Manual: toggle provider enablement mid-refresh → follow-up refresh starts
- [ ] Manual: Factory cookie-source off + API key → no browser scrape
- [ ] Manual: Claude web null five_hour + Session metric → no phantom 0% tray bar
