### PR TITLE
Relax interaction guard: 14-day age, 15 PRs per 7-day window

### DIFF
--- a/.github/scripts/interaction-guard.mjs
+++ b/.github/scripts/interaction-guard.mjs
@@ -1,8 +1,8 @@
-const accountAgeDays = 30;
+const accountAgeDays = 14;
 const windowDays = 7;
 const limits = {
   issue: { count: 10, label: "issues" },
-  pull_request: { count: 4, label: "pull requests" },
+  pull_request: { count: 15, label: "pull requests" }, // 15 PRs per 7-day window; relax in 2026-08 from 4 (was aggressively blocking legit contributors)
 };
 // Must match the fromJSON list in the guard job's `if:` in
 // .github/workflows/interaction-guard.yml.

--- a/.github/scripts/interaction-guard.test.mjs
+++ b/.github/scripts/interaction-guard.test.mjs
@@ -5,17 +5,29 @@ import { closePayload, evaluateInteraction, isTrustedAuthor } from "./interactio
 
 const now = "2026-07-08T00:00:00.000Z";
 
-test("blocks accounts younger than 30 days", () => {
+test("blocks accounts younger than 14 days", () => {
   const result = evaluateInteraction({
     kind: "issue",
     author: "new-user",
-    userCreatedAt: "2026-06-20T00:00:00.000Z",
+    userCreatedAt: "2026-06-25T00:00:00.000Z",
     now,
     recentCount: 1,
   });
 
   assert.equal(result.allowed, false);
-  assert.match(result.reason, /at least 30 days old/);
+  assert.match(result.reason, /at least 14 days old/);
+});
+
+test("allows accounts exactly 14 days old", () => {
+  const result = evaluateInteraction({
+    kind: "issue",
+    author: "two-week-user",
+    userCreatedAt: "2026-06-24T00:00:00.000Z",
+    now,
+    recentCount: 1,
+  });
+
+  assert.equal(result.allowed, true);
 });
 
 test("allows old accounts under the weekly issue limit", () => {
@@ -43,17 +55,29 @@ test("blocks the 11th issue in 7 days", () => {
   assert.match(result.reason, /10 issues per 7 days/);
 });
 
-test("blocks the 5th pull request in 7 days", () => {
+test("allows the 15th pull request in 7 days", () => {
+  const result = evaluateInteraction({
+    kind: "pull_request",
+    author: "busy-user",
+    userCreatedAt: "2026-05-01T00:00:00.000Z",
+    now,
+    recentCount: 15,
+  });
+
+  assert.equal(result.allowed, true);
+});
+
+test("blocks the 16th pull request in 7 days", () => {
   const result = evaluateInteraction({
     kind: "pull_request",
     author: "spammy-user",
     userCreatedAt: "2026-05-01T00:00:00.000Z",
     now,
-    recentCount: 5,
+    recentCount: 16,
   });
 
   assert.equal(result.allowed, false);
-  assert.match(result.reason, /4 pull requests per 7 days/);
+  assert.match(result.reason, /15 pull requests per 7 days/);
 });
 
 test("trusts maintainer associations", () => {


### PR DESCRIPTION
Context: current guard (30-day account age floor + 4 PRs/7d) kept auto-closing legitimate external contributors (e.g. issue #247's reporter got repeatedly auto-closed while contributing a detailed bug report with live evidence). Changes: accountAgeDays 30->14; pull_request limit 4->15 per the same 7-day window; issues window limit stays 10/7d. Tests updated to pin the new constants.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->