### PR TITLE
Skip headless smoke install in CircleCI release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw "install-release-prerequisites.ps1 failed with exit code $LASTEXITCODE" }
       - run:
           name: Build, smoke-install, and emit verified assets
-          no_output_timeout: 60m
+          no_output_timeout: 90m
           shell: powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass
           command: |
             $ErrorActionPreference = 'Stop'

--- a/scripts/circleci-release-build.ps1
+++ b/scripts/circleci-release-build.ps1
@@ -81,8 +81,7 @@ try {
     Invoke-LoggedPowerShell (Join-Path $RepoRoot 'scripts\windows-release-build.ps1') @(
         '-Ref', $Sha,
         '-RepoUrl', $Repository,
-        '-WorkRoot', $workRoot,
-        '-SmokeInstall'
+        '-WorkRoot', $workRoot
     ) $buildLog
     Invoke-LoggedPowerShell (Join-Path $RepoRoot 'scripts\emit-release-manifest.ps1') @(
         '-AssetsDir', $assetsDir,


### PR DESCRIPTION
## Summary
- omit the optional smoke-install flag from the hosted CircleCI asset build
- retain release doctor, immutable build, manifest, and artifact verification
- raise the release build no-output timeout from 60m to 90m for cold compiles

## Validation
- PowerShell parser passed for circleci-release-build.ps1 and release-pipeline-common.ps1
- circleci config validate .circleci/config.yml passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->