### PR TITLE
Use a short ephemeral WorkRoot for Windows release builds

### DIFF
--- a/scripts/circleci-release-build.ps1
+++ b/scripts/circleci-release-build.ps1
@@ -57,8 +57,15 @@ if (-not (Test-Path -LiteralPath $RepoRoot -PathType Container)) { throw "Missin
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 Clear-DirectoryContents $OutputDir
 $version = Get-ReleaseVersionFromTag $Tag
-$tempRoot = if ($env:TEMP) { $env:TEMP } else { [IO.Path]::GetTempPath() }
-$workRoot = Join-Path $tempRoot ('win-codexbar-circleci-' + [guid]::NewGuid().ToString('N'))
+$tempRoot = if ($env:USERPROFILE) {
+    Join-Path $env:USERPROFILE 'cb'
+} elseif ($env:TEMP) {
+    Join-Path $env:TEMP 'cb'
+} else {
+    Join-Path ([IO.Path]::GetTempPath()) 'cb'
+}
+New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+$workRoot = Join-Path $tempRoot ('r-' + [guid]::NewGuid().ToString('N'))
 $assetsDir = Join-Path $workRoot 'assets'
 $doctorLog = Join-Path $OutputDir 'release-doctor.log'
 $buildLog = Join-Path $OutputDir 'windows-release-build.log'


### PR DESCRIPTION
Keep the hosted Windows release checkout under a short per-user path so repository fixture paths do not exceed MAX_PATH during Git checkout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->