### PR TITLE
fix: harden Cursor Cli + issue 210-212 end-to-end proofs

### DIFF
--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -584,6 +584,70 @@ mod tests {
     }
 
     #[test]
+    fn issue_210_reporter_shape_secondary_is_one_percent_not_one_hundred() {
+        // Mirrors the reporter JSON: session 8%, fable 2%, all-models should be 1%
+        // while seven_day.utilization is the stale 1.0 (would display as 100%).
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {
+                    "utilization": 8.0,
+                    "resets_at": "2026-07-20T04:29:59.671218Z"
+                },
+                "seven_day": {
+                    "utilization": 1.0,
+                    "resets_at": "2026-07-26T22:59:59.671246Z"
+                },
+                "limits": [
+                    {
+                        "kind": "weekly_all",
+                        "group": "weekly",
+                        "percent": 1.0,
+                        "resets_at": "2026-07-26T22:59:59.671595Z"
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "group": "weekly",
+                        "percent": 2.0,
+                        "resets_at": "2026-07-26T22:59:59.671595Z",
+                        "scope": {
+                            "model": {
+                                "id": "claude-fable",
+                                "display_name": "Fable"
+                            }
+                        }
+                    }
+                ]
+            }"#,
+        )
+        .expect("issue 210 body");
+
+        let credentials = ClaudeOAuthCredentials {
+            access_token: "token".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            scopes: vec![],
+            rate_limit_tier: Some("default_claude_max_5x".to_string()),
+        };
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &credentials);
+
+        assert_eq!(usage.login_method.as_deref(), Some("Claude Max 5x"));
+        assert!((usage.primary.used_percent - 8.0).abs() < f64::EPSILON);
+        let weekly = usage.secondary.expect("secondary weekly");
+        assert!(
+            (weekly.used_percent - 1.0).abs() < f64::EPSILON,
+            "secondary was {}, expected 1% (not 100%)",
+            weekly.used_percent
+        );
+        assert!((weekly.used_percent - 100.0).abs() > 1.0);
+        let fable = usage
+            .extra_rate_windows
+            .iter()
+            .find(|w| w.title.contains("Fable"))
+            .expect("Fable only window");
+        assert!((fable.window.used_percent - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
     fn parses_retry_after_seconds() {
         let header = HeaderValue::from_static("17");
         let duration = ClaudeOAuthFetcher::retry_after_duration(Some(&header));

--- a/rust/src/providers/cursor/mod.rs
+++ b/rust/src/providers/cursor/mod.rs
@@ -43,10 +43,13 @@ impl CursorProvider {
         ctx: &FetchContext,
     ) -> Result<api::CursorUsageResult, ProviderError> {
         match ctx.source_mode {
-            SourceMode::Auto | SourceMode::Web => self.fetch_web_usage_parts(ctx).await,
-            SourceMode::Cli | SourceMode::OAuth => {
-                Err(ProviderError::UnsupportedSource(ctx.source_mode))
+            // Cli is only ever set by the shell for "no cookie yet"; treat it as
+            // web so empty-manual users get browser cookie attempt (or AuthRequired)
+            // instead of "Source mode 'Cli' not supported" (#212).
+            SourceMode::Auto | SourceMode::Web | SourceMode::Cli => {
+                self.fetch_web_usage_parts(ctx).await
             }
+            SourceMode::OAuth => Err(ProviderError::UnsupportedSource(ctx.source_mode)),
         }
     }
 
@@ -136,5 +139,48 @@ impl Provider for CursorProvider {
 
     fn supports_web(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::FetchContext;
+
+    #[tokio::test]
+    async fn cli_mode_does_not_return_unsupported_source() {
+        let provider = CursorProvider::new();
+        let ctx = FetchContext {
+            source_mode: SourceMode::Cli,
+            manual_cookie_header: None,
+            ..FetchContext::default()
+        };
+        let err = provider
+            .fetch_usage(&ctx)
+            .await
+            .expect_err("no cookies on this machine");
+        // Must not be UnsupportedSource — that was the user-visible #212 bug.
+        assert!(
+            !matches!(err, ProviderError::UnsupportedSource(_)),
+            "unexpected UnsupportedSource: {err}"
+        );
+        assert!(
+            matches!(
+                err,
+                ProviderError::NoCookies | ProviderError::AuthRequired | ProviderError::Other(_)
+            ),
+            "expected cookie/auth style error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_mode_still_unsupported() {
+        let provider = CursorProvider::new();
+        let ctx = FetchContext {
+            source_mode: SourceMode::OAuth,
+            ..FetchContext::default()
+        };
+        let err = provider.fetch_usage(&ctx).await.expect_err("oauth unsupported");
+        assert!(matches!(err, ProviderError::UnsupportedSource(SourceMode::OAuth)));
     }
 }

--- a/rust/src/providers/opencode/mod.rs
+++ b/rust/src/providers/opencode/mod.rs
@@ -719,4 +719,50 @@ mod tests {
         // 0.25 fraction scales to 25%
         assert!((snap.secondary.as_ref().unwrap().used_percent - 25.0).abs() < f64::EPSILON);
     }
+
+    #[test]
+    fn parse_subscription_accepts_realistic_server_fn_body() {
+        let provider = OpenCodeProvider::new();
+        // Shape closer to a live server-fn payload: nested under result/data.
+        let body = r#"{
+          "result": {
+            "data": {
+              "rollingUsage": { "usagePercent": 33.0, "resetInSec": 1800 },
+              "weeklyUsage": { "usagePercent": 12.5, "resetInSec": 604800 },
+              "renewAt": "2026-08-01T00:00:00Z"
+            }
+          }
+        }"#;
+        let snap = provider
+            .parse_subscription(body)
+            .expect("server-fn body should parse end-to-end");
+        assert!((snap.primary.used_percent - 33.0).abs() < f64::EPSILON);
+        assert!((snap.secondary.as_ref().unwrap().used_percent - 12.5).abs() < f64::EPSILON);
+        assert_eq!(snap.login_method.as_deref(), Some("OpenCode"));
+    }
+
+    #[tokio::test]
+    async fn web_mode_without_cookies_is_auth_not_unsupported() {
+        let provider = OpenCodeProvider::new();
+        let ctx = FetchContext {
+            source_mode: SourceMode::Web,
+            manual_cookie_header: None,
+            ..FetchContext::default()
+        };
+        let err = provider
+            .fetch_usage(&ctx)
+            .await
+            .expect_err("no cookies available");
+        assert!(
+            !matches!(err, ProviderError::UnsupportedSource(_)),
+            "got UnsupportedSource: {err}"
+        );
+        assert!(
+            matches!(
+                err,
+                ProviderError::AuthRequired | ProviderError::NoCookies | ProviderError::Other(_)
+            ),
+            "got: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Follow-up after #213 verification with real provider paths (not just tiny helpers):

- **Cursor (#212):** `SourceMode::Cli` now uses the same web/cookie path as Auto/Web so even CLI/`FetchContext` Cli can never surface UnsupportedSource again.
- **Proofs:** reporter-shaped Claude OAuth body (session 8% / weekly_all 1% / Fable 2%), OpenCode nested server-fn parse, live `fetch_usage` async checks for Cursor Cli and OpenCode Web without cookies.

## Live check on this machine
`codexbar 0.43.0` release CLI built from main — no local Claude OAuth / Cursor / OpenCode cookies, so live usage correctly returns auth/no-cookies (not wrong UnsupportedSource / not phantom 100% parse).

## Test plan
- [x] Full `providers::claude` (51)
- [x] Full `providers::opencode` (20)
- [x] Full `providers::cursor` (9)
- [x] Desktop `fetch_context` (14)
- [x] New issue_210 / cli_mode / server_fn / web_mode proofs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787189632&installation_model_id=427695&pr_number=214&repository=nesszer%2FWin-CodexBar&return_to=https%3A%2F%2Fgithub.com%2Fnesszer%2FWin-CodexBar%2Fpull%2F214&signature=08caf96fcf32830b15c14911783dc648d3f608bf347622d032867a18fac1a7f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->