### PR TITLE
Install MSVC target for release toolchain

### DIFF
--- a/scripts/install-release-prerequisites.ps1
+++ b/scripts/install-release-prerequisites.ps1
@@ -481,17 +481,17 @@ if (-not $AssertOnly) {
         throw "$rustup default $toolchain exited with code $LASTEXITCODE"
     }
 }
-$installedTargets = @(& $rustup target list --installed)
+$installedTargets = @(& $rustup target list --installed --toolchain $toolchain)
 if ($LASTEXITCODE -ne 0) {
-    throw "$rustup target list --installed exited with code $LASTEXITCODE"
+    throw "$rustup target list --installed --toolchain $toolchain exited with code $LASTEXITCODE"
 }
 if ($installedTargets -notcontains $target) {
     if ($AssertOnly) {
         throw "Rust target $target is not installed for $toolchain."
     }
-    & $rustup target add $target
+    & $rustup target add $target --toolchain $toolchain
     if ($LASTEXITCODE -ne 0) {
-        throw "$rustup target add $target exited with code $LASTEXITCODE"
+        throw "$rustup target add $target --toolchain $toolchain exited with code $LASTEXITCODE"
     }
 }
 Write-Host "[ok] Rust target $target ($toolchain)"


### PR DESCRIPTION
## Summary
- check the MSVC target under stable-x86_64-pc-windows-msvc explicitly
- add the target with rustup --toolchain instead of the image-selected toolchain
- keep direct rustup invocation and existing default-toolchain setup

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- direct exact-toolchain target smoke check passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->