### PR TITLE
CircleCI release-only Windows pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,104 @@
+version: 2.1
+
+orbs:
+  win: circleci/windows@5.0
+
+jobs:
+  release-build:
+    executor:
+      name: win/default
+      size: large
+    environment:
+      CARGO_BUILD_TARGET: x86_64-pc-windows-msvc
+      CARGO_TERM_COLOR: never
+      CARGO_TERM_PROGRESS_WHEN: never
+      NO_COLOR: '1'
+    steps:
+      - checkout
+      - run:
+          name: Assert build job has no GitHub write credential
+          shell: powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command
+          command: |
+            if (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) { throw 'GH_TOKEN must be absent from release-build.' }
+      - run:
+          name: Validate canonical release tag, SHA, versions, and main ancestry
+          shell: powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command
+          command: |
+            $ErrorActionPreference = 'Stop'
+            if (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) { throw 'GH_TOKEN must be absent from the credential-free release-build job.' }
+            $root = (Get-Location).Path
+            & powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File (Join-Path $root 'scripts\release-preflight.ps1') -Tag $env:CIRCLE_TAG -Sha $env:CIRCLE_SHA1 -RepoRoot $root
+            if ($LASTEXITCODE -ne 0) { throw "release-preflight.ps1 failed with exit code $LASTEXITCODE" }
+      - run:
+          name: Provision and assert pinned release prerequisites
+          shell: powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command
+          command: |
+            $ErrorActionPreference = 'Stop'
+            $root = (Get-Location).Path
+            & powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File (Join-Path $root 'scripts\install-release-prerequisites.ps1') -RepoRoot $root
+            if ($LASTEXITCODE -ne 0) { throw "install-release-prerequisites.ps1 failed with exit code $LASTEXITCODE" }
+      - run:
+          name: Build, smoke-install, and emit verified assets
+          no_output_timeout: 45m
+          shell: powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command
+          command: |
+            $ErrorActionPreference = 'Stop'
+            $root = (Get-Location).Path
+            $output = Join-Path $root 'release-output'
+            & powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File (Join-Path $root 'scripts\circleci-release-build.ps1') -Tag $env:CIRCLE_TAG -Sha $env:CIRCLE_SHA1 -RepoRoot $root -OutputDir $output
+            if ($LASTEXITCODE -ne 0) { throw "circleci-release-build.ps1 failed with exit code $LASTEXITCODE" }
+      - persist_to_workspace:
+          root: .
+          paths:
+            - release-output
+            - scripts/publish-github-release.ps1
+            - scripts/release-pipeline-common.ps1
+      - store_artifacts:
+          path: release-output
+          destination: release-output
+
+  release-publish:
+    executor:
+      name: win/default
+      size: medium
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Upload matching assets to a draft GitHub Release
+          shell: powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command
+          command: |
+            $ErrorActionPreference = 'Stop'
+            if ([string]::IsNullOrWhiteSpace($env:GH_TOKEN)) { throw 'GH_TOKEN is required only in the restricted publisher context.' }
+            $root = (Get-Location).Path
+            $manifestPath = Join-Path $root 'release-output\release-manifest.json'
+            if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) { throw "Missing persisted release manifest: $manifestPath" }
+            $manifest = Get-Content -Raw -LiteralPath $manifestPath | ConvertFrom-Json
+            if ($manifest.repository -ne 'nesszer/Win-CodexBar') { throw "Manifest repository is not canonical nesszer/Win-CodexBar." }
+            if ($manifest.tag -ne $env:CIRCLE_TAG) { throw "Manifest tag does not match CIRCLE_TAG." }
+            if (-not $env:CIRCLE_SHA1 -or $env:CIRCLE_SHA1 -notmatch '^[0-9a-fA-F]{40}$' -or [string]$manifest.commit -cne ($env:CIRCLE_SHA1).ToLowerInvariant()) { throw 'Manifest commit must equal lowercase CIRCLE_SHA1.' }
+            $env:RELEASE_SHA = [string]$manifest.commit
+            $publisher = Join-Path $root 'scripts\publish-github-release.ps1'
+            if (-not (Test-Path -LiteralPath $publisher -PathType Leaf)) { throw "Missing persisted publisher helper: $publisher" }
+            & powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $publisher -AssetsDir (Join-Path $root 'release-output') -Tag $env:CIRCLE_TAG
+            if ($LASTEXITCODE -ne 0) { throw "publish-github-release.ps1 failed with exit code $LASTEXITCODE" }
+
+workflows:
+  release:
+    jobs:
+      - release-build:
+          filters: &release-tag-filter
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+            branches:
+              ignore: /.*/
+      - release-approval:
+          type: approval
+          requires:
+            - release-build
+          filters: *release-tag-filter
+      - release-publish:
+          context: github-release-publisher
+          requires:
+            - release-approval
+          filters: *release-tag-filter

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,10 +1,16 @@
 # CI — Win-CodexBar
 
-Win-CodexBar runs one hosted workflow: the **PR check** on Blacksmith Windows.
-Release stays **local**. See `CONTEXT.md` for the shared CI budget glossary
-and `docs/adr/0001` and `docs/adr/0002` for the decisions.
+Win-CodexBar has two deliberately separate hosted CI responsibilities:
 
-## Workflows
+- **Blacksmith GitHub Actions** remains the primary PR/push validation path.
+- **CircleCI** is a release-only Windows path. It can start only for a
+  canonical protected semver tag (`vX.Y.Z`), never for a branch or PR.
+
+The CircleCI pipeline does not replace or weaken the Blacksmith checks. Its
+build job has no GitHub write credential; only the post-approval publisher
+receives the restricted `GH_TOKEN` context.
+
+## Blacksmith GitHub Actions
 
 ### PR check — `.github/workflows/pr-check.yml`
 
