### PR TITLE
feat(codex): add Codex accounts panel in provider settings (PR 4/5)

### DIFF
--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -2446,6 +2446,44 @@ body:has(.tray-panel-reveal) {
   font-size: 0.82rem;
 }
 
+/* ── Codex multi-account (ADR 0003) ─────────────────────────────────── */
+
+.provider-detail-note {
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  color: var(--provider-status-ok, #4ade80);
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin-bottom: 12px;
+  font-size: 0.82rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.codex-accounts-list {
+  gap: 6px;
+}
+
+.codex-accounts-card {
+  padding: 8px 10px;
+}
+
+.codex-accounts-add {
+  margin-top: 8px;
+}
+
+.codex-usage {
+  font-size: 0.74rem;
+  font-weight: 500;
+  color: var(--provider-row-text-secondary);
+}
+
+.codex-usage--blocked {
+  color: var(--provider-status-error);
+}
+
 .provider-detail-pace__stage {
   font-size: 0.86rem;
   font-weight: 600;

--- a/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/ProviderDetailPane.tsx
@@ -30,6 +30,7 @@ import { ChartsSection } from "./sections/charts/ChartsSection";
 import { CookieSourceSection } from "./sections/CookieSourceSection";
 import { RegionSection } from "./sections/RegionSection";
 import { CodexUsageOptions } from "./sections/credentials/CodexUsageOptions";
+import { CodexAccountsSection } from "./sections/credentials/CodexAccountsSection";
 import { TokenAccountsPanel } from "../tokens/TokenAccountsPanel";
 import { ApiKeySection } from "./ApiKeySection";
 import { CookieSection } from "./CookieSection";
@@ -316,6 +317,7 @@ export function ProviderDetailPane({
       />
       <CredentialsDispatcher providerId={detail.id} t={t} />
       {detail.id === "codex" && <CodexUsageOptions t={t} />}
+      {detail.id === "codex" && <CodexAccountsSection t={t} />}
       <CredentialStorageSection
         status={credentialStatus}
         busy={busy}

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/credentials/CodexAccountsSection.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/credentials/CodexAccountsSection.test.tsx
@@ -1,0 +1,142 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  CodexAccount,
+  CodexAccountsStateBridge,
+  CodexAccountUsageSnapshot,
+  CodexSwitchResult,
+} from "../../../../../types/bridge";
+
+const tauriMocks = vi.hoisted(() => ({
+  getCodexAccountsState: vi.fn(),
+  codexAccountAdd: vi.fn(),
+  codexAccountFetch: vi.fn(),
+  codexAccountRemove: vi.fn(),
+  codexAccountSwitch: vi.fn(),
+  codexAccountRestartDesktop: vi.fn(),
+}));
+
+const eventMocks = vi.hoisted(() => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("../../../../../lib/tauri", () => tauriMocks);
+vi.mock("@tauri-apps/api/event", () => eventMocks);
+
+import { CodexAccountsSection } from "./CodexAccountsSection";
+
+const t = (key: string) => key;
+
+function account(id: string, extra: Partial<CodexAccount> = {}): CodexAccount {
+  return {
+    id,
+    nickname: null,
+    emailHint: `user-${id}@example.com`,
+    authSubject: null,
+    providerAccountId: null,
+    codexHomePath: `C:/fake/${id}`,
+    source: "managedByApp",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    lastAuthenticatedAt: null,
+    ...extra,
+  };
+}
+
+function snapshot(usedPercent: number, plan = "free"): CodexAccountUsageSnapshot {
+  return {
+    email: "user@example.com",
+    providerAccountId: null,
+    plan,
+    allowed: true,
+    limitReached: false,
+    primaryWindow: { usedPercent, resetAt: null, limitWindowSeconds: 3600 },
+    secondaryWindow: null,
+    credits: null,
+    updatedAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("CodexAccountsSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing before the store loads, then lists accounts", async () => {
+    tauriMocks.getCodexAccountsState.mockResolvedValue(
+      { accounts: [account("1"), account("2", { source: "ambient" })], snapshots: {} } as CodexAccountsStateBridge,
+    );
+    const { container } = render(<CodexAccountsSection t={t} />);
+    expect(container.querySelector(".codex-accounts")).toBeNull();
+
+    await waitFor(() => {
+      expect(screen.getByText("user-1@example.com")).toBeDefined();
+    });
+    expect(screen.getByText("user-2@example.com")).toBeDefined();
+    expect(screen.getByText("CodexAccountsSourceManaged")).toBeDefined();
+    expect(screen.getByText("CodexAccountsSourceAmbient")).toBeDefined();
+  });
+
+  it("shows the usage pill and blocked state from a snapshot", async () => {
+    tauriMocks.getCodexAccountsState.mockResolvedValue(
+      {
+        accounts: [account("1")],
+        snapshots: {
+          "1": snapshot(38),
+        },
+      } as CodexAccountsStateBridge,
+    );
+    render(<CodexAccountsSection t={t} />);
+    await waitFor(() => {
+      expect(screen.getByText("free · 38%")).toBeDefined();
+    });
+  });
+
+  it("adds an account and reloads", async () => {
+    tauriMocks.getCodexAccountsState.mockResolvedValueOnce(
+      { accounts: [], snapshots: {} } as CodexAccountsStateBridge,
+    );
+    tauriMocks.getCodexAccountsState.mockResolvedValueOnce(
+      { accounts: [account("1")], snapshots: {} } as CodexAccountsStateBridge,
+    );
+    render(<CodexAccountsSection t={t} />);
+    await waitFor(() => {
+      expect(screen.getByText("CodexAccountsAddButton")).toBeDefined();
+    });
+
+    tauriMocks.codexAccountAdd.mockResolvedValue(account("1"));
+    await act(async () => {
+      screen.getByText("CodexAccountsAddButton").click();
+    });
+    await waitFor(() => {
+      expect(screen.getByText("user-1@example.com")).toBeDefined();
+    });
+    expect(tauriMocks.codexAccountAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("switches an account and offers a desktop restart when a session can be restored", async () => {
+    tauriMocks.getCodexAccountsState.mockResolvedValue(
+      { accounts: [account("1")], snapshots: {} } as CodexAccountsStateBridge,
+    );
+    tauriMocks.codexAccountSwitch.mockResolvedValue(
+      { desktopSessionRestoreExists: true, desktopSessionRestorePath: "C:/s", desktopSessionBackupPath: null } as CodexSwitchResult,
+    );
+    render(<CodexAccountsSection t={t} />);
+    await waitFor(() => {
+      expect(screen.getByText("CodexAccountsSwitchButton")).toBeDefined();
+    });
+
+    await act(async () => {
+      screen.getByText("CodexAccountsSwitchButton").click();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/CodexSwitchSuccess/)).toBeDefined();
+    });
+    expect(screen.getByText(/CodexSwitchRestartPrompt/)).toBeDefined();
+
+    await act(async () => {
+      screen.getByText("CodexAccountsRestartDesktop").click();
+    });
+    expect(tauriMocks.codexAccountRestartDesktop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop-tauri/src/surfaces/settings/providers/sections/credentials/CodexAccountsSection.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/providers/sections/credentials/CodexAccountsSection.tsx
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type {
+  CodexAccount,
+  CodexAccountsStateBridge,
+  CodexAccountUsageSnapshot,
+  CodexSwitchResult,
+} from "../../../../../types/bridge";
+import type { LocaleKey } from "../../../../../i18n/keys";
+import {
+  codexAccountAdd,
+  codexAccountFetch,
+  codexAccountRemove,
+  codexAccountRestartDesktop,
+  codexAccountSwitch,
+  getCodexAccountsState,
+} from "../../../../../lib/tauri";
+
+interface Props {
+  t: (key: LocaleKey) => string;
+}
+
+/**
+ * Inline "Codex Accounts" surface shown inside the Settings → Providers →
+ * Codex detail pane.
+ *
+ * Multi-account Codex support (ADR 0003). Reads the shared account +
+ * snapshot store via `get_codex_accounts_state` and drives the
+ * `codex_account_*` IPC surface: add (login into a managed home), switch the
+ * active ambient identity, refresh per-account usage, and remove managed
+ * homes. For MSIX Codex Desktop installs a restart action is offered when a
+ * session snapshot is available to restore.
+ */
+export function CodexAccountsSection({ t }: Props) {
+  const [accounts, setAccounts] = useState<CodexAccount[]>([]);
+  const [snapshots, setSnapshots] = useState<
+    Record<string, CodexAccountUsageSnapshot>
+  >({});
+  const [loaded, setLoaded] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [switchResult, setSwitchResult] = useState<CodexSwitchResult | null>(
+    null,
+  );
+
+  const load = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const next: CodexAccountsStateBridge = await getCodexAccountsState();
+      setAccounts(next.accounts);
+      setSnapshots(next.snapshots);
+      setLoaded(true);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Live-refresh after the provider engine runs the per-account lanes
+  // (ADR 0003 multi-account refresh) so the panel stays current.
+  useEffect(() => {
+    let cancelled = false;
+    const unlistenPromise = listen("codex-accounts-updated", () => {
+      if (!cancelled) void load();
+    });
+    return () => {
+      cancelled = true;
+      void unlistenPromise.then((fn) => fn());
+    };
+  }, [load]);
+
+  const handleAdd = async () => {
+    setBusy(true);
+    setError(null);
+    setSwitchResult(null);
+    try {
+      await codexAccountAdd();
+      await load();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSwitch = async (id: string) => {
+    setBusy(true);
+    setError(null);
+    setSwitchResult(null);
+    try {
+      const result = await codexAccountSwitch(id);
+      setSwitchResult(result);
+      await load();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleFetch = async (id: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const snapshot = await codexAccountFetch(id);
+      setSnapshots((prev) => ({ ...prev, [id]: snapshot }));
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRemove = async (id: string) => {
+    setBusy(true);
+    setError(null);
+    setSwitchResult(null);
+    try {
+      await codexAccountRemove(id);
+      await load();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRestartDesktop = async () => {
+    if (!switchResult) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await codexAccountRestartDesktop(
+        null,
+        switchResult.desktopSessionBackupPath ?? null,
+        switchResult.desktopSessionRestorePath ?? null,
+      );
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!loaded) {
+    return null;
+  }
+
+  return (
+    <section className="provider-detail-section codex-accounts">
+      <div className="provider-detail-section__header">
+        <h4>{t("CodexAccountsTitle")}</h4>
+        {accounts.length === 0 && (
+          <button
+            type="button"
+            className="credential-btn credential-btn--primary"
+            disabled={busy}
+            onClick={() => void handleAdd()}
+          >
+            {t("CodexAccountsAddButton")}
+          </button>
+        )}
+      </div>
+      <p className="settings-section__hint">{t("CodexAccountsHint")}</p>
+
+      {error && (
+        <div className="provider-detail-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {switchResult && (
+        <div className="provider-detail-note" role="status">
+          {t("CodexSwitchSuccess")}
+          {switchResult.desktopSessionRestoreExists && (
+            <>
+              {" "}
+              {t("CodexSwitchRestartPrompt")}{" "}
+              <button
+                type="button"
+                className="credential-btn credential-btn--secondary"
+                disabled={busy}
+                onClick={() => void handleRestartDesktop()}
+              >
+                {t("CodexAccountsRestartDesktop")}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
+      {accounts.length === 0 ? (
+        <p className="credential-empty">{t("CodexAccountsEmpty")}</p>
+      ) : (
+        <>
+          <ul className="credential-list codex-accounts-list">
+            {accounts.map((account) => {
+              const snapshot = snapshots[account.id];
+              return (
+                <li
+                  key={account.id}
+                  className="credential-card codex-accounts-card"
+                >
+                  <div className="credential-card__header">
+                    <div className="credential-card__info">
+                      <strong>
+                        {account.nickname ??
+                          account.emailHint ??
+                          account.authSubject ??
+                          shrink(account.id)}
+                      </strong>
+                      <span className="credential-card__meta">
+                        <span className="credential-card__badge credential-card__badge--set">
+                          {account.source === "ambient"
+                            ? t("CodexAccountsSourceAmbient")
+                            : t("CodexAccountsSourceManaged")}
+                        </span>
+                        {snapshot ? (
+                          <CodexUsagePill snapshot={snapshot} t={t} />
+                        ) : (
+                          <span className="credential-card__date">
+                            {t("CodexAccountsUsageUnavailable")}
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                    <div className="credential-card__actions">
+                      <button
+                        type="button"
+                        className="credential-btn credential-btn--secondary"
+                        disabled={busy}
+                        onClick={() => void handleFetch(account.id)}
+                      >
+                        {t("CodexAccountsFetchButton")}
+                      </button>
+                      <button
+                        type="button"
+                        className="credential-btn credential-btn--primary"
+                        disabled={busy}
+                        onClick={() => void handleSwitch(account.id)}
+                      >
+                        {t("CodexAccountsSwitchButton")}
+                      </button>
+                      <button
+                        type="button"
+                        className="credential-btn credential-btn--danger"
+                        disabled={busy}
+                        onClick={() => void handleRemove(account.id)}
+                      >
+                        {t("CodexAccountsRemoveButton")}
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+          <div className="codex-accounts-add">
+            <button
+              type="button"
+              className="credential-btn credential-btn--primary"
+              disabled={busy}
+              onClick={() => void handleAdd()}
+            >
+              {t("CodexAccountsAddButton")}
+            </button>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function shrink(id: string): string {
+  return id.length <= 12 ? id : `${id.slice(0, 8)}…`;
+}
+
+function CodexUsagePill({
+  snapshot,
+  t,
+}: {
+  snapshot: CodexAccountUsageSnapshot;
+  t: (key: LocaleKey) => string;
+}) {
+  const window = snapshot.primaryWindow;
+  const percent = window ? Math.round(window.usedPercent) : null;
+  const plan = snapshot.plan ?? "";
+  const blocked = snapshot.allowed === false || snapshot.limitReached === true;
+  const label = [plan, percent !== null ? `${percent}%` : null]
+    .filter(Boolean)
+    .join(" · ");
+  return (
+    <span className={blocked ? "codex-usage codex-usage--blocked" : "codex-usage"}>
+      {label || t("CodexAccountsUsageUnavailable")}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Add the ADR 0003 accounts panel inside the Codex provider detail pane (`Settings → Providers → Codex`).
- `CodexAccountsSection` lists accounts (ambient + managed) with per-account usage bars, and exposes add / switch / fetch / remove / restart-desktop actions wired to the bridge commands.
- Adds the panel styles to `styles.css` (menu/tray styles land in PR 5/5) and mounts the section in `ProviderDetailPane`.

## Related issue

ADR 0003 (`docs/adr/0003-multi-account-codex.md`). No issue number yet.

## Affected areas

- [ ] Tray panel
- [x] Settings UI
- [ ] Config file / settings persistence
- [x] Provider-specific behavior (Codex accounts panel)
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

Hosted PR check runs on Blacksmith Windows when `CI_BUDGET_MODE` is not `off` (see `.github/workflows/pr-check.yml` and `CONTEXT.md`). Still run the local slice and list commands/results below. If a check is not relevant, say why.

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1`
- [ ] For full pre-release validation: `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>`
- [ ] For installer/release changes: `powershell.exe -File scripts\windows-release-build.ps1 -Ref <ref> -SmokeInstall`
- [ ] Thermo-nuclear code quality review completed before submitting: https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md
- [ ] Other: `pnpm test CodexAccountsSection` (4 tests) pass

## UI / tray proof

For UI, tray, settings, or visual behavior changes, use CUA Driver for visual proof. If CUA Driver cannot be used, explain why and attach equivalent manual proof.

- [ ] Not applicable
- [ ] CUA Driver visual proof attached
- [x] CUA Driver could not be used; equivalent manual proof and explanation attached — settings panel rendering validated via unit tests (jsdom); CUA proof pending on a Windows host (AGENTS.md: MSIX/WebView2 paths require Windows-native validation). Will attach CUA proof in follow-up if requested.

## Notes for reviewers

- Depends on #255, #256, #258. Branch is based on the #258 branch; diff against `main` will be rebased onto `main` after #258 merges.
- **size:exception (marginal, 485 lines)**: the component ships with its co-located test file and its styles block; splitting the test or styles from the component would break the "tests/docs travel with the unit" rule for a 85-line overage.
- Tray menu flyout (option A) is the final slice, PR 5/5.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | codex-multi-account (ADR 0003) |
| Tracker PR | Not needed (stacked PRs to main) |
| Position | 4 of 5 |
| Base | `main` (rebase after #258 merges) |
| Depends on | #258 (frontend bridge + i18n) |
| Follow-up | #5 tray menu flyout |
| Review budget | 485 / 400 (marginal size:exception) |
| Starts at | `#258` merged state |
| Ends with | Codex accounts panel renders in Settings → Providers with add/switch/fetch/remove actions |

### Chain Overview

```text
main
 ├── #255 domain core — reviewed
 ├── #256 shell commands + lanes — reviewed
 ├── #258 frontend bridge + i18n — reviewed
 └── 📍 #4 This PR — settings accounts panel
      └── #5 tray menu flyout
```

### Scope
- Includes: `CodexAccountsSection.tsx` (+ test), mount in `ProviderDetailPane.tsx`, panel styles in `styles.css`.
- Excludes: tray/menu flyout component and its styles — PR 5/5.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit (4 jsdom tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788526827&installation_model_id=427695&pr_number=259&repository=nesszer%2FWin-CodexBar&return_to=https%3A%2F%2Fgithub.com%2Fnesszer%2FWin-CodexBar%2Fpull%2F259&signature=2bb9cf528cc165c336f50d426e52cf0f4499647f4ea23ecd41381ddc852abb24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->