### PR TITLE
fix(cursor): clamp plan usage at 100% (0.45 port #2255)

### DIFF
--- a/rust/src/providers/cursor/api.rs
+++ b/rust/src/providers/cursor/api.rs
@@ -143,21 +143,23 @@ impl CursorApi {
                         .or_else(|| plan.breakdown.as_ref().and_then(|b| b.total))
                         .unwrap_or(0) as f64;
 
+                    // Upstream #2255: clamp plan usage at 100% when included usage
+                    // exceeds the plan limit (overage must not paint >100% bars).
                     let percent = if let Some(percent) = plan.total_percent_used {
-                        percent
+                        clamp_percent(percent)
                     } else if limit_cents > 0.0 {
-                        (used_cents / limit_cents) * 100.0
+                        clamp_percent((used_cents / limit_cents) * 100.0)
                     } else {
                         0.0
                     };
 
-                    let secondary = plan
-                        .auto_percent_used
-                        .map(|v| RateWindow::with_details(v, None, billing_end, None));
+                    let secondary = plan.auto_percent_used.map(|v| {
+                        RateWindow::with_details(clamp_percent(v), None, billing_end, None)
+                    });
 
-                    let model_specific = plan
-                        .api_percent_used
-                        .map(|v| RateWindow::with_details(v, None, billing_end, None));
+                    let model_specific = plan.api_percent_used.map(|v| {
+                        RateWindow::with_details(clamp_percent(v), None, billing_end, None)
+                    });
 
                     let cost = Self::on_demand_cost(individual.on_demand.as_ref(), billing_end)
                         .or_else(|| {
@@ -264,8 +266,15 @@ impl CursorApi {
                     .map(|remaining| remaining + usage.used.unwrap_or(0))
             })
             .unwrap_or(0) as f64;
-        (limit > 0.0).then_some(used / limit * 100.0)
+        (limit > 0.0).then_some(clamp_percent(used / limit * 100.0))
     }
+}
+
+fn clamp_percent(value: f64) -> f64 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    value.clamp(0.0, 100.0)
 }
 
 impl Default for CursorApi {
@@ -414,6 +423,29 @@ mod tests {
 
         assert!(cost.is_some());
         assert_eq!(plan_type.as_deref(), Some("Cursor Pro"));
+    }
+
+    #[test]
+    fn clamps_plan_usage_percent_at_100_when_over_limit() {
+        // Upstream #2255: included usage past limit must not paint >100%.
+        let json = r#"{
+            "membershipType": "pro",
+            "individualUsage": {
+                "plan": {
+                    "used": 6000,
+                    "limit": 5000,
+                    "totalPercentUsed": 120.0,
+                    "autoPercentUsed": 110.0,
+                    "apiPercentUsed": 105.0
+                }
+            }
+        }"#;
+        let summary = parse_summary(json);
+        let (primary, secondary, model_specific, _, _, _) =
+            api().build_result(summary, None).unwrap();
+        assert!((primary.used_percent - 100.0).abs() < 0.01);
+        assert!((secondary.unwrap().used_percent - 100.0).abs() < 0.01);
+        assert!((model_specific.unwrap().used_percent - 100.0).abs() < 0.01);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Port stack **PR C** (upstream 0.45.0 #2255).

Clamp Cursor plan / auto / API usage percentages at **100%** when included usage exceeds the plan limit so the tray never paints >100% overage as a super-full bar.

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --lib providers::cursor`
- [x] Fixture: total/auto/api percents 120/110/105 → all 100

No packaging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787190848&installation_model_id=427695&pr_number=217&repository=nesszer%2FWin-CodexBar&return_to=https%3A%2F%2Fgithub.com%2Fnesszer%2FWin-CodexBar%2Fpull%2F217&signature=7dd7db4fa36a93acc4b1fc907bd8d5a8d46e8e959284ad25500eb8be09eed1b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->