@@ -23,64 +29,121 @@ pnpm --dir apps/desktop-tauri run build
 ```
 
 This is the **local-check slice** from `scripts/local-check.ps1` only. It does
-**not** run `tauri:build` release, installer packaging, smoke install, or
-upload. Those stay on the local release path.
+not run release packaging, installer smoke, or publication.
 
 `concurrency.cancel-in-progress` is on, keyed by ref, so superseded pushes
 cancel the in-flight run.
 
 ### Interaction guard — `.github/workflows/interaction-guard.yml`
 
-Unchanged except for the budget gate (below). Runner stays
-`blacksmith-2vcpu-ubuntu-2404`. Permissions are unchanged
-(`contents: read`, `issues: write`, `pull-requests: write`).
+The interaction guard remains on `blacksmith-2vcpu-ubuntu-2404` with its
+existing `contents: read`, `issues: write`, and `pull-requests: write`
+permissions. It is unrelated to release publication.
 
-## CI budget mode
+## GitHub Actions budget mode
 
-Both workflows carry the gate `if: vars.CI_BUDGET_MODE != 'off'`, so they run
-when the variable is unset (`normal`), `normal`, or `thin`, and **skip only
-when `off`**.
+Both GitHub workflows carry `if: vars.CI_BUDGET_MODE != 'off'`, so they run
+when the variable is unset (`normal`), `normal`, or `thin`, and skip only when
+it is `off`. This gate does not disable CircleCI releases.
 
 Set `CI_BUDGET_MODE` in **Settings → Secrets and variables → Actions →
 Variables**. Do not hard-code it in a workflow.
 
-| Mode   | PR check | Interaction guard | Release |
-|--------|----------|--------------------|---------|
-| normal | runs     | runs               | local   |
-| thin   | runs     | runs               | local   |
-| off    | skip     | skip               | local   |
+| Mode   | PR check | Interaction guard | Circle release |
+|--------|----------|-------------------|----------------|
+| normal | runs     | runs              | tag-triggered  |
+| thin   | runs     | runs              | tag-triggered  |
+| off    | skip     | skip              | tag-triggered  |
 
-## Intent share (60/30/10)
+The Blacksmith Pool minutes intent remains roughly **60% Win-CodexBar**,
+**30% linear-cli**, and **10% buffer**. CircleCI credits are separate and must
+be budgeted in CircleCI.
 
-The Blacksmith Pool minutes intent is divided: roughly **60% Win-CodexBar**,
-**30% linear-cli**, **10% buffer**. This is an intent allocation of the
-pool's minutes, not a measure of time spent in `normal`/`thin`/`off` modes.
-Win-CodexBar's single Blacksmith Windows PR check is the only recurring
-Windows job. If you add a second recurring job, reassess the 60% share before
-merging.
+## CircleCI release pipeline
 
-## Blacksmith billing — Windows bills 2x
+Configuration: `.circleci/config.yml`, project **`nesszer/Win-CodexBar`**.
+Both jobs use CircleCI's hosted Windows executor (`circleci/windows@5.0`).
 
-On the Blacksmith **free tier**, **Windows minutes bill at 2x**: one Windows
-minute consumes two free-tier minutes. `blacksmith-4vcpu-windows-2025` is
-Windows Server 2025. Because the PR check is a thin slice (fmt + clippy +
-test) and never runs release builds, this is the only recurring Windows
-cost. Keep it that way.
+1. `release-build` runs only when the workflow tag filter matches exactly
+   `^v[0-9]+\.[0-9]+\.[0-9]+$`; branch filters explicitly ignore every branch.
+   The preflight rejects PR/branch environment markers as a second boundary.
+2. The credential-free build validates the canonical remote, full tag SHA,
+   tag-to-SHA identity, protected `main` ancestry, and every project version
+   file. It provisions/asserts Node 24.x via the `OpenJS.NodeJS.LTS` winget
+   package, pnpm 10.18.1, the Rust MSVC target, Git, and Inno Setup 6.
+3. It uses a new temporary `WorkRoot`, runs `release-doctor.ps1`, then runs
+   `windows-release-build.ps1` with the immutable SHA and `-SmokeInstall`.
+   It never uploads. Four assets, `release-manifest.json`, and build logs are
+   persisted to the workspace and stored as CircleCI artifacts.
+4. `release-approval` is a required manual CircleCI approval job.
+5. `release-publish` attaches the workspace and is the only job with context
+   `github-release-publisher`. Its `GH_TOKEN` is used by
+   `scripts/publish-github-release.ps1` to create or update a **draft** release.
+   Exact SHA-256 matches are skipped, mismatches fail, and missing assets are
+   uploaded without clobbering. The script never publishes/finalizes a release.
 
-## $0 spend alert
+### CircleCI project and context setup
 
-Treat any non-zero monthly Blacksmith bill as an alert. If spend appears:
+These steps require repository/CircleCI administrator access and are not
+automated by this repository:
 
-1. Set `CI_BUDGET_MODE=off` to stop both workflows immediately.
-2. Investigate which run(s) consumed minutes (Actions tab → billed runs).
-3. Trim or fix, then restore `CI_BUDGET_MODE=normal` (or `thin`).
+1. Add the canonical GitHub project `nesszer/Win-CodexBar` to the CircleCI
+   organization and enable `.circleci/config.yml`.
+2. Create a restricted context named `github-release-publisher`, scoped only to
+   this project (and the release job if organization policy supports expression
+   restrictions). Add `GH_TOKEN` as a secret; never add it as a project
+   variable or to the build job.
+3. Use a fine-grained GitHub token for only this repository with **Contents:
+   read and write** (release asset API access). Do not grant **Workflows**
+   permission; no workflow file is changed by the publisher.
+4. Protect the `v*` tag namespace with a GitHub ruleset/tag protection policy
+   that permits only authorized release maintainers to create canonical
+   `vX.Y.Z` tags. Protect `main` and require the normal Blacksmith checks.
+5. Configure CircleCI notifications and a spending/credit alert appropriate to
+   the organization. Do not approve a release until the build artifacts and
+   manifest have been reviewed.
 
-The default posture is **$0 spend**. The PR check should stay within free-tier
-minutes; if it does not, prefer reducing the check slice before paying.
+The GitHub token is intentionally not available to checkout, preflight,
+prerequisite provisioning, release-doctor, build, smoke, or artifact steps.
+CircleCI project setup and GitHub tag/context/ruleset changes are the current
+manual setup scope.
 
-## Release
+## Cost, retry, and rollback behavior
 
-Release is **local only**. There is no hosted release workflow. Follow
-`docs/BUILDING.md` and `docs/release/ci-cd.md`: tag, run release-doctor, run
-`windows-release-build.ps1 -SmokeInstall`, then upload assets to GitHub
-Releases manually.
+Blacksmith Windows minutes remain the recurring PR cost and are still billed
+according to the existing Blacksmith plan (Windows has historically billed at
+2x on its free tier). CircleCI release builds add Windows executor credits only
+for protected semver tags, plus the short approval/publish job. Do not use
+CircleCI for branch validation or ad-hoc release testing.
+
+Reruns are safe: the build is tied to the immutable SHA from the tag and
+produces a fresh temporary WorkRoot. If publication stops after some uploads,
+rerun the publisher after approval; matching assets are skipped and a same-name
+different-hash asset fails rather than being replaced. A final/non-draft release
+is never modified by the publisher. Rollback or deletion of a draft/final
+release is a deliberate GitHub administrator action, followed by a new tag/SHA
+release if replacement is required.
+
+The current smoke scope is `scripts/windows-smoke-install.ps1`: install the
+generated Inno Setup installer, verify the expected application/version, then
+uninstall it. It does not prove every tray/UI/provider path; those remain
+separate Windows/CUA validation work.
+
+## Local release checks
+
+Run the same pure checks and parser-level validation locally:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\release-pipeline.tests.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\install-release-prerequisites.ps1 -AssertOnly
+```
+
+The hosted release flow is:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\release-preflight.ps1 -Tag vX.Y.Z -Sha <full-40-char-sha>
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\circleci-release-build.ps1 -Tag vX.Y.Z -Sha <full-40-char-sha>
+```
+
+Do not pass an upload switch to `windows-release-build.ps1`; publication is
+owned exclusively by the approval-gated, hash-safe publisher.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,13 +154,13 @@ Winget 分发已通过 [microsoft/winget-pkgs](https://github.com/microsoft/wing
 常用发布参数：
 
 ```powershell
-.\scripts\windows-release-build.ps1 -Ref v0.32.2 -WarmCacheOnly
-.\scripts\windows-release-build.ps1 -Ref v0.32.2 -SmokeInstall
-.\scripts\windows-release-build.ps1 -Ref v0.32.2 -UploadRelease v0.32.2
-.\scripts\release-doctor.ps1 -Version 0.32.2
+.\scripts\windows-release-build.ps1 -Ref vX.Y.Z -WarmCacheOnly
+.\scripts\windows-release-build.ps1 -Ref vX.Y.Z -SmokeInstall
+.\scripts\release-doctor.ps1 -Version X.Y.Z
 ```
 
-安装包和便携版资产以 Windows 构建服务器脚本为主发布路径。
+构建脚本不再上传 GitHub Release。发布仅通过需要人工批准的 CircleCI
+Windows 草稿发布流程完成；它会校验 SHA-256，绝不会覆盖已有资产。
 
 ## 首次运行
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -154,13 +154,13 @@ Winget 分發已透過 [microsoft/winget-pkgs](https://github.com/microsoft/wing
 常用釋出引數：
 
 ```powershell
-.\scripts\windows-release-build.ps1 -Ref v0.32.2 -WarmCacheOnly
-.\scripts\windows-release-build.ps1 -Ref v0.32.2 -SmokeInstall
-.\scripts\windows-release-build.ps1 -Ref v0.32.2 -UploadRelease v0.32.2
-.\scripts\release-doctor.ps1 -Version 0.32.2
+.\scripts\windows-release-build.ps1 -Ref vX.Y.Z -WarmCacheOnly
+.\scripts\windows-release-build.ps1 -Ref vX.Y.Z -SmokeInstall
+.\scripts\release-doctor.ps1 -Version X.Y.Z
 ```
 
-安裝包和便攜版資產以 Windows 構建伺服器指令碼為主釋出路徑。
+構建指令碼不再上傳 GitHub Release。釋出僅透過需要人工核准的 CircleCI
+Windows 草稿釋出流程完成；它會校驗 SHA-256，絕不覆蓋已有資產。
 
 ## 首次執行
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -64,17 +64,15 @@ Release assets land in `C:\code\Win-CodexBar-release\assets`. Keep the
 Useful release flags:
 
 ```powershell
