### PR TITLE
docs: clarify SignPath code signing is pending, not yet implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Winget distribution is approved through [microsoft/winget-pkgs](https://github.c
 
 ## Code signing
 
-> **Code signing:** Windows releases of Win-CodexBar are signed for free by SignPath.io, certificate by SignPath Foundation. See [docs/CODE_SIGNING.md](docs/CODE_SIGNING.md) for the signing policy.
+> **Code signing:** Free signing via SignPath.io (certificate: SignPath Foundation) is **planned, pending onboarding — not yet wired into the release pipeline**. See [docs/CODE_SIGNING.md](docs/CODE_SIGNING.md) for the signing policy.
 > Windows release installers are currently unsigned, which may cause an incorrect SmartScreen/Defender alert — verify the SHA-256 published alongside each release; see [docs/PRIVACY.md](docs/PRIVACY.md) for data handling.
 
 ## First Run

--- a/docs/CODE_SIGNING.md
+++ b/docs/CODE_SIGNING.md
@@ -1,6 +1,8 @@
 # Code signing policy
 
-Free code signing of Win-CodexBar releases provided by SignPath.io, certificate by SignPath Foundation.
+Free code signing of Win-CodexBar releases via SignPath.io, certificate by SignPath Foundation.
+
+> **Status: pending onboarding — not yet implemented.** All current release artifacts (installer and portable build) are **unsigned**; authenticity relies on the SHA-256 `.sha256` sidecar files published alongside each release. The sections below describe the target process once SignPath onboarding and pipeline wiring are complete.
 
 ## Project identity
 
@@ -23,13 +25,15 @@ Free code signing of Win-CodexBar releases provided by SignPath.io, certificate 
 - CI runs on GitHub Actions (`.github/workflows/pr-check.yml`).
 - The Windows release pipeline is driven by `scripts/windows-release-build.ps1`, which builds the Tauri release binary plus the console CLI and packages them with Inno Setup into the installer (`CodexBar-<version>-Setup.exe`) and portable build, writing SHA-256 sidecar files for every artifact.
 - Release artifacts are published to [GitHub Releases](https://github.com/nesszer/Win-CodexBar/releases).
-- Release signing is submitted to SignPath from this pipeline; each release-signing request is approved manually by the approver listed above before signed binaries are published.
+- **Not yet wired:** release signing will be submitted to SignPath from this pipeline once SignPath onboarding completes; each release-signing request is approved manually by the approver listed above before signed binaries are published.
 
 ## Privacy
 
 See [docs/PRIVACY.md](PRIVACY.md) for the project's privacy policy.
 
 ## Notes
+
+*The notes below apply once signing is active:*
 
 - Certificates are issued in the SignPath Foundation's name; signed binaries show "SignPath Foundation" as the publisher.
 - Every release-signing request requires manual approval per release; no unattended signing is performed.


### PR DESCRIPTION
## What

Docs-only correction of the code-signing statements:

- **README.md**: the "Code signing" callout claimed Windows releases *are signed for free by SignPath.io* while the very next line said installers *are currently unsigned*. It now states signing is **planned, pending onboarding — not yet wired into the release pipeline**. The accurate "currently unsigned, verify the SHA-256 published alongside each release" line is unchanged.
- **docs/CODE_SIGNING.md**: the Build-system section described a SignPath submission step ("Release signing is submitted to SignPath from this pipeline") that does not exist in `scripts/windows-release-build.ps1` or anywhere in the repo. It now opens with a **Status: pending onboarding — not yet implemented** note stating all current artifacts are unsigned and authenticity relies on the published SHA-256 `.sha256` sidecars, labels the pipeline signing step **Not yet wired**, and marks the Notes section as applying once signing is active.

The signing policy, roles, and target process are kept future-ready; only the tense/placement of claims changed. No workflow code or secrets were added — no SignPath credentials exist yet.

## Why

Refs #257 — during the Defender `Trojan:Win32/Wacatac.B!ml` investigation, both v0.47.0 artifacts verified as `NotSigned` and no signing step exists in the pipeline, so the docs misstated reality in both directions (README also contradicted itself in adjacent lines).

## What this does NOT do

- **This does not resolve, fix, or close the detection reported in #257.** It only makes the documentation truthful. The issue stays open until the WDSI determination and/or real signed artifacts exist.
- No behavior changes; markdown only.

## Checks

Docs-only change: `pr-check.yml` ignores `docs/**` and `**/*.md` on `pull_request`, so no CI jobs are expected to run for this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->