### PR TITLE
Use user Rustup proxies for release builds

### DIFF
--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -200,15 +200,25 @@ function Get-ObjdumpImportsWebView2Loader {
 }
 
 $git = Require-Command "git"
-$rustup = Get-Command rustup -ErrorAction SilentlyContinue
-if ($rustup) {
-    $rustupBinDir = Split-Path -Parent $rustup.Source
-    if (@($env:Path -split ';') -notcontains $rustupBinDir) {
+$rustupBinCandidates = @()
+if ($env:CARGO_HOME) {
+    $rustupBinCandidates += Join-Path $env:CARGO_HOME 'bin'
+}
+if ($env:USERPROFILE) {
+    $rustupBinCandidates += Join-Path $env:USERPROFILE '.cargo\bin'
+}
+foreach ($rustupBinDir in $rustupBinCandidates) {
+    if ((Test-Path -LiteralPath $rustupBinDir -PathType Container) -and (@($env:Path -split ';') -notcontains $rustupBinDir)) {
         $env:Path = "$rustupBinDir;$env:Path"
     }
 }
+$rustup = Get-Command rustup -ErrorAction SilentlyContinue
+if (-not $rustup) {
+    throw 'rustup is required for Windows release builds.'
+}
 $cargo = Require-Command "cargo"
 $pnpm = Require-Command "pnpm"
+Write-Host "Rustup command: $($rustup.Source)"
 Write-Host "Cargo command: $($cargo.Source)"
 Write-Host "Rustc command: $((Get-Command rustc -ErrorAction Stop).Source)"
 


### PR DESCRIPTION
## Summary
- prepend CARGO_HOME/bin and USERPROFILE/.cargo/bin before resolving Rustup, cargo, and rustc
- fail clearly when rustup is unavailable
- log Rustup, Cargo, and Rustc paths before the build

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- corrected Rustup candidate PATH smoke check passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->