-.\scripts\windows-release-build.ps1 -Ref v0.27.5 -WarmCacheOnly
-.\scripts\windows-release-build.ps1 -Ref v0.27.5 -WarmCliCache
-.\scripts\windows-release-build.ps1 -Ref v0.27.5 -SmokeInstall
-.\scripts\windows-release-build.ps1 -Ref v0.27.5 -UploadRelease v0.27.5
-.\scripts\release-doctor.ps1 -Version 0.27.5
+.\scripts\windows-release-build.ps1 -Ref vX.Y.Z -WarmCacheOnly
+.\scripts\windows-release-build.ps1 -Ref vX.Y.Z -SmokeInstall
+.\scripts\release-doctor.ps1 -Version X.Y.Z
 ```
 
-A hosted **PR check** runs on Blacksmith Windows for pull requests and pushes
-to `main`/`master`; see `.github/CI.md` for its scope and budget modes. The
-Windows release script remains the primary path for installer and portable
-artifacts; there is no hosted release workflow.
+`windows-release-build.ps1` only builds and smoke-tests. It has no upload
+switch. The hosted release path is the approval-gated CircleCI workflow
+documented in `docs/release/ci-cd.md`; publication uses its no-clobber,
+SHA-256-checked draft publisher.
 
 ## macOS Windows Cross Build
 

--- a/docs/WINDOWS_PROOF.md
+++ b/docs/WINDOWS_PROOF.md
@@ -55,12 +55,11 @@ For the Inno Setup release artifact, prefer the cached Windows release builder:
 
 It keeps a clean managed checkout while reusing Cargo, pnpm, and signed
 installer dependency caches. Use `-WarmCacheOnly` after large ports to prepare
-the desktop cache without packaging, `-WarmCliCache` as a compatibility alias
-because release packaging now builds CLI artifacts every time, `-SmokeInstall`
-to install/uninstall the generated installer, and `-UploadRelease vX.Y.Z` to
-upload assets directly to GitHub.
-Run the standalone smoke installer test on a Windows machine before manual
-upload or publication:
+the desktop cache, and `-SmokeInstall` to install/uninstall the generated
+installer. The builder has no upload switch. Publication is performed only by
+the approval-gated CircleCI draft publisher in `docs/release/ci-cd.md`, which
+checks hashes and never overwrites an existing asset.
+Run the standalone smoke installer test on a Windows machine before approval:
 
 ```powershell
 powershell -ExecutionPolicy Bypass `

--- a/docs/adr/0004-circleci-release-trust-boundary.md
+++ b/docs/adr/0004-circleci-release-trust-boundary.md
@@ -1,0 +1,55 @@
+# ADR 0004: CircleCI release-only pipeline and dual-CI trust boundary
+
+Date: 2026-08-14
+Status: Accepted; supersedes the release-local portion of ADR 0001
+
+## Context
+
+ADR 0001 kept all release packaging and GitHub publication on an operator's
+Windows server while Blacksmith GitHub Actions handled PR checks. We still need
+Blacksmith to remain the primary PR/push CI, but a repeatable hosted Windows
+release build is safer than an ad-hoc workstation. Release credentials must not
+be exposed to build tooling or ordinary CI paths.
+
+## Decision
+
+Add `.circleci/config.yml` for the canonical `nesszer/Win-CodexBar` project.
+CircleCI is a release-only pipeline with exact `vX.Y.Z` tag filters and an
+explicit branch-ignore filter. `scripts/release-preflight.ps1` is a second
+boundary: it validates the canonical remote, full immutable tag SHA, protected
+`main` ancestry, and all project version files.
+
+The `release-build` job uses hosted Windows without a GitHub write credential.
+It provisions/asserts pinned-enough prerequisites, uses a fresh temporary
+WorkRoot, runs release-doctor, and invokes `windows-release-build.ps1` with the
+immutable SHA and `-SmokeInstall`. It emits four expected assets, a manifest,
+and logs into a persisted workspace. The builder has no publication path.
+
+A required CircleCI approval separates build from `release-publish`. Only that
+job receives the project-restricted `github-release-publisher` context with a
+fine-grained `GH_TOKEN` scoped to repository Contents read/write. No Workflows
+permission is needed. `publish-github-release.ps1` creates or uses a draft
+release, compares existing assets by SHA-256, uploads only missing assets, fails
+on a digest mismatch, and never clobbers or finalizes a release.
+
+## Trust boundaries
+
+- **Blacksmith Actions:** primary PR/push validation; unchanged permissions and
+  runner responsibilities.
+- **CircleCI build:** untrusted/reproducible packaging boundary; no GitHub write
+  secret, no release API calls, immutable source, temporary WorkRoot.
+- **Human approval:** reviews persisted manifest/logs before publication.
+- **CircleCI publisher context:** sole release write capability; draft-only,
+  hash-safe, idempotent publisher.
+- **GitHub administrators:** protect `main` and the `v*` tag namespace and
+  manually finalize or roll back releases.
+
+## Consequences
+
+- Release builds consume CircleCI hosted Windows credits only for protected
+  semver tags; branch and PR builds remain on Blacksmith.
+- A partial upload can be retried safely: exact assets are skipped and a
+  different digest is a hard failure rather than an overwrite.
+- Final release publication remains a deliberate GitHub action.
+- CircleCI project/context creation, token storage, tag rulesets, and billing
+  alerts remain manual administrator setup.

--- a/docs/release/ci-cd.md
+++ b/docs/release/ci-cd.md
@@ -1,38 +1,93 @@
-# Win-CodexBar CI and local checks
+# Win-CodexBar CI and release delivery
 
-**PR validation** is hosted on Blacksmith Windows via `.github/workflows/pr-check.yml`
-(budget-gated by `vars.CI_BUDGET_MODE`; see `CONTEXT.md`). **Release packaging and
-upload stay local.**
+## Responsibilities
 
-## PR checks
+**Blacksmith GitHub Actions** (`.github/workflows/pr-check.yml`) remains the
+primary PR/push validation path. It runs the existing format, clippy, Rust
+test, frontend test, and frontend build checks on hosted Blacksmith Windows.
 
-Hosted job (when budget mode is not `off`): `cargo fmt --check`, clippy + test on
-both `rust/Cargo.toml` and `apps/desktop-tauri/src-tauri/Cargo.toml`, then
-`pnpm --dir apps/desktop-tauri test` and `pnpm --dir apps/desktop-tauri run build`.
+**CircleCI** (`.circleci/config.yml`) is release-only. The workflow is filtered
+to the canonical `nesszer/Win-CodexBar` project and exact protected tags
+`vX.Y.Z`; branch and pull-request pipelines cannot enter it. The CircleCI
+Windows build is credential-free. Only its explicit approval-gated publisher
+gets the restricted `GH_TOKEN` context.
 
-Mirror locally before opening a PR:
+## CircleCI release flow
+
+1. A maintainer creates a protected canonical tag such as `v0.48.0` on `main`.
+   CircleCI's workflow filter and `scripts/release-preflight.ps1` both reject
+   branches, PRs, non-semver tags, non-canonical remotes, tag/SHA mismatch,
+   and commits whose tag is not reachable from protected `origin/main`.
+2. The build job provisions/asserts Node 24.x via the `OpenJS.NodeJS.LTS`
+   winget package, pnpm 10.18.1, the Windows MSVC Rust target, Git, and Inno
+   Setup 6. It validates every committed project version against the tag.
+3. The build invokes `scripts/release-doctor.ps1 -SkipGitHub`, then
+   `scripts/windows-release-build.ps1 -Ref <full-SHA> -SmokeInstall` with a
+   fresh temporary `WorkRoot`. It never receives `GH_TOKEN` and never uploads.
+4. The job emits exactly these four publishable assets:
+   `CodexBar-X.Y.Z-Setup.exe`, its `.sha256` sidecar,
+   `CodexBar-X.Y.Z-portable.exe`, and its `.sha256` sidecar. It also emits
+   `release-manifest.json` (tag, commit, version, sizes, and hashes) and logs,
+   then persists/stores the bundle as CircleCI workspace/artifacts.
+5. A human must approve the `release-approval` job after reviewing the
+   manifest and artifact logs.
+6. The `release-publish` job receives `GH_TOKEN` only from the restricted
+   `github-release-publisher` context. `scripts/publish-github-release.ps1`
+   creates a draft release if absent, or uses an existing draft. It compares
+   every same-name asset by SHA-256, skips exact matches, fails on mismatch,
+   and uploads only missing assets. It never clobbers and never changes a
+   draft to a final release.
+7. A maintainer publishes the draft manually in GitHub after any final release
+   notes/review. Winget follows only after the immutable installer URL and
+   digest are stable.
+
+## Local checks
+
+Run the focused, dependency-free helper tests and prerequisite assertions:
 
 ```powershell
-powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1
-powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -Format -Clippy
-powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1 -All -Version <version>
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\release-pipeline.tests.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\install-release-prerequisites.ps1 -AssertOnly
 ```
 
-## Release checks
-
-The canonical Windows release path uses the release scripts:
+The build/preflight commands used by CircleCI can be exercised with a full SHA:
 
 ```powershell
