### PR TITLE
Handle Inno compiler usage output under PowerShell stop mode

### DIFF
--- a/scripts/install-release-prerequisites.ps1
+++ b/scripts/install-release-prerequisites.ps1
@@ -480,8 +480,14 @@ if (-not $iscc) {
 }
 $innoVersion = (Get-Item -LiteralPath $iscc).VersionInfo.FileVersion
 if ($innoVersion -notmatch '^6\.') {
-    $compilerHelp = (& $iscc '/?' 2>&1 | Out-String)
-    if ($compilerHelp -notmatch '(?i)Inno Setup 6') {
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $compilerHelp = (& $iscc '/?' 2>&1 | Out-String)
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    if ($compilerHelp -notmatch '(?i)(Inno Setup 6|Usage:\s+iscc)') {
         throw "Inno Setup 6.x is required; found '$innoVersion'."
     }
     $innoVersion = '6.x (compiler verified)'


### PR DESCRIPTION
Capture ISCC.exe usage output with a temporary non-terminating error preference so Chocolatey's compiler can be validated on the CircleCI Windows image.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->