### PR TITLE
Accept verified Inno compiler when file version is unavailable

### DIFF
--- a/scripts/install-release-prerequisites.ps1
+++ b/scripts/install-release-prerequisites.ps1
@@ -480,7 +480,11 @@ if (-not $iscc) {
 }
 $innoVersion = (Get-Item -LiteralPath $iscc).VersionInfo.FileVersion
 if ($innoVersion -notmatch '^6\.') {
-    throw "Inno Setup 6.x is required; found '$innoVersion'."
+    $compilerHelp = (& $iscc '/?' 2>&1 | Out-String)
+    if ($compilerHelp -notmatch '(?i)Inno Setup 6') {
+        throw "Inno Setup 6.x is required; found '$innoVersion'."
+    }
+    $innoVersion = '6.x (compiler verified)'
 }
 Write-Host "[ok] Inno Setup $innoVersion ($iscc)"
 


### PR DESCRIPTION
CircleCI's Chocolatey Inno Setup compiler can report FileVersion 0.0.0.0; verify the executable's Inno Setup 6 help output instead of rejecting a usable compiler.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->