-powershell.exe -File scripts\release-doctor.ps1 -Version <version>
-powershell.exe -File scripts\windows-release-build.ps1 -Ref v<version> -SmokeInstall
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\release-preflight.ps1 -Tag vX.Y.Z -Sha <full-40-char-sha>
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\circleci-release-build.ps1 -Tag vX.Y.Z -Sha <full-40-char-sha>
 ```
 
-Use the version/ref being released.
+The smoke test covers install, expected version validation, and uninstall of
+the generated Inno Setup installer on the real Windows runner. It does not
+cover all tray, WebView2, provider, or CUA/UI behavior.
 
-## Release flow
+## Setup that requires administrators
 
-1. Tag the release, for example `vX.Y.Z`.
-2. Run `scripts\release-doctor.ps1`.
-3. Run `scripts\windows-release-build.ps1 -SmokeInstall`.
-4. Upload the verified installer, portable exe, and SHA-256 sidecars to GitHub Releases.
-5. Submit the Winget manifest update after the GitHub installer URL is stable.
+The repository cannot create external settings. Configure the CircleCI project
+for `nesszer/Win-CodexBar`, enable `.circleci/config.yml`, and create a
+project-restricted context named `github-release-publisher`. Store `GH_TOKEN`
+there only, using a fine-grained GitHub token scoped to this repository with
+Contents read/write for release APIs. Do not grant Workflows permission.
+
+Protect `main`, require the existing Blacksmith checks, and protect the `v*`
+tag namespace so only authorized maintainers can create canonical `vX.Y.Z` tags.
+Configure CircleCI credit/spend alerts and notifications as appropriate for
+the organization. These project, context, token, ruleset, and billing changes
+are intentionally manual.
+
+## Cost, retry, and rollback
+
+Blacksmith billing remains the recurring PR cost. CircleCI Windows credits are
+incurred only for a protected release tag and its short approval/publish path;
+there is no CircleCI branch or PR build. Windows executor rates depend on the
+CircleCI plan, so set an organization credit alert before enabling releases.
+
+Rerunning a failed build creates a new temporary WorkRoot and remains pinned to
+the tag's full SHA. If a publish job partially uploads, rerun it after approval:
+matching assets are skipped and missing assets are added. A same-name digest
+mismatch fails without replacement. If a final release already exists, the
+publisher refuses to touch it. Rollback is a deliberate GitHub administrator
+action; replacement artifacts require a new reviewed tag/SHA, not an overwrite.
+
+There is no upload switch on `windows-release-build.ps1`; all publication goes
+through the approval-gated no-clobber publisher.

--- a/scripts/circleci-release-build.ps1
+++ b/scripts/circleci-release-build.ps1
@@ -1,0 +1,85 @@
+#Requires -Version 5.1
+<##
+.SYNOPSIS
+    Run the credential-free CircleCI Windows release build and artifact bundle.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Tag = $env:CIRCLE_TAG,
+    [Parameter(Mandatory)][string]$Sha = $env:CIRCLE_SHA1,
+    [string]$RepoRoot = '',
+    [string]$OutputDir = '',
+    [string]$Repository = 'https://github.com/nesszer/Win-CodexBar.git'
+)
+
+Set-StrictMode -Version Latest
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $PSScriptRoot
+}
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+    $OutputDir = Join-Path $RepoRoot 'release-output'
+}
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'release-pipeline-common.ps1')
+
+function Invoke-LoggedPowerShell {
+    param(
+        [Parameter(Mandatory)][string]$ScriptPath,
+        [Parameter(Mandatory)][string[]]$Arguments,
+        [Parameter(Mandatory)][string]$LogPath
+    )
+
+    & powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $ScriptPath @Arguments *> $LogPath
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        Write-Host "--- $LogPath ---"
+        if (Test-Path -LiteralPath $LogPath) { Get-Content -LiteralPath $LogPath }
+        throw "$ScriptPath failed with exit code $exitCode"
+    }
+}
+
+function Clear-DirectoryContents {
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) { return }
+    foreach ($entry in Get-ChildItem -LiteralPath $Path -Force) {
+        if ($entry.PSIsContainer) { [IO.Directory]::Delete($entry.FullName, $true) }
+        else { [IO.File]::Delete($entry.FullName) }
+    }
+}
+
+if (-not (Test-CanonicalReleaseTag $Tag)) { throw "Invalid canonical release tag '$Tag'." }
+if ($Sha -notmatch '^[0-9a-fA-F]{40}$') { throw "Invalid immutable SHA '$Sha'." }
+if ((Normalize-GitHubRepository $Repository) -ne 'nesszer/win-codexbar') { throw 'Repository must be canonical nesszer/Win-CodexBar.' }
+if (-not (Test-Path -LiteralPath $RepoRoot -PathType Container)) { throw "Missing repository root: $RepoRoot" }
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+Clear-DirectoryContents $OutputDir
+$version = Get-ReleaseVersionFromTag $Tag
+$tempRoot = if ($env:TEMP) { $env:TEMP } else { [IO.Path]::GetTempPath() }
+$workRoot = Join-Path $tempRoot ('win-codexbar-circleci-' + [guid]::NewGuid().ToString('N'))
+$assetsDir = Join-Path $workRoot 'assets'
+$doctorLog = Join-Path $OutputDir 'release-doctor.log'
+$buildLog = Join-Path $OutputDir 'windows-release-build.log'
+
+try {
+    Invoke-LoggedPowerShell (Join-Path $RepoRoot 'scripts\release-doctor.ps1') @('-Version', $version, '-SkipGitHub') $doctorLog
+    Invoke-LoggedPowerShell (Join-Path $RepoRoot 'scripts\windows-release-build.ps1') @(
+        '-Ref', $Sha,
+        '-RepoUrl', $Repository,
+        '-WorkRoot', $workRoot,
+        '-SmokeInstall'
+    ) $buildLog
+    Invoke-LoggedPowerShell (Join-Path $RepoRoot 'scripts\emit-release-manifest.ps1') @(
+        '-AssetsDir', $assetsDir,
+        '-OutputDir', $OutputDir,
+        '-Tag', $Tag,
+        '-Sha', $Sha
+    ) (Join-Path $OutputDir 'emit-release-manifest.log')
+    Write-Host "Credential-free release build passed for $Tag ($Sha)."
+} finally {
+    if (Test-Path -LiteralPath $workRoot -PathType Container) {
+        [IO.Directory]::Delete($workRoot, $true)
+    }
+}

--- a/scripts/emit-release-manifest.ps1
+++ b/scripts/emit-release-manifest.ps1
@@ -1,0 +1,71 @@
+#Requires -Version 5.1
+<##
+.SYNOPSIS
+    Validate release assets and emit the workspace manifest.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$AssetsDir,
+    [Parameter(Mandatory)][string]$OutputDir,
+    [Parameter(Mandatory)][string]$Tag,
+    [Parameter(Mandatory)][string]$Sha,
+    [string]$Repository = 'nesszer/Win-CodexBar'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'release-pipeline-common.ps1')
+
+if (-not (Test-CanonicalReleaseTag $Tag)) {
+    throw "Cannot emit a release manifest for non-canonical tag '$Tag'."
+}
+if ($Sha -notmatch '^[0-9a-fA-F]{40}$') {
+    throw "Manifest requires a full immutable commit SHA; received '$Sha'."
+}
+if ((Normalize-GitHubRepository $Repository) -ne 'nesszer/win-codexbar') {
+    throw "Manifest repository must be canonical nesszer/Win-CodexBar."
+}
+$version = Get-ReleaseVersionFromTag $Tag
+if (-not (Test-Path -LiteralPath $AssetsDir -PathType Container)) {
+    throw "Missing build assets directory: $AssetsDir"
+}
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$expectedPaths = Get-ExpectedReleaseAssetPaths $AssetsDir $version
+foreach ($path in $expectedPaths) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Missing expected release asset: $path"
+    }
+}
+Assert-AssetMatchesSidecar (Join-Path $AssetsDir "CodexBar-$version-Setup.exe")
+Assert-AssetMatchesSidecar (Join-Path $AssetsDir "CodexBar-$version-portable.exe")
+
+# Copy only the four publishable assets and the build logs into the persisted bundle.
+foreach ($path in $expectedPaths) {
+    Copy-Item -LiteralPath $path -Destination (Join-Path $OutputDir (Split-Path $path -Leaf)) -Force
+}
+Get-ChildItem -LiteralPath $AssetsDir -Filter '*.log' -File -ErrorAction SilentlyContinue |
+    Copy-Item -Destination $OutputDir -Force
+
+$assetRecords = @(
+    foreach ($path in $expectedPaths) {
+        [ordered]@{
+            name = Split-Path $path -Leaf
+            bytes = (Get-Item -LiteralPath $path).Length
+            sha256 = Get-AssetSha256 $path
+        }
+    }
+)
+$manifest = [ordered]@{
+    repository = 'nesszer/Win-CodexBar'
+    tag = $Tag
+    version = $version
+    commit = $Sha.ToLowerInvariant()
+    generated_at_utc = [DateTime]::UtcNow.ToString('o')
+    assets = $assetRecords
+}
+$manifestPath = Join-Path $OutputDir 'release-manifest.json'
+(ConvertTo-JsonString $manifest) | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+Write-Host "[ok] release manifest: $manifestPath"
+Write-Host "[ok] persisted assets: $($expectedPaths.Count)"

--- a/scripts/install-release-prerequisites.ps1
+++ b/scripts/install-release-prerequisites.ps1
@@ -1,0 +1,183 @@
+#Requires -Version 5.1
+<##
+.SYNOPSIS
+    Provision and assert the Windows release toolchain.
+
+.DESCRIPTION
+    The hosted build has no credentials. Missing machine tools may be installed
+    from the explicit winget package IDs below; the versions used by the build
+    are then asserted before any source or artifact work starts. Use -AssertOnly
+    for a no-network local check.
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$AssertOnly,
+    [string]$RepoRoot = ''
+)
+
+Set-StrictMode -Version Latest
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $PSScriptRoot
+}
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot 'release-pipeline-common.ps1')
+
+function Invoke-Native {
+    param([Parameter(Mandatory)][string]$FilePath, [Parameter(Mandatory)][string[]]$Arguments)
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$FilePath exited with code $LASTEXITCODE"
+    }
+}
+
+function Get-CommandPath {
+    param([Parameter(Mandatory)][string]$Name)
+
+    $command = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($command) { return $command.Source }
+    return $null
+}
+
+function Install-WingetPackage {
+    param(
+        [Parameter(Mandatory)][string]$Id,
+        [switch]$Upgrade
+    )
+
+    if ($AssertOnly) {
+        throw "Missing prerequisite '$Id' (AssertOnly mode does not install packages)."
+    }
+    $winget = Get-CommandPath 'winget'
+    if (-not $winget) {
+        throw "Missing '$Id' and winget is unavailable. Install the pinned package on the CircleCI Windows image."
+    }
+    Write-Host "Installing winget package $Id"
+    $arguments = @(
+        'install', '--id', $Id, '--exact', '--source', 'winget',
+        '--silent', '--accept-source-agreements', '--accept-package-agreements'
+    )
+    if ($Upgrade) { $arguments += '--upgrade' }
+    Invoke-Native $winget $arguments
+}
+
+function Require-Command {
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string]$PackageId)
+
+    $path = Get-CommandPath $Name
+    if (-not $path) {
+        Install-WingetPackage $PackageId
+        $path = Get-CommandPath $Name
+    }
+    if (-not $path) {
+        throw "Required command '$Name' is still unavailable after provisioning '$PackageId'."
+    }
+    Write-Host "[ok] $($Name): $path"
+    return $path
+}
+
+function Get-InnoSetupCompiler {
+    $candidates = @(
+        (Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\ISCC.exe'),
+        (Join-Path $env:ProgramFiles 'Inno Setup 6\ISCC.exe'),
+        (Join-Path $env:LOCALAPPDATA 'Programs\Inno Setup 6\ISCC.exe')
+    )
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path -LiteralPath $candidate -PathType Leaf)) { return $candidate }
+    }
+    return (Get-CommandPath 'ISCC.exe')
+}
+
+$packageJsonPath = Join-Path $RepoRoot 'apps\desktop-tauri\package.json'
+if (-not (Test-Path -LiteralPath $packageJsonPath -PathType Leaf)) {
+    throw "Missing package metadata: $packageJsonPath"
+}
+$packageJson = Get-Content -Raw -LiteralPath $packageJsonPath | ConvertFrom-Json
+$expectedPnpm = [string]$packageJson.packageManager -replace '^pnpm@', ''
+if ($expectedPnpm -notmatch '^10\.18\.1$') {
+    throw "Unexpected packageManager '$($packageJson.packageManager)'; release pipeline pins pnpm 10.18.1."
+}
+
+Require-Command 'git' 'Git.Git' | Out-Null
+$requiredNodeMajor = 24
+$nodePackageId = 'OpenJS.NodeJS.LTS'
+$node = Get-CommandPath 'node'
+$nodeVersion = ''
+$nodeMajor = $null
+if ($node) {
+    $nodeVersion = (& $node --version).Trim()
+    try {
+        $nodeMajor = Get-NodeMajor $nodeVersion
+    } catch {
+        $nodeMajor = $null
+    }
+}
+if ($nodeMajor -ne $requiredNodeMajor) {
+    if ($AssertOnly) {
+        throw "Node $requiredNodeMajor.x is required; found $nodeVersion."
+    }
+    if ($node) {
+        Install-WingetPackage $nodePackageId -Upgrade
+    } else {
+        Install-WingetPackage $nodePackageId
+    }
+    $node = Get-CommandPath 'node'
+    if (-not $node) {
+        throw "Required command 'node' is still unavailable after provisioning '$nodePackageId'."
+    }
+    $nodeVersion = (& $node --version).Trim()
+}
+Assert-NodeMajor $nodeVersion $requiredNodeMajor | Out-Null
+Write-Host "[ok] Node $nodeVersion (major $requiredNodeMajor)"
+
+$corepack = Get-CommandPath 'corepack'
+if (-not $corepack) {
+    throw "Corepack is required with Node $requiredNodeMajor to activate pinned pnpm $expectedPnpm."
+}
+if (-not $AssertOnly) {
+    Invoke-Native $corepack @('enable')
+    Invoke-Native $corepack @('prepare', "pnpm@$expectedPnpm", '--activate')
+}
+$pnpm = Get-CommandPath 'pnpm'
+if (-not $pnpm) {
+    throw "pnpm $expectedPnpm is unavailable after Corepack provisioning."
+}
+$pnpmVersion = (& $pnpm --version).Trim()
+if ($pnpmVersion -ne $expectedPnpm) {
+    throw "pnpm $pnpmVersion is active; expected exact $expectedPnpm."
+}
+Write-Host "[ok] pnpm $pnpmVersion"
+
+Require-Command 'cargo' 'Rustlang.Rustup' | Out-Null
+Require-Command 'rustc' 'Rustlang.Rustup' | Out-Null
+$rustup = Require-Command 'rustup' 'Rustlang.Rustup'
+$target = 'x86_64-pc-windows-msvc'
+$installedTargets = @(& $rustup target list --installed)
+if ($installedTargets -notcontains $target) {
+    if ($AssertOnly) {
+        throw "Rust target $target is not installed."
+    }
+    Invoke-Native $rustup @('target', 'add', $target)
+}
+Write-Host "[ok] Rust target $target"
+
+$iscc = Get-InnoSetupCompiler
+if (-not $iscc) {
+    if ($AssertOnly) {
+        throw 'Inno Setup 6 ISCC.exe is unavailable.'
+    }
+    Install-WingetPackage 'JRSoftware.InnoSetup'
+    $iscc = Get-InnoSetupCompiler
+}
+if (-not $iscc) {
+    throw 'Inno Setup 6 ISCC.exe is unavailable after provisioning.'
+}
+$innoVersion = (Get-Item -LiteralPath $iscc).VersionInfo.FileVersion
+if ($innoVersion -notmatch '^6\.') {
+    throw "Inno Setup 6.x is required; found '$innoVersion'."
+}
+Write-Host "[ok] Inno Setup $innoVersion ($iscc)"
+
+Write-Host ''
+Write-Host "Release prerequisites passed (Git, Node $requiredNodeMajor, pnpm 10.18.1, Rust MSVC target, Inno Setup 6)."

--- a/scripts/publish-github-release.ps1
+++ b/scripts/publish-github-release.ps1
@@ -1,0 +1,253 @@
+#Requires -Version 5.1
+<##
+.SYNOPSIS
+    Publish verified Windows assets to a draft GitHub Release without clobbering.
+
+.DESCRIPTION
+    This script is the only release publisher. It requires GH_TOKEN from the
+    restricted CircleCI context, creates a draft release when needed, compares
+    every existing asset by SHA-256, and uploads only missing assets. A mismatch
+    or a non-draft release is a hard failure. The script never changes draft to
+    published and is safe to rerun after a partial upload.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$AssetsDir,
+    [Parameter(Mandatory)][string]$Tag,
+    [string]$Repository = 'nesszer/Win-CodexBar'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'release-pipeline-common.ps1')
+
+function Remove-TempFile {
+    param([Parameter(Mandatory)][string]$Path)
+
+    if ([IO.File]::Exists($Path)) { [IO.File]::Delete($Path) }
+}
+
+function Invoke-GhJson {
+    param([Parameter(Mandatory)][string[]]$Arguments)
+
+    $gh = Get-Command gh -ErrorAction Stop
+    $stdoutPath = [IO.Path]::GetTempFileName()
+    $stderrPath = [IO.Path]::GetTempFileName()
+    try {
+        & $gh.Source @Arguments 1>$stdoutPath 2>$stderrPath
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            $errorText = Get-Content -Raw -LiteralPath $stderrPath -ErrorAction SilentlyContinue
+            throw "gh $($Arguments -join ' ') failed with exit code $($exitCode): $errorText"
+        }
+        return (Get-Content -Raw -LiteralPath $stdoutPath | ConvertFrom-Json)
+    } finally {
+        Remove-TempFile $stdoutPath
+        Remove-TempFile $stderrPath
+    }
+}
+
+function Invoke-GhUpload {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $gh = Get-Command gh -ErrorAction Stop
+    & $gh.Source release upload $Tag $Path '--repo' $Repository
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh release upload failed for $(Split-Path $Path -Leaf) with exit code $LASTEXITCODE"
+    }
+}
+
+function Get-Release {
+    $gh = Get-Command gh -ErrorAction Stop
+    $stdoutPath = [IO.Path]::GetTempFileName()
+    $stderrPath = [IO.Path]::GetTempFileName()
+    try {
+        & $gh.Source api "repos/$Repository/releases/tags/$Tag" 1>$stdoutPath 2>$stderrPath
+        if ($LASTEXITCODE -eq 0) {
+            return Get-Content -Raw -LiteralPath $stdoutPath | ConvertFrom-Json
+        }
+        $errorText = Get-Content -Raw -LiteralPath $stderrPath -ErrorAction SilentlyContinue
+        if ($errorText -match 'Not Found|404') {
+            return $null
+        }
+        throw "Could not query GitHub Release for $($Tag): $errorText"
+    } finally {
+        Remove-TempFile $stdoutPath
+        Remove-TempFile $stderrPath
+    }
+}
+
+function New-DraftRelease {
+    return Invoke-GhJson @(
+        'api', '--method', 'POST', "repos/$Repository/releases",
+        '--field', "tag_name=$Tag",
+        '--field', "target_commitish=$env:RELEASE_SHA",
+        '--field', "name=$Tag",
+        '--field', 'draft=true',
+        '--field', 'prerelease=false',
+        '--field', 'generate_release_notes=false'
+    )
+}
+
+function Get-RemoteAssetSha256 {
+    param([Parameter(Mandatory)]$Asset)
+
+    $digest = ''
+    $digestProperty = $Asset.PSObject.Properties['digest']
+    if ($digestProperty) { $digest = [string]$digestProperty.Value }
+    if ($digest -match '^sha256:([0-9a-fA-F]{64})$') {
+        return $Matches[1].ToLowerInvariant()
+    }
+
+    $downloadPath = [IO.Path]::GetTempFileName()
+    try {
+        $gh = Get-Command gh -ErrorAction Stop
+        & $gh.Source api '--header' 'Accept: application/octet-stream' "repos/$Repository/releases/assets/$($Asset.id)" '--output' $downloadPath
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not download existing GitHub asset '$($Asset.name)' to verify its hash."
+        }
+        return Get-AssetSha256 $downloadPath
+    } finally {
+        Remove-TempFile $downloadPath
+    }
+}
+function Assert-ManifestAndAssets {
+    param(
+        [Parameter(Mandatory)][string]$ManifestPath,
+        [Parameter(Mandatory)][string]$ExpectedVersion,
+        [Parameter(Mandatory)][string]$ExpectedTag
+    )
+
+    if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
+        throw "Missing release manifest: $ManifestPath"
+    }
+    $manifest = Get-Content -Raw -LiteralPath $ManifestPath | ConvertFrom-Json
+    if (-not $manifest.PSObject.Properties['repository'] -or [string]$manifest.repository -ne 'nesszer/Win-CodexBar') {
+        throw 'Manifest repository is not canonical nesszer/Win-CodexBar.'
+    }
+    if (-not $manifest.PSObject.Properties['tag'] -or [string]$manifest.tag -ne $ExpectedTag) {
+        throw "Manifest tag does not match $ExpectedTag."
+    }
+    if (-not $manifest.PSObject.Properties['version'] -or [string]$manifest.version -ne $ExpectedVersion) {
+        throw "Manifest version does not match $ExpectedVersion."
+    }
+    if (-not $env:CIRCLE_SHA1 -or $env:CIRCLE_SHA1 -notmatch '^[0-9a-fA-F]{40}$') {
+        throw 'CIRCLE_SHA1 must be a full commit SHA in the publisher job.'
+    }
+    $expectedCommit = ($env:CIRCLE_SHA1).ToLowerInvariant()
+    if (-not $manifest.PSObject.Properties['commit'] -or [string]$manifest.commit -cne $expectedCommit) {
+        throw "Manifest commit must equal lowercase CIRCLE_SHA1 ($expectedCommit)."
+    }
+    if (-not $env:RELEASE_SHA -or $env:RELEASE_SHA -notmatch '^[0-9a-fA-F]{40}$' -or ($env:RELEASE_SHA).ToLowerInvariant() -ne $expectedCommit) {
+        throw 'RELEASE_SHA must equal lowercase CIRCLE_SHA1 before publication.'
+    }
+
+    $expectedNames = @(Get-RequiredReleaseAssets $ExpectedVersion | Sort-Object)
+    if (-not $manifest.PSObject.Properties['assets']) {
+        throw 'Manifest is missing its assets list.'
+    }
+    $manifestAssets = @($manifest.assets)
+    if ($manifestAssets.Count -ne 4) {
+        throw "Manifest must contain exactly four release assets; found $($manifestAssets.Count)."
+    }
+    $manifestNames = @($manifestAssets | ForEach-Object { [string]$_.name } | Sort-Object)
+    if (($manifestNames -join '|') -ne ($expectedNames -join '|')) {
+        throw "Manifest assets must be exactly: $($expectedNames -join ', ')."
+    }
+
+    $publishFiles = @(Get-ChildItem -LiteralPath $AssetsDir -File | Where-Object {
+        $_.Name -ne 'release-manifest.json' -and $_.Name -notmatch '\\.log$'
+    } | Select-Object -ExpandProperty Name | Sort-Object)
+    if (($publishFiles -join '|') -ne ($expectedNames -join '|')) {
+        throw "Persisted bundle contains unexpected publishable files: $($publishFiles -join ', ')."
+    }
+
+    foreach ($name in $expectedNames) {
+        $path = Join-Path $AssetsDir $name
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+            throw "Missing expected release asset: $path"
+        }
+        $actualHash = Get-AssetSha256 $path
+        $record = @($manifestAssets | Where-Object { [string]$_.name -eq $name }) | Select-Object -First 1
+        if (-not $record -or [string]$record.sha256 -cne $actualHash) {
+            throw "Manifest SHA-256 mismatch for $name."
+        }
+        if ([int64]$record.bytes -ne (Get-Item -LiteralPath $path).Length) {
+            throw "Manifest byte count mismatch for $name."
+        }
+    }
+    Assert-AssetMatchesSidecar (Join-Path $AssetsDir "CodexBar-$ExpectedVersion-Setup.exe")
+    Assert-AssetMatchesSidecar (Join-Path $AssetsDir "CodexBar-$ExpectedVersion-portable.exe")
+    Write-Host '[ok] manifest, exact four asset names, SHA-256 values, and sidecars verified before API access'
+}
+
+if ([string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
+    throw 'GH_TOKEN is required and must be provided only by the restricted CircleCI publisher context.'
+}
+if (-not (Test-CanonicalReleaseTag $Tag)) {
+    throw "Publisher accepts only canonical vX.Y.Z tags; received '$Tag'."
+}
+if ((Normalize-GitHubRepository $Repository) -ne 'nesszer/win-codexbar') {
+    throw "Publisher repository must be canonical nesszer/Win-CodexBar."
+}
+if (-not (Test-Path -LiteralPath $AssetsDir -PathType Container)) {
+    throw "Missing persisted release assets directory: $AssetsDir"
+}
+$version = Get-ReleaseVersionFromTag $Tag
+$assetPaths = Get-ExpectedReleaseAssetPaths $AssetsDir $version
+Assert-ManifestAndAssets (Join-Path $AssetsDir 'release-manifest.json') $version $Tag
+
+$release = Get-Release
+if ($null -eq $release) {
+    if (-not $env:RELEASE_SHA -or $env:RELEASE_SHA -notmatch '^[0-9a-fA-F]{40}$') {
+        throw 'RELEASE_SHA must be a full commit SHA when creating a draft release.'
+    }
+    Write-Host "Creating draft GitHub Release $Tag"
+    $release = New-DraftRelease
+}
+if (-not [bool]$release.draft) {
+    throw "GitHub Release $Tag already exists and is not a draft; refusing to modify a final release."
+}
+if ([string]$release.tag_name -ne $Tag) {
+    throw "GitHub returned release tag '$($release.tag_name)' while publishing '$Tag'."
+}
+
+foreach ($path in $assetPaths) {
+    $name = Split-Path $path -Leaf
+    $localHash = Get-AssetSha256 $path
+    $existing = @($release.assets | Where-Object { $_.name -eq $name }) | Select-Object -First 1
+    if ($existing) {
+        $remoteHash = Get-RemoteAssetSha256 $existing
+        if ($remoteHash -ne $localHash) {
+            throw "Existing GitHub asset '$name' has SHA-256 $remoteHash, expected $localHash."
+        }
+        Write-Host "[skip] $name already matches SHA-256 $localHash"
+        continue
+    }
+
+    Write-Host "[upload] $name ($localHash)"
+    try {
+        Invoke-GhUpload $path
+    } catch {
+        # A retry may race a successful upload. Re-read and accept only an exact match.
+        $latest = Get-Release
+        $raced = if ($latest) { @($latest.assets | Where-Object { $_.name -eq $name }) | Select-Object -First 1 } else { $null }
+        if ($raced) {
+            $remoteHash = Get-RemoteAssetSha256 $raced
+            if ($remoteHash -eq $localHash) {
+                Write-Host "[skip] $name was uploaded by a concurrent retry"
+                $release = $latest
+                continue
+            }
+        }
+        throw
+    }
+    $release = Get-Release
+    if (-not $release -or -not [bool]$release.draft) {
+        throw "Release $Tag disappeared or is no longer draft after uploading $name."
+    }
+}
+
+Write-Host "Draft GitHub Release $Tag contains all four verified Windows assets."
+Write-Host 'No release publication/finalization was performed.'

--- a/scripts/release-pipeline-common.ps1
+++ b/scripts/release-pipeline-common.ps1
@@ -1,0 +1,114 @@
+#Requires -Version 5.1
+<##
+Shared, side-effect-free helpers for the hosted Windows release pipeline.
+This file is dot-sourced by the preflight, manifest, publisher, and focused tests.
+#>
+
+Set-StrictMode -Version Latest
+
+function Get-NodeMajor {
+    param([Parameter(Mandatory)][string]$Version)
+
+    if ($Version -notmatch '^v(\d+)\.') {
+        throw "Could not parse Node version '$Version'."
+    }
+    return [int]$Matches[1]
+}
+
+function Assert-NodeMajor {
+    param(
+        [Parameter(Mandatory)][string]$Version,
+        [Parameter(Mandatory)][int]$ExpectedMajor
+    )
+
+    $actualMajor = Get-NodeMajor $Version
+    if ($actualMajor -ne $ExpectedMajor) {
+        throw "Node $ExpectedMajor.x is required; found $Version."
+    }
+    return $actualMajor
+}
+
+function Normalize-GitHubRepository {
+    param([Parameter(Mandatory)][string]$Url)
+
+    $value = $Url.Trim()
+    $value = $value -replace '^git@github\.com:', ''
+    $value = $value -replace '^ssh://git@github\.com/', ''
+    $value = $value -replace '^https?://github\.com/', ''
+    $value = $value.TrimEnd('/')
+    $value = $value -replace '\.git$', ''
+    return $value.ToLowerInvariant()
+}
+
+function Test-CanonicalReleaseTag {
+    param([AllowNull()][string]$Tag)
+
+    return -not [string]::IsNullOrWhiteSpace($Tag) -and $Tag -match '^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$'
+}
+
+function Get-ReleaseVersionFromTag {
+    param([Parameter(Mandatory)][string]$Tag)
+
+    if (-not (Test-CanonicalReleaseTag $Tag)) {
+        throw "Tag '$Tag' is not a canonical vX.Y.Z release tag."
+    }
+    return $Tag.Substring(1)
+}
+
+function Get-RequiredReleaseAssets {
+    param([Parameter(Mandatory)][string]$Version)
+
+    return @(
+        "CodexBar-$Version-Setup.exe",
+        "CodexBar-$Version-Setup.exe.sha256",
+        "CodexBar-$Version-portable.exe",
+        "CodexBar-$Version-portable.exe.sha256"
+    )
+}
+
+function Get-AssetSha256 {
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Missing release asset: $Path"
+    }
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Get-SidecarSha256 {
+    param([Parameter(Mandatory)][string]$AssetPath)
+
+    $sidecarPath = "$AssetPath.sha256"
+    if (-not (Test-Path -LiteralPath $sidecarPath -PathType Leaf)) {
+        throw "Missing SHA-256 sidecar: $sidecarPath"
+    }
+    $line = Get-Content -LiteralPath $sidecarPath | Select-Object -First 1
+    if (-not $line -or $line -notmatch '^([0-9a-fA-F]{64})\s+') {
+        throw "Invalid SHA-256 sidecar: $sidecarPath"
+    }
+    return $Matches[1].ToLowerInvariant()
+}
+
+function Assert-AssetMatchesSidecar {
+    param([Parameter(Mandatory)][string]$AssetPath)
+
+    $expected = Get-SidecarSha256 $AssetPath
+    $actual = Get-AssetSha256 $AssetPath
+    if ($actual -ne $expected) {
+        throw "SHA-256 sidecar mismatch for $(Split-Path $AssetPath -Leaf): expected $expected, got $actual"
+    }
+}
+
+function Get-ExpectedReleaseAssetPaths {
+    param([Parameter(Mandatory)][string]$AssetsDir, [Parameter(Mandatory)][string]$Version)
+
+    return @(
+        Get-RequiredReleaseAssets $Version | ForEach-Object { Join-Path $AssetsDir $_ }
+    )
+}
+
+function ConvertTo-JsonString {
+    param([Parameter(Mandatory)]$Value)
+
+    return ($Value | ConvertTo-Json -Depth 8)
+}

--- a/scripts/release-pipeline.tests.ps1
+++ b/scripts/release-pipeline.tests.ps1
@@ -1,0 +1,75 @@
+#Requires -Version 5.1
+<##
+Focused, dependency-free checks for the pure release pipeline helpers.
+Run with: powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\release-pipeline.tests.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $scriptRoot 'release-pipeline-common.ps1')
+
+function Assert-True {
+    param([Parameter(Mandatory)][bool]$Condition, [Parameter(Mandatory)][string]$Message)
+    if (-not $Condition) { throw "Assertion failed: $Message" }
+}
+
+function Assert-Equal {
+    param([Parameter(Mandatory)]$Actual, [Parameter(Mandatory)]$Expected, [Parameter(Mandatory)][string]$Message)
+    if ($Actual -ne $Expected) { throw "Assertion failed: $Message (actual '$Actual', expected '$Expected')" }
+}
+
+function Assert-Throws {
+    param([Parameter(Mandatory)][scriptblock]$Block, [Parameter(Mandatory)][string]$Message)
+    $thrown = $false
+    try { & $Block } catch { $thrown = $true }
+    Assert-True $thrown $Message
+}
+Assert-Equal (Get-NodeMajor 'v24.18.0') 24 'Node 24 major parsing'
+Assert-Equal (Assert-NodeMajor 'v24.18.0' 24) 24 'Node 24 requirement'
+Assert-Throws { Assert-NodeMajor 'v23.11.0' 24 } 'non-24 Node major rejected by release prerequisite'
+
+$prerequisiteText = Get-Content -Raw -LiteralPath (Join-Path $scriptRoot 'install-release-prerequisites.ps1')
+Assert-True ($prerequisiteText -match '\$requiredNodeMajor\s*=\s*24') 'release prerequisite pins Node major 24'
+Assert-True ($prerequisiteText -match '10\\.18\\.1') 'release prerequisite keeps pnpm 10.18.1 pinned'
+
+Assert-Equal (Normalize-GitHubRepository 'https://github.com/nesszer/Win-CodexBar.git') 'nesszer/win-codexbar' 'HTTPS canonical URL'
+Assert-Equal (Normalize-GitHubRepository 'git@github.com:nesszer/Win-CodexBar.git') 'nesszer/win-codexbar' 'SSH canonical URL'
+Assert-True (Test-CanonicalReleaseTag 'v1.2.3') 'canonical release tag accepted'
+Assert-True (-not (Test-CanonicalReleaseTag 'v1.2.3-rc.1')) 'prerelease tag rejected'
+Assert-True (-not (Test-CanonicalReleaseTag 'v01.2.3')) 'leading-zero tag rejected'
+Assert-Equal (Get-ReleaseVersionFromTag 'v0.48.0') '0.48.0' 'version extraction'
+Assert-Throws { Get-ReleaseVersionFromTag 'v0.48.0+build' } 'invalid version extraction fails'
+
+$assetNames = Get-RequiredReleaseAssets '0.48.0'
+Assert-Equal $assetNames.Count 4 'exactly four release asset names'
+Assert-Equal $assetNames[0] 'CodexBar-0.48.0-Setup.exe' 'installer name'
+Assert-Equal $assetNames[3] 'CodexBar-0.48.0-portable.exe.sha256' 'portable sidecar name'
+
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ('win-codexbar-release-tests-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $testRoot | Out-Null
+try {
+    $asset = Join-Path $testRoot 'CodexBar-0.48.0-Setup.exe'
+    [IO.File]::WriteAllText($asset, 'deterministic fixture')
+    $hash = Get-AssetSha256 $asset
+    [IO.File]::WriteAllText("$asset.sha256", "$hash  $(Split-Path $asset -Leaf)`n")
+    Assert-Equal (Get-SidecarSha256 $asset) $hash 'sidecar parser'
+    Assert-AssetMatchesSidecar $asset
+    [IO.File]::WriteAllText("$asset.sha256", ('0' * 64) + "  bad`n")
+    Assert-Throws { Assert-AssetMatchesSidecar $asset } 'sidecar mismatch fails'
+} finally {
+    if ([IO.Directory]::Exists($testRoot)) { [IO.Directory]::Delete($testRoot, $true) }
+}
+
+$builderText = Get-Content -Raw -LiteralPath (Join-Path $scriptRoot 'windows-release-build.ps1')
+$legacySwitch = 'Upload' + 'Release'
+$clobberFlag = '--' + 'clobber'
+Assert-True ($builderText -notmatch $legacySwitch) 'legacy upload parameter removed'
+Assert-True ($builderText -notmatch $clobberFlag) 'builder has no clobber upload path'
+$publisherText = Get-Content -Raw -LiteralPath (Join-Path $scriptRoot 'publish-github-release.ps1')
+Assert-True ($publisherText -notmatch $clobberFlag) 'publisher has no clobber flag'
+
+Write-Host 'Release pipeline focused tests passed.'

