### PR TITLE
Provision MSVC target in release build context

### DIFF
--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -244,9 +244,19 @@ try {
             Write-Host "Warning: rustup auto-self-update disable failed with exit code $rustupExitCode"
         }
         Invoke-Native $rustup.Source @("toolchain", "install", $toolchain, "--profile", "minimal")
-        if ($env:CARGO_BUILD_TARGET -ne "x86_64-pc-windows-msvc") {
-            Invoke-Native $rustup.Source @("target", "add", $env:CARGO_BUILD_TARGET, "--toolchain", $toolchain)
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Continue'
+            & $rustup.Source target add $env:CARGO_BUILD_TARGET --toolchain $toolchain 2>&1 | ForEach-Object { Write-Host $_ }
+            $rustupExitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
         }
+        if ($rustupExitCode -ne 0) {
+            throw "$($rustup.Source) target add $env:CARGO_BUILD_TARGET --toolchain $toolchain exited with code $rustupExitCode"
+        }
+        $installedRustTargets = @(& $rustup.Source target list --installed --toolchain $toolchain)
+        Write-Host "Rust installed targets ($toolchain): $($installedRustTargets -join ', ')"
         $env:RUSTUP_TOOLCHAIN = $toolchain
     }
     $env:PNPM_HOME = if ($env:PNPM_HOME) { $env:PNPM_HOME } else { Join-Path $CacheDir "pnpm-home" }


### PR DESCRIPTION
## Summary
- add the MSVC target explicitly in windows-release-build.ps1 after toolchain setup
- use the exact stable toolchain and direct rustup invocation in the build process
- log installed targets before Cargo/Tauri compilation

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- direct build-context rustup target add/list smoke check passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->