### PR TITLE
Fix cargo cache paths and trim unused Rust std targets in PR check

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -16,10 +16,8 @@ Exact commands run, in order:
 
 ```powershell
 cargo fmt --all --check
-cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
-cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings
-cargo test --manifest-path rust/Cargo.toml
-cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
 pnpm --dir apps/desktop-tauri test
 pnpm --dir apps/desktop-tauri run build
 ```

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Remove unused preinstalled Rust targets
+        run: rustup target remove x86_64-pc-windows-gnu i686-pc-windows-msvc
+        continue-on-error: true
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -41,9 +45,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: |
-            rust
-            apps/desktop-tauri/src-tauri
+          workspaces: .
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -65,17 +65,11 @@ jobs:
       - name: Rust format check
         run: cargo fmt --all --check
 
-      - name: Shared Rust clippy
-        run: cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
+      - name: Rust clippy (workspace)
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: Tauri Rust clippy
-        run: cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings
-
-      - name: Shared Rust tests
-        run: cargo test --manifest-path rust/Cargo.toml
-
-      - name: Tauri Rust tests
-        run: cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml
+      - name: Rust tests (workspace)
+        run: cargo test --workspace
 
       - name: Frontend tests
         run: pnpm --dir apps/desktop-tauri test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The runner image preinstalls these std targets; dropping them before the
+      # stable sync avoids re-downloading rust-std for targets CI never builds.
       - name: Remove unused preinstalled Rust targets
         run: rustup target remove x86_64-pc-windows-gnu i686-pc-windows-msvc
         continue-on-error: true
@@ -44,8 +46,6 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: .
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
The `Cache cargo` step never cached build artifacts. The repo is a single cargo workspace rooted at the repo root, so all builds write to the root `target/` directory, but `Swatinem/rust-cache` was configured with `workspaces: rust` and `apps/desktop-tauri/src-tauri`, so it cached `rust/target` and `apps/desktop-tauri/src-tauri/target`, paths cargo never writes. Every run reported a "full match" cache hit (only ~131 MB of `~/.cargo` registry) and then cold-compiled ~280 dependency crates across the clippy/test steps, which is roughly 85% of job wall time.

```yaml
- name: Cache cargo
  uses: Swatinem/rust-cache@v2
  with:
    workspaces: .
```

With the root workspace cached, warm runs should only recompile the two workspace crates. Note the first run on this branch is a cold build that seeds the new cache.

Two further cleanups:

- A pre-step removes the image-preinstalled `x86_64-pc-windows-gnu` and `i686-pc-windows-msvc` std targets before `dtolnay/rust-toolchain` syncs stable. CI only builds `x86_64-pc-windows-msvc`, and those extra targets forced rustup to download 2 of 7 components for nothing on every run (the toolchain sync ranged from 11s to 174s across sampled runs). The step is `continue-on-error` so a missing target on a future image can never fail the gate.
- The four per-manifest cargo invocations (2x clippy, 2x test) are consolidated into `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace`, which cover the same two member crates with less per-invocation overhead. `scripts/local-check.ps1` intentionally keeps per-manifest commands because its `-Rust` / `-Tauri` / `-Clippy` flags exist for selective local runs; the hosted gate always runs everything, so coverage is unchanged.

Evidence from Blacksmith job logs: runs 90467427438 (250s) and 90464342160 (629s) both hit cache key `v0-rust-pr-check-Windows_NT-x64-8af1e26a-9cf9292a` with "full match: true" yet recompiled identical crate counts (280/298/247/210 Compiling/Checking lines per step).