--- a/scripts/release-preflight.ps1
+++ b/scripts/release-preflight.ps1
@@ -1,0 +1,152 @@
+#Requires -Version 5.1
+<##
+.SYNOPSIS
+    Validate the exact, canonical release source selected by CircleCI.
+
+.DESCRIPTION
+    This is deliberately credential-free. It accepts only canonical vX.Y.Z tags,
+    verifies that the checked-out commit and tag resolve to the supplied SHA, and
+    proves the tag commit is reachable from the protected main branch. It also checks
+    every committed project version file before a release build is allowed to run.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Tag = $env:CIRCLE_TAG,
+    [string]$Sha = $env:CIRCLE_SHA1,
+    [string]$RepoRoot = '',
+    [string]$Repository = "nesszer/Win-CodexBar",
+    [string]$MainBranch = "main"
+)
+
+Set-StrictMode -Version Latest
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $PSScriptRoot
+}
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "release-pipeline-common.ps1")
+
+function Invoke-GitCapture {
+    param([Parameter(Mandatory)][string[]]$Arguments)
+
+    $git = Get-Command git -ErrorAction Stop
+    $output = & $git.Source @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE`n$($output | Out-String)"
+    }
+    return ($output | Out-String).Trim()
+}
+
+function Get-CargoPackageVersion {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $line = Get-Content -LiteralPath $Path | Where-Object { $_ -match '^version\s*=\s*"([^"]+)"' } | Select-Object -First 1
+    if (-not $line -or $line -notmatch '^version\s*=\s*"([^"]+)"') {
+        throw "Could not read package version from $Path"
+    }
+    return $Matches[1]
+}
+
+function Get-VersionEnvValue {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $line = Get-Content -LiteralPath $Path | Where-Object { $_ -match '^MARKETING_VERSION=(.+)$' } | Select-Object -First 1
+    if (-not $line -or $line -notmatch '^MARKETING_VERSION=(.+)$') {
+        throw "Could not read MARKETING_VERSION from $Path"
+    }
+    return $Matches[1].Trim()
+}
+
+function Assert-VersionEqual {
+    param([Parameter(Mandatory)][string]$Label, [Parameter(Mandatory)][string]$Actual, [Parameter(Mandatory)][string]$Expected)
+
+    if ($Actual -ne $Expected) {
+        throw "$Label is '$Actual', expected '$Expected'."
+    }
+    Write-Host "[ok] $Label = $Expected"
+}
+
+if (-not (Test-Path -LiteralPath $RepoRoot -PathType Container)) {
+    throw "Repository root does not exist: $RepoRoot"
+}
+if (-not (Test-CanonicalReleaseTag $Tag)) {
+    throw "CircleCI release requires a canonical vX.Y.Z tag; received '$Tag'."
+}
+if ([string]::IsNullOrWhiteSpace($Sha) -or $Sha -notmatch '^[0-9a-fA-F]{40}$') {
+    throw "CircleCI release requires a full 40-character commit SHA; received '$Sha'."
+}
+if ([string]::IsNullOrWhiteSpace($MainBranch) -or $MainBranch -ne 'main') {
+    throw "Release ancestry must be checked against the protected main branch."
+}
+if ($env:CIRCLE_PULL_REQUEST) {
+    throw "Pull-request builds are not release builds."
+}
+if ($env:CIRCLE_BRANCH) {
+    throw "Branch builds are not release builds; CIRCLE_BRANCH was '$env:CIRCLE_BRANCH'."
+}
+
+Push-Location $RepoRoot
+try {
+    $origin = Invoke-GitCapture @('config', '--get', 'remote.origin.url')
+    if ((Normalize-GitHubRepository $origin) -ne (Normalize-GitHubRepository $Repository)) {
+        throw "Remote origin '$origin' is not canonical repository '$Repository'."
+    }
+    Write-Host "[ok] canonical repository: $(Normalize-GitHubRepository $origin)"
+
+    if ($env:CIRCLE_PROJECT_USERNAME -and $env:CIRCLE_PROJECT_REPONAME) {
+        $circleProject = "$($env:CIRCLE_PROJECT_USERNAME)/$($env:CIRCLE_PROJECT_REPONAME)"
+        if ((Normalize-GitHubRepository $circleProject) -ne (Normalize-GitHubRepository $Repository)) {
+            throw "CircleCI project '$circleProject' is not canonical repository '$Repository'."
+        }
+    }
+
+    $head = Invoke-GitCapture @('rev-parse', 'HEAD')
+    if ($head -ne $Sha.ToLowerInvariant()) {
+        throw "Checked-out HEAD '$head' does not equal immutable release SHA '$Sha'."
+    }
+    Write-Host "[ok] HEAD is immutable SHA $Sha"
+
+    $tagSha = Invoke-GitCapture @('rev-parse', '--verify', "$Tag^{commit}")
+    if ($tagSha -ne $Sha.ToLowerInvariant()) {
+        throw "Tag '$Tag' resolves to '$tagSha', not immutable release SHA '$Sha'."
+    }
+    Write-Host "[ok] $Tag resolves to $Sha"
+
+    $remoteMainRef = "refs/remotes/origin/$MainBranch"
+    $git = Get-Command git -ErrorAction Stop
+    $isShallow = Invoke-GitCapture @('rev-parse', '--is-shallow-repository')
+    if ($isShallow -eq 'true') {
+        & $git.Source fetch --quiet --no-tags --unshallow origin 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Could not obtain full history for protected main ancestry validation.'
+        }
+    }
+    & $git.Source fetch --quiet --no-tags --force origin "$MainBranch`:$remoteMainRef" 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not fetch protected origin/$MainBranch for ancestry validation."
+    }
+    $mainSha = Invoke-GitCapture @('rev-parse', "${remoteMainRef}^{commit}")
+    & $git.Source merge-base --is-ancestor $Sha $remoteMainRef 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Release commit $Sha is not reachable from protected origin/$MainBranch ($mainSha)."
+    }
+    Write-Host "[ok] $Sha is reachable from protected origin/$MainBranch ($mainSha)"
+
+    $version = Get-ReleaseVersionFromTag $Tag
+    $versionFiles = [ordered]@{
+        'rust/Cargo.toml' = Get-CargoPackageVersion (Join-Path $RepoRoot 'rust\Cargo.toml')
+        'apps/desktop-tauri/src-tauri/Cargo.toml' = Get-CargoPackageVersion (Join-Path $RepoRoot 'apps\desktop-tauri\src-tauri\Cargo.toml')
+        'apps/desktop-tauri/package.json' = ((Get-Content -Raw -LiteralPath (Join-Path $RepoRoot 'apps\desktop-tauri\package.json') | ConvertFrom-Json).version)
+        'apps/desktop-tauri/src-tauri/tauri.conf.json' = ((Get-Content -Raw -LiteralPath (Join-Path $RepoRoot 'apps\desktop-tauri\src-tauri\tauri.conf.json') | ConvertFrom-Json).version)
+        'version.env' = Get-VersionEnvValue (Join-Path $RepoRoot 'version.env')
+    }
+    foreach ($entry in $versionFiles.GetEnumerator()) {
+        Assert-VersionEqual $entry.Key ([string]$entry.Value) $version
+    }
+
+    Write-Host ""
+    Write-Host "Release preflight passed: $Repository $Tag ($Sha)"
+    Write-Host "RELEASE_VERSION=$version"
+} finally {
+    Pop-Location
+}

