### PR TITLE
Tolerate read-only files during release cleanup

### DIFF
--- a/scripts/circleci-release-build.ps1
+++ b/scripts/circleci-release-build.ps1
@@ -80,6 +80,15 @@ try {
     Write-Host "Credential-free release build passed for $Tag ($Sha)."
 } finally {
     if (Test-Path -LiteralPath $workRoot -PathType Container) {
-        [IO.Directory]::Delete($workRoot, $true)
+        foreach ($entry in @(Get-ChildItem -LiteralPath $workRoot -Force -Recurse -ErrorAction SilentlyContinue)) {
+            if ($entry -is [IO.FileInfo]) {
+                try { $entry.IsReadOnly = $false } catch { }
+            }
+        }
+        try {
+            [IO.Directory]::Delete($workRoot, $true)
+        } catch {
+            Write-Warning "Could not remove ephemeral WorkRoot '$workRoot': $($_.Exception.Message)"
+        }
     }
 }


### PR DESCRIPTION
Do not fail the credential-free build when Git pack files in the ephemeral WorkRoot retain read-only attributes; normalize file attributes and warn if cleanup still cannot complete.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->