### PR TITLE
fix(opencode): sub-1% usage units (port 0.45.2 #2331)

### DIFF
--- a/rust/src/providers/opencode/mod.rs
+++ b/rust/src/providers/opencode/mod.rs
@@ -345,7 +345,10 @@ impl OpenCodeProvider {
     }
 
     fn window_percent(obj: &Value) -> Option<f64> {
-        let percent_keys = [
+        // Direct percent fields may arrive as 0..1 fractions or 0..100 percents.
+        // Upstream #2331: only apply the *100 heuristic to *direct* fields — never to
+        // a computed used/limit ratio (already 0..100; e.g. used=1, limit=100 → 1.0).
+        const DIRECT_PERCENT_KEYS: &[&str] = &[
             "usagePercent",
             "usedPercent",
             "percentUsed",
@@ -356,25 +359,35 @@ impl OpenCodeProvider {
             "utilization",
             "utilizationPercent",
             "utilization_percent",
-            "usage",
             "value",
         ];
 
-        Self::first_f64(obj, &percent_keys)
-            .map(|val| if val <= 1.0 { val * 100.0 } else { val })
-            .or_else(|| Self::percent_from_used_limit(obj))
+        if let Some(val) = Self::first_f64(obj, DIRECT_PERCENT_KEYS) {
+            let scaled = if (0.0..=1.0).contains(&val) {
+                val * 100.0
+            } else {
+                val
+            };
+            return Some(scaled);
+        }
+        Self::percent_from_used_limit(obj)
     }
 
     fn percent_from_used_limit(obj: &Value) -> Option<f64> {
         let used = obj
             .get("used")
             .or(obj.get("usage"))
+            .or(obj.get("consumed"))
+            .or(obj.get("count"))
+            .or(obj.get("usedTokens"))
             .and_then(|v| v.as_f64());
         let limit = obj
             .get("limit")
             .or(obj.get("total"))
+            .or(obj.get("allowance"))
             .and_then(|v| v.as_f64());
         match (used, limit) {
+            // Already 0..100 — do not run the direct-fraction *100 heuristic.
             (Some(used), Some(limit)) if limit > 0.0 => Some((used / limit) * 100.0),
             _ => None,
         }
@@ -718,6 +731,39 @@ mod tests {
         assert!((snap.primary.used_percent - 11.0).abs() < f64::EPSILON);
         // 0.25 fraction scales to 25%
         assert!((snap.secondary.as_ref().unwrap().used_percent - 25.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn sub_one_percent_computed_used_limit_is_not_rescaled_to_100() {
+        // Upstream #2331: used=1, limit=100 → 1%, not 100% (false exhausted).
+        let provider = OpenCodeProvider::new();
+        let now = DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+        let payload = serde_json::json!({
+            "rollingUsage": { "used": 1, "limit": 100, "resetInSec": 600 },
+            "weeklyUsage": { "used": 1, "limit": 200, "resetInSec": 86400 }
+        });
+        let snap = provider.parse_usage_json(&payload, now).expect("snapshot");
+        assert!(
+            (snap.primary.used_percent - 1.0).abs() < 0.001,
+            "primary {}",
+            snap.primary.used_percent
+        );
+        assert!(
+            (snap.secondary.as_ref().unwrap().used_percent - 0.5).abs() < 0.001,
+            "secondary {}",
+            snap.secondary.as_ref().unwrap().used_percent
+        );
+    }
+
+    #[test]
+    fn direct_fractional_usage_percent_still_scales() {
+        let provider = OpenCodeProvider::new();
+        let now = DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+        let payload = serde_json::json!({
+            "rollingUsage": { "usagePercent": 0.25, "resetInSec": 600 }
+        });
+        let snap = provider.parse_usage_json(&payload, now).expect("snapshot");
+        assert!((snap.primary.used_percent - 25.0).abs() < 0.001);
     }
 
     #[test]

--- a/rust/src/providers/opencode/scraper.rs
+++ b/rust/src/providers/opencode/scraper.rs
@@ -29,7 +29,7 @@ const PERCENT_KEYS: &[&str] = &[
     "utilization",
     "utilizationPercent",
     "utilization_percent",
-    "usage",
+    // Note: raw "usage" is often a token count — handled via used/limit only.
 ];
 
 /// Keys to look for when parsing reset time in seconds
@@ -470,25 +470,37 @@ impl OpenCodeUsageFetcher {
 
     /// Parse a window object into (percent, reset_in_sec)
     fn parse_window(json: &serde_json::Value, _now: DateTime<Utc>) -> Option<(f64, i64)> {
-        let percent = PERCENT_KEYS
+        // Direct percent field (may be 0..1 fraction or 0..100).
+        let direct = PERCENT_KEYS
             .iter()
             .find_map(|k| json.get(k).and_then(|v| v.as_f64()));
+        let percent_is_direct = direct.is_some();
+
+        let percent = direct.or_else(|| {
+            // Computed used/limit is already 0..100 — never apply fraction rescale (#2331).
+            let used = ["used", "usage", "consumed", "count", "usedTokens"]
+                .iter()
+                .find_map(|k| json.get(*k).and_then(|v| v.as_f64()));
+            let limit = ["limit", "total", "allowance"]
+                .iter()
+                .find_map(|k| json.get(*k).and_then(|v| v.as_f64()));
+            match (used, limit) {
+                (Some(u), Some(l)) if l > 0.0 => Some((u / l) * 100.0),
+                _ => None,
+            }
+        })?;
 
         let reset_in = RESET_IN_KEYS
             .iter()
-            .find_map(|k| json.get(k).and_then(|v| v.as_i64()));
+            .find_map(|k| json.get(k).and_then(|v| v.as_i64()))
+            .unwrap_or(0);
 
-        match (percent, reset_in) {
-            (Some(p), Some(r)) => {
-                let normalized_percent = if (0.0..=1.0).contains(&p) {
-                    p * 100.0
-                } else {
-                    p.clamp(0.0, 100.0)
-                };
-                Some((normalized_percent, r.max(0)))
-            }
-            _ => None,
-        }
+        let normalized_percent = if percent_is_direct && (0.0..=1.0).contains(&percent) {
+            percent * 100.0
+        } else {
+            percent.clamp(0.0, 100.0)
+        };
+        Some((normalized_percent.clamp(0.0, 100.0), reset_in.max(0)))
     }
 
     fn find_datetime(json: &serde_json::Value, keys: &[&str]) -> Option<DateTime<Utc>> {

--- a/rust/src/providers/opencodego/mod.rs
+++ b/rust/src/providers/opencodego/mod.rs
@@ -190,8 +190,33 @@ impl OpenCodeGoProvider {
                 let reset = Self::extract_number(&reset_pattern, text)
                     .map(|n| n as i64)
                     .unwrap_or(0);
-                let p = if p <= 1.0 { p * 100.0 } else { p };
+                // Regex path only matches direct percent field names — fraction
+                // heuristic is safe here (upstream #2331). used/limit computed
+                // percents must not use this path without a separate gate.
+                let p = if (0.0..=1.0).contains(&p) { p * 100.0 } else { p };
                 return Some((p.clamp(0.0, 100.0), reset.max(0)));
+            }
+
+            // Computed used/limit (already 0..100) — do not apply fraction *100.
+            let used_pattern = format!(
+                r#"{}[^}}]*?(?:used|usage|consumed)\s*[:=]\s*([0-9]+(?:\.[0-9]+)?)"#,
+                name
+            );
+            let limit_pattern = format!(
+                r#"{}[^}}]*?(?:limit|total|allowance)\s*[:=]\s*([0-9]+(?:\.[0-9]+)?)"#,
+                name
+            );
+            if let (Some(used), Some(limit)) = (
+                Self::extract_number(&used_pattern, text),
+                Self::extract_number(&limit_pattern, text),
+            ) {
+                if limit > 0.0 {
+                    let reset = Self::extract_number(&reset_pattern, text)
+                        .map(|n| n as i64)
+                        .unwrap_or(0);
+                    let p = (used / limit) * 100.0;
+                    return Some((p.clamp(0.0, 100.0), reset.max(0)));
+                }
             }
         }
         None
@@ -430,6 +455,17 @@ mod tests {
     }
 
     #[test]
+    fn sub_one_percent_computed_used_limit_is_not_rescaled() {
+        let text = r#"
+            rollingUsage: { used: 1, limit: 100, resetInSec: 600 }
+            weeklyUsage: { used: 1, limit: 200, resetInSec: 86400 }
+        "#;
+        let snap = OpenCodeGoProvider::parse_usage_text(text).unwrap();
+        assert!((snap.primary.used_percent - 1.0).abs() < 0.001);
+        assert!((snap.secondary.as_ref().unwrap().used_percent - 0.5).abs() < 0.001);
+    }
+
+    #[test]
     fn parses_usage_blocks() {
         let text = r#"
             rollingUsage: { usagePercent: 42.5, resetInSec: 3600 }
@@ -439,7 +475,7 @@ mod tests {
         let snap = OpenCodeGoProvider::parse_usage_text(text).unwrap();
         assert!((snap.primary.used_percent - 42.5).abs() < 0.001);
         let secondary = snap.secondary.expect("weekly");
-        // 0.13 normalized as fraction → 13%
+        // usagePercent: 0.13 is a direct fraction → 13%
         assert!((secondary.used_percent - 13.0).abs() < 0.001);
         let tertiary = snap.tertiary.expect("monthly");
         assert!((tertiary.used_percent - 7.0).abs() < 0.001);


### PR DESCRIPTION
## Summary
First PR of the **0.43 → 0.45.2** Windows port stack.

Ports upstream CodexBar **#2331** / v0.45.2: OpenCode and OpenCode Go must not treat a **computed** used/limit percent (already 0…100) with the direct-field fraction heuristic (`<= 1 → *100`). That turned real **1%** usage into **100%** (false exhausted).

- Direct fields (`usagePercent`, etc.) may still be 0…1 fractions → scale to percent
- `used`/`limit` (and aliases) stay as `(used/limit)*100` with **no** second scale
- Drop raw `"usage"` as a percent key in the scraper (token counts)

## Audits (read-only upstream)
- `%TEMP%\port-045\audit-backend.md`
- `%TEMP%\port-045\audit-ui.md`
- `%TEMP%\port-045\audit-skip.md`

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --lib providers::opencode`
- [x] `cargo test --manifest-path rust/Cargo.toml --lib providers::opencodego`
- [x] New fixtures: used=1/limit=100 → 1%; used=1/limit=200 → 0.5%; direct 0.25 → 25%

No version bump / packaging (port stack continues).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787190530&installation_model_id=427695&pr_number=215&repository=nesszer%2FWin-CodexBar&return_to=https%3A%2F%2Fgithub.com%2Fnesszer%2FWin-CodexBar%2Fpull%2F215&signature=488ba3f179ea3b51468e4b6098592f826ae27f389e4bb9f63285d856461cc217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->