### PR TITLE
Fix FloatBar DPI-aware content sizing

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
@@ -447,8 +447,11 @@ pub fn resize(
     height: f64,
     click_through: bool,
 ) -> Result<(), String> {
+    let width = width.ceil().clamp(1.0, u32::MAX as f64) as u32;
+    let height = height.ceil().clamp(1.0, u32::MAX as f64) as u32;
+
     window
-        .set_size(LogicalSize::new(width, height))
+        .set_size(PhysicalSize::new(width, height))
         .map_err(|e| e.to_string())?;
     apply_no_activate(window);
     apply_click_through(window, click_through);

--- a/apps/desktop-tauri/src/floatbar/FloatBar.css
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.css
@@ -22,6 +22,7 @@ body.floatbar-window #root {
  * group reads like a compact widget sitting on the Windows taskbar. */
 .floatbar {
   display: inline-flex;
+  flex: none;
   align-items: center;
   justify-content: center;
   gap: calc(4px * var(--floatbar-scale, 1));

--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -358,6 +358,46 @@ describe("FloatBar", () => {
     });
   });
 
+  it("resizes the native window in physical pixels at the WebView DPI", async () => {
+    tauriMocks.getCachedProviders.mockResolvedValue([]);
+    tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
+    const originalDevicePixelRatio = window.devicePixelRatio;
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 1.5,
+    });
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 20,
+        top: 0,
+        right: 100,
+        bottom: 20,
+        left: 0,
+        toJSON: () => ({}),
+      });
+
+    try {
+      renderFloatBar(bootstrap());
+
+      await waitFor(() => {
+        expect(coreMocks.invoke).toHaveBeenCalledWith("resize_float_bar", {
+          width: 162,
+          height: 42,
+        });
+      });
+    } finally {
+      rectSpy.mockRestore();
+      Object.defineProperty(window, "devicePixelRatio", {
+        configurable: true,
+        value: originalDevicePixelRatio,
+      });
+    }
+  });
+
   it("uses the localized reset formatter in pill tooltips", async () => {
     const resetsAt = new Date(Date.now() + 3 * 60 * 60_000 + 42 * 60_000).toISOString();
     tauriMocks.getCachedProviders.mockResolvedValue([

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -381,8 +381,14 @@ export default function FloatBar({ state }: { state: BootstrapState }) {
       resizeRafRef.current = null;
       const rect = el.getBoundingClientRect();
       const padding = 8;
-      const w = Math.ceil(rect.width + padding);
-      const h = Math.ceil(rect.height + padding);
+      const dpr =
+        Number.isFinite(window.devicePixelRatio) && window.devicePixelRatio > 0
+          ? window.devicePixelRatio
+          : 1;
+      // DOM measurements are CSS pixels; the native command accepts physical
+      // pixels so the window remains correctly sized on scaled displays.
+      const w = Math.ceil(Math.ceil(rect.width + padding) * dpr);
+      const h = Math.ceil(Math.ceil(rect.height + padding) * dpr);
       const last = lastResizeRef.current;
       if (last && Math.abs(last.w - w) <= 1 && Math.abs(last.h - h) <= 1) return;
       lastResizeRef.current = { w, h };
@@ -409,6 +415,12 @@ export default function FloatBar({ state }: { state: BootstrapState }) {
     const observer = new ResizeObserver(resizeToContent);
     observer.observe(el);
     return () => observer.disconnect();
+  }, [resizeToContent]);
+
+  useEffect(() => {
+    // Re-measure after moving onto a monitor with a different scale factor.
+    window.addEventListener("resize", resizeToContent);
+    return () => window.removeEventListener("resize", resizeToContent);
   }, [resizeToContent]);
 
   useEffect(


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Related issue

Fixes #

## Affected areas

Check every area this PR changes or could affect:

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

Hosted PR check runs on Blacksmith Windows when `CI_BUDGET_MODE` is not `off` (see `.github/workflows/pr-check.yml` and `CONTEXT.md`). Still run the local slice and list commands/results below. If a check is not relevant, say why.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1`
- [ ] For full pre-release validation: `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>`
- [ ] For installer/release changes: `powershell.exe -File scripts\windows-release-build.ps1 -Ref <ref> -SmokeInstall`
- [ ] Thermo-nuclear code quality review completed before submitting: https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md
- [ ] Other:

## UI / tray proof

For UI, tray, settings, or visual behavior changes, use CUA Driver for visual proof. If CUA Driver cannot be used, explain why and attach equivalent manual proof.

- [ ] Not applicable
- [ ] CUA Driver visual proof attached
- [ ] CUA Driver could not be used; equivalent manual proof and explanation attached

## Notes for reviewers

Call out risky areas, follow-up work, or anything reviewers should focus on.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->