### PR TITLE
Fix CircleCI release build output streaming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw "install-release-prerequisites.ps1 failed with exit code $LASTEXITCODE" }
       - run:
           name: Build, smoke-install, and emit verified assets
-          no_output_timeout: 45m
+          no_output_timeout: 60m
           shell: powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass
           command: |
             $ErrorActionPreference = 'Stop'

--- a/scripts/circleci-release-build.ps1
+++ b/scripts/circleci-release-build.ps1
@@ -30,8 +30,14 @@ function Invoke-LoggedPowerShell {
         [Parameter(Mandatory)][string]$LogPath
     )
 
-    & powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $ScriptPath @Arguments *> $LogPath
-    $exitCode = $LASTEXITCODE
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        & powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $ScriptPath @Arguments 2>&1 | Tee-Object -FilePath $LogPath
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
     if ($exitCode -ne 0) {
         Write-Host "--- $LogPath ---"
         if (Test-Path -LiteralPath $LogPath) { Get-Content -LiteralPath $LogPath }


### PR DESCRIPTION
## Summary
- stream credential-free release-build PowerShell output to CircleCI while retaining per-step logs
- tolerate child native stderr while preserving the child exit code
- raise the build step no-output timeout from 45m to 60m

## Validation
- PowerShell parser passed for circleci-release-build.ps1 and release-pipeline-common.ps1
- focused tee helper test passed for stdout/stderr capture and non-zero exit propagation
- circleci config validate .circleci/config.yml passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->