### PR TITLE
fix: Claude weekly_all, OpenCode parse, Cursor Cli (#210 #211 #212)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -33,7 +33,7 @@ pub(crate) fn build_fetch_context(
     let has_kimi_code_api_key =
         id == ProviderId::Kimi && api_key.as_deref().is_some_and(|key| !key.trim().is_empty());
 
-    let (source_mode, cookie_header) = if id.cookie_domain().is_none() {
+    let (mut source_mode, mut cookie_header) = if id.cookie_domain().is_none() {
         let source_mode = if active_token_env.is_some() {
             SourceMode::OAuth
         } else {
@@ -82,6 +82,28 @@ pub(crate) fn build_fetch_context(
             _ => (usage_source, stored_cookie),
         }
     };
+
+    // Cookie-web providers (Cursor, OpenCode, …) reject SourceMode::Cli. The shell
+    // historically mapped "manual + no cookie" to Cli, which surfaces as
+    // "Source mode 'Cli' not supported". Remap to Web and try browser cookies
+    // unless the user explicitly disabled cookies ("off").
+    if source_mode == SourceMode::Cli
+        && cookie_source != "off"
+        && !instantiate_provider(id).supports_cli()
+    {
+        if cookie_header
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(|s| s.is_empty())
+        {
+            cookie_header = provider_cookie_domain(id, settings).and_then(|domain| {
+                codexbar::browser::cookies::get_cookie_header(domain)
+                    .ok()
+                    .filter(|h| !h.is_empty())
+            });
+        }
+        source_mode = SourceMode::Web;
+    }
 
     let workspace_id = settings.workspace_id(id).trim().to_string();
     let api_region = settings.api_region(id).trim().to_string();

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -293,8 +293,47 @@ fn fetch_context_defaults_to_manual_cookies_without_browser_import() {
         &token_accounts,
     );
 
+    // Cursor does not support Cli; empty manual cookie remaps to Web (browser attempt).
+    assert_eq!(ctx.source_mode, SourceMode::Web);
+}
+
+#[test]
+fn fetch_context_cursor_cookie_off_stays_cli() {
+    let mut settings = Settings::default();
+    settings.set_cookie_source(ProviderId::Cursor, "off");
+    let cookies = ManualCookies::default();
+    let api_keys = ApiKeys::default();
+    let token_accounts = HashMap::new();
+
+    let ctx = super::build_fetch_context(
+        ProviderId::Cursor,
+        &settings,
+        &cookies,
+        &api_keys,
+        &token_accounts,
+    );
+
+    // Explicit cookie-off keeps Cli (no browser scrape).
     assert_eq!(ctx.source_mode, SourceMode::Cli);
     assert!(ctx.manual_cookie_header.is_none());
+}
+
+#[test]
+fn fetch_context_opencode_empty_manual_remaps_to_web() {
+    let settings = Settings::default();
+    let cookies = ManualCookies::default();
+    let api_keys = ApiKeys::default();
+    let token_accounts = HashMap::new();
+
+    let ctx = super::build_fetch_context(
+        ProviderId::OpenCode,
+        &settings,
+        &cookies,
+        &api_keys,
+        &token_accounts,
+    );
+
+    assert_eq!(ctx.source_mode, SourceMode::Web);
 }
 
 #[test]

--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -362,12 +362,16 @@ impl ClaudeOAuthFetcher {
 
         let mut usage = UsageSnapshot::new(primary);
 
-        // Secondary: 7-day window
-        if let Some(weekly) = response
-            .seven_day
-            .as_ref()
-            .and_then(|w| Self::to_rate_window(w, Some(10080)))
-        {
+        // Secondary: prefer limits[] weekly_all over legacy seven_day (avoids
+        // phantom 100% when Anthropic leaves seven_day.utilization stale).
+        if let Some(weekly) = super::scoped_weekly::weekly_all_window(&response.limits).or_else(
+            || {
+                response
+                    .seven_day
+                    .as_ref()
+                    .and_then(|w| Self::to_rate_window(w, Some(10080)))
+            },
+        ) {
             usage = usage.with_secondary(weekly);
         }
 
@@ -386,26 +390,18 @@ impl ClaudeOAuthFetcher {
             usage = usage.with_model_specific(sonnet);
         }
 
-        let extra_windows = [(
-            "claude-routines",
-            "Daily Routines",
-            response
-                .seven_day_routines
-                .as_ref()
-                .and_then(|w| Self::to_rate_window(w, Some(10080))),
-        )];
-        for (id, title, window) in extra_windows {
-            if let Some(window) = window {
-                usage
-                    .extra_rate_windows
-                    .push(NamedRateWindow::new(id, title, window));
-            }
+        if let Some(window) = response
+            .seven_day_routines
+            .as_ref()
+            .and_then(|w| Self::to_rate_window(w, Some(10080)))
+        {
             usage
                 .extra_rate_windows
-                .extend(super::scoped_weekly::scoped_weekly_windows(
-                    &response.limits,
-                ));
+                .push(NamedRateWindow::new("claude-routines", "Daily Routines", window));
         }
+        usage
+            .extra_rate_windows
+            .extend(super::scoped_weekly::scoped_weekly_windows(&response.limits));
 
         // Login method from rate limit tier or default
         if let Some(ref tier) = credentials.rate_limit_tier {
@@ -538,6 +534,53 @@ mod tests {
             .expect("Fable scoped weekly limit");
         assert_eq!(scoped.title, "Fable only");
         assert_eq!(scoped.window.used_percent, 7.0);
+    }
+
+    #[test]
+    fn weekly_all_limit_wins_over_stale_seven_day_utilization() {
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": 8.0, "resets_at": "2026-07-20T04:29:59Z"},
+                "seven_day": {"utilization": 1.0, "resets_at": "2026-07-26T22:59:59Z"},
+                "limits": [
+                    {
+                        "kind": "weekly_all",
+                        "group": "weekly",
+                        "percent": 1,
+                        "resets_at": "2026-07-26T22:59:59Z"
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "group": "weekly",
+                        "percent": 2,
+                        "resets_at": "2026-07-26T22:59:59Z",
+                        "scope": {"model": {"display_name": "Fable"}}
+                    }
+                ]
+            }"#,
+        )
+        .expect("oauth body with weekly_all");
+
+        let credentials = ClaudeOAuthCredentials {
+            access_token: "token".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            scopes: vec![],
+            rate_limit_tier: Some("default_claude_max_5x".to_string()),
+        };
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &credentials);
+
+        assert!((usage.primary.used_percent - 8.0).abs() < f64::EPSILON);
+        // seven_day.utilization 1.0 would normalize to 100%; weekly_all wins.
+        assert!((usage.secondary.expect("weekly").used_percent - 1.0).abs() < f64::EPSILON);
+        assert_eq!(
+            usage
+                .extra_rate_windows
+                .iter()
+                .filter(|w| w.id.starts_with("claude-weekly-scoped-"))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/rust/src/providers/claude/scoped_weekly.rs
+++ b/rust/src/providers/claude/scoped_weekly.rs
@@ -54,11 +54,7 @@ pub(super) fn scoped_weekly_windows(limits: &[ScopedWeeklyLimit]) -> Vec<NamedRa
             if slug.is_empty() || !seen.insert(slug.clone()) {
                 return None;
             }
-            let resets_at = limit
-                .resets_at
-                .as_deref()
-                .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
-                .map(|value| value.with_timezone(&Utc));
+            let resets_at = limit_resets_at(limit);
             Some(NamedRateWindow::new(
                 format!("claude-weekly-scoped-{slug}"),
                 format!("{title} only"),
@@ -66,6 +62,38 @@ pub(super) fn scoped_weekly_windows(limits: &[ScopedWeeklyLimit]) -> Vec<NamedRa
             ))
         })
         .collect()
+}
+
+/// All-models weekly window from `limits[]` (`kind == "weekly_all"`).
+///
+/// Prefer this over legacy `seven_day.utilization` when Anthropic migrates
+/// weekly totals into the limits array (avoids phantom 100% from stale fields).
+pub(super) fn weekly_all_window(limits: &[ScopedWeeklyLimit]) -> Option<RateWindow> {
+    limits.iter().find_map(|limit| {
+        let kind = limit.kind.as_deref()?;
+        if !matches!(kind, "weekly_all" | "all_models" | "weekly_models") {
+            return None;
+        }
+        if limit.group.as_deref().is_some_and(|g| g != "weekly") {
+            return None;
+        }
+        let percent = limit.percent.filter(|value| value.is_finite())?;
+        let resets_at = limit_resets_at(limit);
+        Some(RateWindow::with_details(
+            percent.clamp(0.0, 100.0),
+            Some(7 * 24 * 60),
+            resets_at,
+            None,
+        ))
+    })
+}
+
+fn limit_resets_at(limit: &ScopedWeeklyLimit) -> Option<DateTime<Utc>> {
+    limit
+        .resets_at
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
 }
 
 #[cfg(test)]
@@ -101,5 +129,25 @@ mod tests {
         .unwrap();
 
         assert!(scoped_weekly_windows(&limits).is_empty());
+    }
+
+    #[test]
+    fn weekly_all_prefers_limits_percent_over_stale_seven_day() {
+        let limits: Vec<ScopedWeeklyLimit> = serde_json::from_str(
+            r#"[
+                {"kind":"weekly_all","group":"weekly","percent":1,"resets_at":"2026-07-26T22:59:59Z"},
+                {"kind":"weekly_scoped","group":"weekly","percent":2,"scope":{"model":{"display_name":"Fable"}}}
+            ]"#,
+        )
+        .unwrap();
+
+        let weekly = weekly_all_window(&limits).expect("weekly_all");
+        assert!((weekly.used_percent - 1.0).abs() < f64::EPSILON);
+        assert_eq!(weekly.window_minutes, Some(7 * 24 * 60));
+        assert!(weekly.resets_at.is_some());
+
+        let scoped = scoped_weekly_windows(&limits);
+        assert_eq!(scoped.len(), 1);
+        assert!((scoped[0].window.used_percent - 2.0).abs() < f64::EPSILON);
     }
 }

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -319,10 +319,13 @@ impl ClaudeWebApiFetcher {
             .map(|w| self.to_rate_window(w, Some(300))) // 5 hours = 300 minutes
             .unwrap_or_else(synthetic_no_session_primary);
 
-        let secondary = usage
-            .seven_day
-            .as_ref()
-            .map(|w| self.to_rate_window(w, Some(10080))); // 7 days = 10080 minutes
+        // Prefer limits[] weekly_all over legacy seven_day (same as OAuth path).
+        let secondary = super::scoped_weekly::weekly_all_window(&usage.limits).or_else(|| {
+            usage
+                .seven_day
+                .as_ref()
+                .map(|w| self.to_rate_window(w, Some(10080))) // 7 days = 10080 minutes
+        });
 
         let model_specific = usage
             .seven_day_opus
@@ -362,10 +365,10 @@ impl ClaudeWebApiFetcher {
                     .extra_rate_windows
                     .push(NamedRateWindow::new(id, title, window));
             }
-            snapshot
-                .extra_rate_windows
-                .extend(super::scoped_weekly::scoped_weekly_windows(&usage.limits));
         }