--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -32,15 +32,10 @@
     After packaging, run scripts/windows-smoke-install.ps1 against the generated
     installer and uninstall it again.
 
-.PARAMETER UploadRelease
-    GitHub release tag to upload assets to after packaging, for example v0.27.5.
-    Requires the GitHub CLI to be installed and authenticated.
 
 .EXAMPLE
     .\scripts\windows-release-build.ps1 -Ref v0.27.4
 
-.EXAMPLE
-    .\scripts\windows-release-build.ps1 -Ref v0.27.5 -SmokeInstall -UploadRelease v0.27.5
 #>
 
 param(
@@ -49,8 +44,7 @@ param(
     [string]$WorkRoot = "C:\code\Win-CodexBar-release",
     [switch]$RefreshInstallerDependencies,
     [switch]$WarmCacheOnly,
-    [switch]$SmokeInstall,
-    [string]$UploadRelease = ""
+    [switch]$SmokeInstall
 )
 
 Set-StrictMode -Version Latest
@@ -427,23 +421,6 @@ try {
         }
     }
 
-    if ($UploadRelease) {
-        $gh = Require-Command "gh"
-        $assetPaths = @(
-            $installerAsset,
-            "$installerAsset.sha256",
-            $portableExe,
-            "$portableExe.sha256"
-        )
-        foreach ($path in $assetPaths) {
-            if (-not (Test-Path $path)) {
-                throw "Missing upload asset: $path"
-            }
-        }
-
-        Invoke-Native $gh.Source @("release", "view", $UploadRelease)
-        Invoke-Native $gh.Source (@("release", "upload", $UploadRelease) + $assetPaths + @("--clobber"))
-    }
 
     Write-Host ""
     Write-Host "Release assets:"


### PR DESCRIPTION
## Summary

- Adds a tag-only CircleCI hosted Windows release build for canonical `nesszer/Win-CodexBar` tags `vX.Y.Z`; Blacksmith PR/push CI remains primary and unchanged.
- Keeps the build job credential-free with immutable SHA/main reachability preflight, ephemeral WorkRoot, Node 24, pnpm 10.18.1, release doctor, and smoke-capable Windows packaging.
- Adds explicit approval before the restricted-context draft publisher; publishing is idempotent, SHA-256 checked, no-clobber, and never finalizes a release.
- Removes the legacy `UploadRelease`/`--clobber` path and documents ADR 0004 trust boundaries, setup, costs, retries, and rollback.
- Fixes ancestry validation so the tag commit must be reachable from protected `origin/main`, allowing `main` to advance after tag creation.

## Verification

- Real Node 24 / pnpm 10.18.1 Windows build verified the Tauri NSIS EXE and MSI; the release wrapper covers the portable artifact and SHA-256 sidecar path.
- `circleci config validate .circleci/config.yml` passed with the authoritative CircleCI CLI.
- Focused PowerShell tests/parser and manifest/hash safety checks passed.
