### PR TITLE
Persist pnpm shims across CircleCI Windows steps

### DIFF
--- a/scripts/install-release-prerequisites.ps1
+++ b/scripts/install-release-prerequisites.ps1
@@ -444,11 +444,20 @@ if (-not $corepack) {
 if (-not $corepack) {
     throw "Corepack is required with Node $requiredNodeMajor to activate pinned pnpm $expectedPnpm."
 }
+$pnpmShimDir = Join-Path $env:LOCALAPPDATA 'CodexBar\release-toolchain\pnpm'
 if (-not $AssertOnly) {
-    Invoke-Native $corepack @('enable')
+    New-Item -ItemType Directory -Force -Path $pnpmShimDir | Out-Null
+    Invoke-Native $corepack @('enable', '--install-directory', $pnpmShimDir)
+    Add-PrerequisitePath $pnpmShimDir
     Invoke-Native $corepack @('prepare', "pnpm@$expectedPnpm", '--activate')
 }
 $pnpm = Get-CommandPath 'pnpm'
+if (-not $pnpm) {
+    $pnpmCandidate = Join-Path $pnpmShimDir 'pnpm.cmd'
+    if (Test-Path -LiteralPath $pnpmCandidate -PathType Leaf) {
+        $pnpm = $pnpmCandidate
+    }
+}
 if (-not $pnpm) {
     throw "pnpm $expectedPnpm is unavailable after Corepack provisioning."
 }

--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -85,6 +85,7 @@ foreach ($nodeRoot in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:LOCALA
 }
 if ($env:APPDATA) { Add-PathIfPresent (Join-Path $env:APPDATA 'npm') }
 if ($env:LOCALAPPDATA) { Add-PathIfPresent (Join-Path $env:LOCALAPPDATA 'pnpm') }
+if ($env:LOCALAPPDATA) { Add-PathIfPresent (Join-Path $env:LOCALAPPDATA 'CodexBar\release-toolchain\pnpm') }
 
 function Require-Command {
     param([string]$Name)


### PR DESCRIPTION
Install Corepack pnpm shims in a stable per-user toolchain directory and add that directory to the release builder PATH so separate CircleCI steps resolve pnpm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->