### PR TITLE
Persist release tool PATH for child PowerShell

### DIFF
--- a/scripts/circleci-release-build.ps1
+++ b/scripts/circleci-release-build.ps1
@@ -23,6 +23,25 @@ if ([string]::IsNullOrWhiteSpace($OutputDir)) {
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'release-pipeline-common.ps1')
 
+function Refresh-ChildProcessPath {
+    $pathValues = @(
+        $env:Path
+        [Environment]::GetEnvironmentVariable('Path', 'Machine')
+        [Environment]::GetEnvironmentVariable('Path', 'User')
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    $entries = New-Object System.Collections.Generic.List[string]
+    foreach ($value in $pathValues) {
+        foreach ($entry in ($value -split ';')) {
+            if (-not [string]::IsNullOrWhiteSpace($entry) -and -not $entries.Contains($entry)) {
+                $entries.Add($entry)
+            }
+        }
+    }
+    $env:Path = $entries -join ';'
+}
+
+Refresh-ChildProcessPath
+
 function Invoke-LoggedPowerShell {
     param(
         [Parameter(Mandatory)][string]$ScriptPath,

--- a/scripts/install-release-prerequisites.ps1
+++ b/scripts/install-release-prerequisites.ps1
@@ -105,18 +105,19 @@ function Add-PrerequisitePath {
     if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
         throw "Cannot add missing tool directory to PATH: $Path"
     }
-    $entries = @($env:Path -split ';' | Where-Object { $_ })
-    if ($entries -notcontains $Path) {
+    if (@($env:Path -split ';' | Where-Object { $_ }) -notcontains $Path) {
         $env:Path = "$Path;$env:Path"
     }
-    try {
-        $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-        $userEntries = @($userPath -split ';' | Where-Object { $_ })
-        if ($userEntries -notcontains $Path) {
-            [Environment]::SetEnvironmentVariable('Path', "$Path;$userPath", 'User')
+    foreach ($scope in @('Machine', 'User')) {
+        try {
+            $scopePath = [Environment]::GetEnvironmentVariable('Path', $scope)
+            $scopeEntries = @($scopePath -split ';' | Where-Object { $_ })
+            if ($scopeEntries -notcontains $Path) {
+                [Environment]::SetEnvironmentVariable('Path', "$Path;$scopePath", $scope)
+            }
+        } catch {
+            Write-Warning "Could not persist PATH for $scope scope: $($_.Exception.Message)"
         }
-    } catch {
-        Write-Warning "Could not persist PATH for future processes: $($_.Exception.Message)"
     }
 }
 
@@ -425,6 +426,8 @@ if (-not $nodeInfo) {
     throw "Required command 'node' is still unavailable after provisioning '$nodePackageId'."
 }
 Assert-NodeMajor $nodeInfo.Version $requiredNodeMajor | Out-Null
+$nodeDirectory = Split-Path -Parent $nodeInfo.Path
+Add-PrerequisitePath $nodeDirectory
 Write-Host "[ok] Node $($nodeInfo.Version) (major $requiredNodeMajor)"
 
 $corepack = Get-CommandPath 'corepack'


### PR DESCRIPTION
## Summary
- persist Node and pnpm tool directories to both machine and user PATH when provisioning
- add the resolved Node directory to persistent PATH after MSI, winget, or zip provisioning
- refresh machine/user PATH in the release wrapper before spawning child PowerShell processes

## Validation
- PowerShell parser passed for all changed scripts
- powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/release-pipeline.tests.ps1 passed
- focused child PowerShell PATH inheritance test passed
- circleci config validate .circleci/config.yml passed
- no version files changed