### PR TITLE
Fix FloatBar weekly usage fallback

### DIFF
--- a/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.test.tsx
@@ -41,6 +41,7 @@ function rateWindow(
   used: number,
   opts: {
     exhausted?: boolean;
+    informational?: boolean;
     resetsAt?: string | null;
     resetDescription?: string | null;
   } = {},
@@ -52,6 +53,7 @@ function rateWindow(
     resetsAt: opts.resetsAt ?? null,
     resetDescription: opts.resetDescription ?? null,
     isExhausted: opts.exhausted ?? false,
+    isInformational: opts.informational ?? false,
     reservePercent: null,
     reserveDescription: null,
   };
@@ -212,6 +214,51 @@ describe("FloatBar", () => {
     // Highest used (codex, 75%) shows first; display follows showAsUsed.
     expect(titles[0]).toMatch(/Codex: 75% used/);
     expect(titles[1]).toMatch(/Claude: 20% used/);
+  });
+
+  it("uses the secondary window when the primary window is informational", async () => {
+    const codex = snapshot("codex", "Codex", 0);
+    codex.primary = rateWindow(0, {
+      informational: true,
+      resetDescription: "No active 5h session",
+    });
+    codex.secondary = rateWindow(26, {
+      resetDescription: "Weekly reset",
+    });
+    tauriMocks.getCachedProviders.mockResolvedValue([
+      snapshot("claude", "Claude", 20),
+      codex,
+    ]);
+    tauriMocks.getSettingsSnapshot.mockResolvedValue(
+      settings({ floatBarShowResetInline: true }),
+    );
+
+    const { container } = renderFloatBar(
+      bootstrap({ floatBarShowResetInline: true }),
+    );
+
+    await waitFor(() => {
+      const pills = container.querySelectorAll(".floatbar__pill");
+      expect(pills.length).toBe(2);
+      expect(pills[0].getAttribute("title")).toContain("Codex: 26% used");
+      expect(pills[0].getAttribute("title")).toContain("Weekly reset");
+      expect(pills[0].textContent).toContain("26%");
+      expect(pills[0].textContent).not.toContain("No active 5h session");
+    });
+  });
+
+  it("uses the secondary window when calculating the pill tone", async () => {
+    const codex = snapshot("codex", "Codex", 0);
+    codex.primary = rateWindow(0, { informational: true });
+    codex.secondary = rateWindow(20, { exhausted: true });
+    tauriMocks.getCachedProviders.mockResolvedValue([codex]);
+    tauriMocks.getSettingsSnapshot.mockResolvedValue(settings());
+
+    const { container } = renderFloatBar(bootstrap());
+
+    await waitFor(() => {
+      expect(container.querySelector(".floatbar__pill--crit")).not.toBeNull();
+    });
   });
 
   it("loads local cost summaries without using the foreground chart endpoint", async () => {

--- a/apps/desktop-tauri/src/floatbar/FloatBar.tsx
+++ b/apps/desktop-tauri/src/floatbar/FloatBar.tsx
@@ -23,6 +23,7 @@ import type {
   BootstrapState,
   ProviderLocalUsageSummary,
   ProviderUsageSnapshot,
+  RateWindowSnapshot,
   SettingsSnapshot,
 } from "../types/bridge";
 import { FLOAT_BAR_CONFIG_CHANGED_EVENT, resizeFloatBar } from "./api";
@@ -82,6 +83,12 @@ type FloatBarCostTarget = {
 
 function providerCostKey(provider: ProviderUsageSnapshot): string {
   return `${provider.providerId}:${provider.accountEmail ?? ""}`;
+}
+
+function floatBarRateWindow(provider: ProviderUsageSnapshot): RateWindowSnapshot {
+  return provider.primary.isInformational && provider.secondary
+    ? provider.secondary
+    : provider.primary;
 }
 
 function hasLocalCost(summary: ProviderLocalUsageSummary | null): summary is ProviderLocalUsageSummary {
@@ -178,11 +185,12 @@ function ProviderPill({
   usedSuffix: string;
   remainingSuffix: string;
 }) {
-  const remaining = Math.max(0, Math.min(100, provider.primary.remainingPercent));
-  const used = Math.max(0, Math.min(100, provider.primary.usedPercent));
+  const rateWindow = floatBarRateWindow(provider);
+  const remaining = Math.max(0, Math.min(100, rateWindow.remainingPercent));
+  const used = Math.max(0, Math.min(100, rateWindow.usedPercent));
   const displayPercent = showAsUsed ? used : remaining;
   const displaySuffix = showAsUsed ? usedSuffix : remainingSuffix;
-  const exhausted = provider.primary.isExhausted || provider.error;
+  const exhausted = rateWindow.isExhausted || provider.error;
   let tone: "ok" | "warn" | "crit" = "ok";
   if (exhausted || remaining <= critRemaining) tone = "crit";
   else if (remaining <= highRemaining) tone = "warn";
@@ -190,8 +198,8 @@ function ProviderPill({
   const brand = getProviderIcon(provider.providerId).brandColor;
   const label = provider.error ? "—" : `${Math.round(displayPercent)}%`;
   const resetText = useFormattedResetTime(
-    provider.primary.resetsAt,
-    provider.primary.resetDescription,
+    rateWindow.resetsAt,
+    rateWindow.resetDescription,
     resetRelative,
   );
   const resetSuffix = resetText ? `\n${resetText}` : "";
@@ -308,7 +316,9 @@ export default function FloatBar({ state }: { state: BootstrapState }) {
       const wanted = new Set(filterIds);
       list = list.filter((p) => wanted.has(p.providerId));
     }
-    return [...list].sort((a, b) => b.primary.usedPercent - a.primary.usedPercent);
+    return [...list].sort(
+      (a, b) => floatBarRateWindow(b).usedPercent - floatBarRateWindow(a).usedPercent,
+    );
   }, [providers, settings.enabledProviders, filterIds]);
 
   const visibleCostTargets = useMemo<FloatBarCostTarget[]>(


### PR DESCRIPTION
## Summary

- use the secondary usage window in FloatBar when the primary window is informational
- apply the same effective window to percentage, reset time, exhaustion tone, and provider sorting
- add regression coverage for weekly fallback behavior and tone calculation

## Related issue

Fixes #275

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [x] Other: FloatBar

## Validation

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1`
- [ ] For full pre-release validation: `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>`
- [ ] For installer/release changes: `powershell.exe -File scripts\windows-release-build.ps1 -Ref <ref> -SmokeInstall`
- [ ] Thermo-nuclear code quality review completed before submitting: https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md
- [x] Other:
  - `vitest run src/floatbar/FloatBar.test.tsx` — 17 passed
  - full frontend `vitest run` — 40 files / 248 tests passed
  - locale drift check, TypeScript check, and Vite production build passed
  - `tauri build --debug --no-bundle` completed successfully on Windows

## UI / tray proof

- [ ] Not applicable
- [ ] CUA Driver visual proof attached
- [x] CUA Driver could not be used; equivalent manual proof and explanation attached

CUA Driver was not installed on the test machine. A fresh debug build containing this change was tested manually on Windows 11 against the affected Codex OAuth account, and manual testing confirmed that the FloatBar now shows the weekly usage correctly.

## Notes for reviewers

The fallback is intentionally local to FloatBar. Provider normalization and the bridge contract already expose the canonical informational primary window introduced by #268.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789189999&installation_model_id=427695&pr_number=278&repository=nesszer%2FWin-CodexBar&return_to=https%3A%2F%2Fgithub.com%2Fnesszer%2FWin-CodexBar%2Fpull%2F278&signature=e9a4ea70f7c8c4c3a9ac7a59c9e066cebb1b816632241a3e64a17a45c7498885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->