### PR TITLE
Fix/qwencloud weekly window

### DIFF
--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -30,6 +30,7 @@
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "4.7.0",
+    "esbuild": "^0.25.12",
     "jsdom": "25.0.1",
     "typescript": "5.6.3",
     "vite": "6.4.2",

--- a/apps/desktop-tauri/pnpm-lock.yaml
+++ b/apps/desktop-tauri/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 4.7.0
         version: 4.7.0(vite@6.4.2)
+      esbuild:
+        specifier: ^0.25.12
+        version: 0.25.12
       jsdom:
         specifier: 25.0.1
         version: 25.0.1

--- a/rust/src/providers/qwencloud/mod.rs
+++ b/rust/src/providers/qwencloud/mod.rs
@@ -343,18 +343,30 @@ impl QwenCloudProvider {
                 ),
             )
         });
+        let weekly = snapshot.weekly_used_percent.map(|percent| {
+            RateWindow::with_details(
+                percent,
+                Some(WEEKLY_MINUTES),
+                snapshot.weekly_resets_at,
+                quota_detail_percent(percent, snapshot.weekly_total_quota),
+            )
+        });
+
+        // Prefer the 5-hour window; fall back to the legacy 30-day envelope; if the
+        // account only exposes the weekly window (e.g. Qwen Cloud individual plans),
+        // promote it to primary instead of failing the whole fetch.
+        let has_five_hour_or_legacy = five_hour.is_some() || legacy.is_some();
         let primary = five_hour
             .or(legacy)
+            .or_else(|| weekly.clone())
             .ok_or_else(|| ProviderError::Parse("Qwen Cloud usage windows missing".into()))?;
         let mut usage = UsageSnapshot::new(primary);
 
-        if let Some(weekly_percent) = snapshot.weekly_used_percent {
-            usage = usage.with_secondary(RateWindow::with_details(
-                weekly_percent,
-                Some(WEEKLY_MINUTES),
-                snapshot.weekly_resets_at,
-                quota_detail_percent(weekly_percent, snapshot.weekly_total_quota),
-            ));
+        // The weekly window is secondary only when it was not promoted to primary.
+        if has_five_hour_or_legacy
+            && let Some(weekly) = weekly
+        {
+            usage = usage.with_secondary(weekly);
         }
 
         if let Some(plan) = snapshot.plan_name.filter(|plan| !plan.trim().is_empty()) {
@@ -1387,5 +1399,37 @@ mod tests {
         assert_eq!(provider.metadata().weekly_label, "Weekly");
         assert!(!provider.metadata().default_enabled);
         assert_eq!(provider.metadata().dashboard_url, Some(DASHBOARD_URL));
+    }
+
+    #[test]
+    fn weekly_only_shape_promotes_weekly_to_primary() {
+        // Real-world fixture: the account exposes only the weekly window, so
+        // there is no per5HourPercentage at all. Previously this failed with
+        // "Qwen Cloud usage windows missing"; now the weekly window becomes
+        // the primary window instead.
+        let payload = serde_json::json!({
+            "code": "200",
+            "data": {
+                "DataV2": {
+                    "data": {
+                        "success": true,
+                        "data": {
+                            "per1WeekPercentage": 0.8439116574633999,
+                            "per1WeekResetTime": 1785234900000_i64
+                        }
+                    },
+                    "success": true,
+                    "httpStatus": 200
+                }
+            },
+            "successResponse": true
+        });
+        let usage = QwenCloudProvider::snapshot_to_usage(
+            QwenCloudProvider::parse(payload.to_string().as_bytes(), None, None).unwrap(),
+        )
+        .unwrap();
+        assert!((usage.primary.used_percent - 84.39116574634).abs() < 1e-9);
+        assert_eq!(usage.primary.window_minutes, Some(WEEKLY_MINUTES));
+        assert!(usage.secondary.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Fixes Qwen Cloud individual plans that expose only the weekly usage window
(per1WeekPercentage, no per5HourPercentage / legacy quota). Previously
snapshot_to_usage failed with "Qwen Cloud usage windows missing"; now the
weekly window is promoted to primary.

## Behavior change

- Weekly-only accounts now show the weekly percentage (e.g. 84.39%) instead
  of no data / error.
- When both windows exist, weekly remains secondary (unchanged).
- Added test `weekly_only_shape_promotes_weekly_to_primary` with real-world
  fixture.

## Commands run

- `cargo test -p codexbar qwencloud` — 9/9 pass
- `cargo fmt --all`

## Validation

Validated in the desktop app (debug build): provider now shows the weekly
84.39% window correctly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789292942&installation_model_id=427695&pr_number=281&repository=nesszer%2FWin-CodexBar&return_to=https%3A%2F%2Fgithub.com%2Fnesszer%2FWin-CodexBar%2Fpull%2F281&signature=ecd193bd2b919706713d4d0c6689c37dcf7219a5f116a9dabd2a186583b95f9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->