+        snapshot
+            .extra_rate_windows
+            .extend(super::scoped_weekly::scoped_weekly_windows(&usage.limits));
 
         if let Some(ref acc) = account {
             if let Some(ref email) = acc.email_address {

--- a/rust/src/providers/opencode/mod.rs
+++ b/rust/src/providers/opencode/mod.rs
@@ -187,10 +187,27 @@ impl OpenCodeProvider {
 
         // Fall back to regex-based parsing. Require at least one window —
         // plans may omit rolling or weekly without being unparseable.
-        let rolling = self.extract_usage_regex(text, "rollingUsage").ok();
-        let weekly = self.extract_usage_regex(text, "weeklyUsage").ok();
+        let rolling = self
+            .extract_usage_regex(text, "rollingUsage")
+            .or_else(|_| self.extract_usage_regex(text, "fiveHourUsage"))
+            .or_else(|_| self.extract_usage_regex(text, "sessionUsage"))
+            .ok();
+        let weekly = self
+            .extract_usage_regex(text, "weeklyUsage")
+            .or_else(|_| self.extract_usage_regex(text, "weekUsage"))
+            .or_else(|_| self.extract_usage_regex(text, "sevenDayUsage"))
+            .ok();
         self.snapshot_from_windows(rolling, weekly, now, self.extract_renewal_regex(text))
             .ok_or_else(|| {
+                let has_usage_hint = text.contains("usagePercent")
+                    || text.contains("usedPercent")
+                    || text.contains("rolling")
+                    || text.contains("weekly");
+                tracing::debug!(
+                    body_len = text.len(),
+                    has_usage_hint,
+                    "OpenCode subscription body missing rolling/weekly usage windows"
+                );
                 ProviderError::Parse("Missing usage percent (rolling or weekly)".into())
             })
     }
@@ -243,12 +260,45 @@ impl OpenCodeProvider {
 
     /// Parse usage from JSON response
     fn parse_usage_json(&self, json: &Value, now: DateTime<Utc>) -> Option<UsageSnapshot> {
-        let renews_at = self.find_datetime(json, &["renewAt", "renew_at"]);
+        // Prefer nested billing/subscription/data roots when present.
+        for root_key in ["data", "subscription", "billing", "result", "payload"] {
+            if let Some(nested) = json.get(root_key)
+                && let Some(snapshot) = self.parse_usage_json(nested, now)
+            {
+                return Some(snapshot);
+            }
+        }
 
-        let rolling =
-            self.find_usage_window(json, &["rollingUsage", "rolling", "rolling_usage"]);
-        let weekly =
-            self.find_usage_window(json, &["weeklyUsage", "weekly", "weekly_usage"]);
+        let renews_at = self.find_datetime(json, &["renewAt", "renew_at", "renewsAt"]);
+
+        let rolling = self.find_usage_window(
+            json,
+            &[
+                "rollingUsage",
+                "rolling",
+                "rolling_usage",
+                "fiveHourUsage",
+                "five_hour",
+                "fiveHour",
+                "sessionUsage",
+                "session",
+                "rateLimit5h",
+                "rate_limit_5h",
+            ],
+        );
+        let weekly = self.find_usage_window(
+            json,
+            &[
+                "weeklyUsage",
+                "weekly",
+                "weekly_usage",
+                "weekUsage",
+                "sevenDayUsage",
+                "seven_day",
+                "rateLimitWeekly",
+                "rate_limit_weekly",
+            ],
+        );
 
         self.snapshot_from_windows(rolling, weekly, now, renews_at)
     }
@@ -263,9 +313,16 @@ impl OpenCodeProvider {
             }
         }
 
-        // Try nested search
+        // Try nested search (depth-limited by recursion over objects only).
         if let Some(obj) = json.as_object() {
-            for (_, value) in obj {
+            for (child_key, value) in obj {
+                // Skip huge unrelated trees that often appear next to usage.
+                if matches!(
+                    child_key.as_str(),
+                    "history" | "invoices" | "members" | "logs" | "events"
+                ) {
+                    continue;
+                }
                 if let Some(window) = self.find_usage_window(value, keys) {
                     return Some(window);
                 }
@@ -277,6 +334,11 @@ impl OpenCodeProvider {
 
     /// Parse a usage window object
     fn parse_window(&self, obj: &Value) -> Option<(f64, i64)> {
+        // Bare number: treat as percent used (0–1 fractions scaled).
+        if let Some(n) = obj.as_f64() {
+            let percent = if n <= 1.0 { n * 100.0 } else { n };
+            return Some((percent.clamp(0.0, 100.0), 0));
+        }
         let percent = Self::window_percent(obj)?;
         let reset_sec = Self::window_reset_seconds(obj).unwrap_or(0);
         Some((percent.clamp(0.0, 100.0), reset_sec.max(0)))
@@ -288,12 +350,14 @@ impl OpenCodeProvider {
             "usedPercent",
             "percentUsed",
             "percent",
+            "pct",
             "usage_percent",
             "used_percent",
             "utilization",
             "utilizationPercent",
             "utilization_percent",
             "usage",
+            "value",
         ];
 
         Self::first_f64(obj, &percent_keys)
@@ -619,5 +683,40 @@ mod tests {
         let text = r#"weeklyUsage: { usagePercent: 55, resetInSec: 99 } not-json"#;
         let snap = provider.parse_subscription(text).expect("snapshot");
         assert!((snap.primary.used_percent - 55.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parses_nested_data_subscription_shape() {
+        let provider = OpenCodeProvider::new();
+        let now = DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+        let payload = serde_json::json!({
+            "data": {
+                "subscription": {
+                    "rollingUsage": { "usedPercent": 18.5, "resetInSeconds": 1200 },
+                    "weeklyUsage": { "percentUsed": 42, "resetsInSec": 86400 }
+                }
+            }
+        });
+        let snap = provider
+            .parse_usage_json(&payload, now)
+            .expect("nested snapshot");
+        assert!((snap.primary.used_percent - 18.5).abs() < f64::EPSILON);
+        assert!((snap.secondary.as_ref().unwrap().used_percent - 42.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parses_five_hour_and_week_aliases() {
+        let provider = OpenCodeProvider::new();
+        let now = DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+        let payload = serde_json::json!({
+            "fiveHourUsage": { "pct": 11, "resetInSec": 300 },
+            "weekUsage": { "value": 0.25, "resetInSec": 7200 }
+        });
+        let snap = provider
+            .parse_usage_json(&payload, now)
+            .expect("alias snapshot");
+        assert!((snap.primary.used_percent - 11.0).abs() < f64::EPSILON);
+        // 0.25 fraction scales to 25%
+        assert!((snap.secondary.as_ref().unwrap().used_percent - 25.0).abs() < f64::EPSILON);
     }
 }


### PR DESCRIPTION
## Summary
Fixes three 0.43.0 user reports with minimal root-cause changes:

- **#210 Claude weekly 100%**: prefer `limits[]` entry `kind: weekly_all` for the all-models secondary window over legacy `seven_day.utilization` (which can stick at `1.0` → 100%). Also stop double-appending scoped weekly extras.
- **#211 OpenCode parse**: widen JSON roots/keys (`data`/`subscription`/`billing`, `fiveHourUsage`/`weekUsage`, `usedPercent`/`pct`/`value`, etc.) and regex aliases so nested server-fn bodies still parse when only one window exists.
- **#212 Cursor Cli unsupported**: shell no longer leaves cookie-web providers on `SourceMode::Cli` when cookie-source is empty manual; remaps to **Web** and tries browser cookies. Explicit cookie-source `off` still stays Cli (no scrape). Factory cookie-off API path unchanged (`supports_cli`).

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --lib weekly_all`
- [x] `cargo test --manifest-path rust/Cargo.toml --lib opencode::tests`
- [x] `cargo test --manifest-path rust/Cargo.toml --lib claude::oauth::tests`
- [x] `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml fetch_context`
- [ ] Manual: Claude Max OAuth weekly matches claude.ai
- [ ] Manual: OpenCode with Firefox cookie import refreshes
- [ ] Manual: Cursor with default cookie settings (no pasted cookie) attempts browser path

Closes #210
Closes #211
Closes #212

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787188827&installation_model_id=427695&pr_number=213&repository=nesszer%2FWin-CodexBar&return_to=https%3A%2F%2Fgithub.com%2Fnesszer%2FWin-CodexBar%2Fpull%2F213&signature=2aa070b51ce6d355035b1f18f0afd81bd4944e6e279082ea6bec0822b8235ca9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->