### PR TITLE
Restore Node tool paths for CircleCI release build

### DIFF
--- a/scripts/install-release-prerequisites.ps1
+++ b/scripts/install-release-prerequisites.ps1
@@ -480,8 +480,14 @@ if (-not $iscc) {
 }
 $innoVersion = (Get-Item -LiteralPath $iscc).VersionInfo.FileVersion
 if ($innoVersion -notmatch '^6\.') {
-    $compilerHelp = (& $iscc '/?' 2>&1 | Out-String)
-    if ($compilerHelp -notmatch '(?i)Inno Setup 6') {
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $compilerHelp = (& $iscc '/?' 2>&1 | Out-String)
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    if ($compilerHelp -notmatch '(?i)(Inno Setup 6|Usage:\s+iscc)') {
         throw "Inno Setup 6.x is required; found '$innoVersion'."
     }
     $innoVersion = '6.x (compiler verified)'

--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -65,10 +65,26 @@ $AssetsDir = Join-Path $WorkRoot "assets"
 $DesktopCargoTargetDir = Join-Path $CacheDir "cargo-target"
 $CliCargoTargetDir = Join-Path $CacheDir "cargo-target-cli"
 
-$UserCargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
-if (Test-Path $UserCargoBin) {
-    $env:Path = "$UserCargoBin;$env:Path"
+function Add-PathIfPresent {
+    param([AllowNull()][string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Container)) {
+        return
+    }
+    if (@($env:Path -split ';') -notcontains $Path) {
+        $env:Path = "$Path;$env:Path"
+    }
 }
+
+$UserCargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
+Add-PathIfPresent $UserCargoBin
+foreach ($nodeRoot in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:LOCALAPPDATA)) {
+    if (-not [string]::IsNullOrWhiteSpace($nodeRoot)) {
+        Add-PathIfPresent (Join-Path $nodeRoot 'nodejs')
+    }
+}
+if ($env:APPDATA) { Add-PathIfPresent (Join-Path $env:APPDATA 'npm') }
+if ($env:LOCALAPPDATA) { Add-PathIfPresent (Join-Path $env:LOCALAPPDATA 'pnpm') }
 
 function Require-Command {
     param([string]$Name)


### PR DESCRIPTION
The prerequisite step runs in a separate shell from the release build. Add standard Node and pnpm shim directories to PATH before windows-release-build.ps1 resolves pnpm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->