### PR TITLE
Ignore rustup informational stderr in release builds

### DIFF
--- a/scripts/circleci-release-build.ps1
+++ b/scripts/circleci-release-build.ps1
@@ -57,8 +57,15 @@ if (-not (Test-Path -LiteralPath $RepoRoot -PathType Container)) { throw "Missin
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 Clear-DirectoryContents $OutputDir
 $version = Get-ReleaseVersionFromTag $Tag
-$tempRoot = if ($env:TEMP) { $env:TEMP } else { [IO.Path]::GetTempPath() }
-$workRoot = Join-Path $tempRoot ('win-codexbar-circleci-' + [guid]::NewGuid().ToString('N'))
+$tempRoot = if ($env:USERPROFILE) {
+    Join-Path $env:USERPROFILE 'cb'
+} elseif ($env:TEMP) {
+    Join-Path $env:TEMP 'cb'
+} else {
+    Join-Path ([IO.Path]::GetTempPath()) 'cb'
+}
+New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+$workRoot = Join-Path $tempRoot ('r-' + [guid]::NewGuid().ToString('N'))
 $assetsDir = Join-Path $workRoot 'assets'
 $doctorLog = Join-Path $OutputDir 'release-doctor.log'
 $buildLog = Join-Path $OutputDir 'windows-release-build.log'

--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -103,9 +103,16 @@ function Invoke-Native {
         [string[]]$ArgumentList
     )
 
-    & $FilePath @ArgumentList
-    if ($LASTEXITCODE -ne 0) {
-        throw "$FilePath exited with code $LASTEXITCODE"
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        & $FilePath @ArgumentList 2>&1 | ForEach-Object { Write-Host $_ }
+        $nativeExitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    if ($nativeExitCode -ne 0) {
+        throw "$FilePath exited with code $nativeExitCode"
     }
 }
 
@@ -225,9 +232,16 @@ try {
     }
     if ($env:CARGO_BUILD_TARGET -and $rustup) {
         $toolchain = "stable-x86_64-pc-windows-msvc"
-        & $rustup.Source set auto-self-update disable
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "Warning: rustup auto-self-update disable failed with exit code $LASTEXITCODE"
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Continue'
+            & $rustup.Source set auto-self-update disable 2>&1 | ForEach-Object { Write-Host $_ }
+            $rustupExitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+        if ($rustupExitCode -ne 0) {
+            Write-Host "Warning: rustup auto-self-update disable failed with exit code $rustupExitCode"
         }
         Invoke-Native $rustup.Source @("toolchain", "install", $toolchain, "--profile", "minimal")
         if ($env:CARGO_BUILD_TARGET -ne "x86_64-pc-windows-msvc") {


### PR DESCRIPTION
Rustup emits informational text on stderr while auto-self-update is disabled; capture native output without turning successful commands into PowerShell terminating errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->