### PR TITLE
Fix preflight canonical repository check

### DIFF
--- a/scripts/release-preflight.ps1
+++ b/scripts/release-preflight.ps1
@@ -93,13 +93,6 @@ try {
     }
     Write-Host "[ok] canonical repository: $(Normalize-GitHubRepository $origin)"
 
-    if ($env:CIRCLE_PROJECT_USERNAME -and $env:CIRCLE_PROJECT_REPONAME) {
-        $circleProject = "$($env:CIRCLE_PROJECT_USERNAME)/$($env:CIRCLE_PROJECT_REPONAME)"
-        if ((Normalize-GitHubRepository $circleProject) -ne (Normalize-GitHubRepository $Repository)) {
-            throw "CircleCI project '$circleProject' is not canonical repository '$Repository'."
-        }
-    }
-
     $head = Invoke-GitCapture @('rev-parse', 'HEAD')
     if ($head -ne $Sha.ToLowerInvariant()) {
         throw "Checked-out HEAD '$head' does not equal immutable release SHA '$Sha'."


### PR DESCRIPTION
Validate the canonical repository through git origin; CircleCI's circleci/ project env vars identify the CircleCI org rather than the GitHub org.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->