### PR TITLE
Prefer Rustup cargo in Windows release builds

### DIFF
--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -200,9 +200,17 @@ function Get-ObjdumpImportsWebView2Loader {
 }
 
 $git = Require-Command "git"
+$rustup = Get-Command rustup -ErrorAction SilentlyContinue
+if ($rustup) {
+    $rustupBinDir = Split-Path -Parent $rustup.Source
+    if (@($env:Path -split ';') -notcontains $rustupBinDir) {
+        $env:Path = "$rustupBinDir;$env:Path"
+    }
+}
 $cargo = Require-Command "cargo"
 $pnpm = Require-Command "pnpm"
-$rustup = Get-Command rustup -ErrorAction SilentlyContinue
+Write-Host "Cargo command: $($cargo.Source)"
+Write-Host "Rustc command: $((Get-Command rustc -ErrorAction Stop).Source)"
 
 New-Item -ItemType Directory -Force $WorkRoot, $CacheDir, $DesktopCargoTargetDir, $CliCargoTargetDir, $PnpmStoreDir, $InstallerDepsDir, $AssetsDir | Out-Null
 


### PR DESCRIPTION
## Summary
- prepend the resolved Rustup bin directory before resolving cargo and pnpm
- ensure release Cargo/Rustc use Rustup proxies and the same target sysroot
- log resolved Cargo and Rustc paths for build diagnostics

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- local Rustup proxy PATH precedence smoke check passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->