### PR TITLE
Install Rust toolchain before resolving cargo

### DIFF
--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -216,6 +216,14 @@ $rustup = Get-Command rustup -ErrorAction SilentlyContinue
 if (-not $rustup) {
     throw 'rustup is required for Windows release builds.'
 }
+$toolchain = 'stable-x86_64-pc-windows-msvc'
+$target = if ($env:CARGO_BUILD_TARGET) { $env:CARGO_BUILD_TARGET } else { 'x86_64-pc-windows-msvc' }
+Invoke-Native $rustup.Source @('toolchain', 'install', $toolchain, '--profile', 'minimal')
+& $rustup.Source target add $target --toolchain $toolchain 2>&1 | ForEach-Object { Write-Host $_ }
+if ($LASTEXITCODE -ne 0) {
+    throw "$($rustup.Source) target add $target --toolchain $toolchain exited with code $LASTEXITCODE"
+}
+$env:RUSTUP_TOOLCHAIN = $toolchain
 $cargo = Require-Command "cargo"
 $pnpm = Require-Command "pnpm"
 Write-Host "Rustup command: $($rustup.Source)"
@@ -249,7 +257,6 @@ try {
         $env:CARGO_BUILD_TARGET = "x86_64-pc-windows-msvc"
     }
     if ($env:CARGO_BUILD_TARGET -and $rustup) {
-        $toolchain = "stable-x86_64-pc-windows-msvc"
         $previousErrorActionPreference = $ErrorActionPreference
         try {
             $ErrorActionPreference = 'Continue'
@@ -261,21 +268,8 @@ try {
         if ($rustupExitCode -ne 0) {
             Write-Host "Warning: rustup auto-self-update disable failed with exit code $rustupExitCode"
         }
-        Invoke-Native $rustup.Source @("toolchain", "install", $toolchain, "--profile", "minimal")
-        $previousErrorActionPreference = $ErrorActionPreference
-        try {
-            $ErrorActionPreference = 'Continue'
-            & $rustup.Source target add $env:CARGO_BUILD_TARGET --toolchain $toolchain 2>&1 | ForEach-Object { Write-Host $_ }
-            $rustupExitCode = $LASTEXITCODE
-        } finally {
-            $ErrorActionPreference = $previousErrorActionPreference
-        }
-        if ($rustupExitCode -ne 0) {
-            throw "$($rustup.Source) target add $env:CARGO_BUILD_TARGET --toolchain $toolchain exited with code $rustupExitCode"
-        }
         $installedRustTargets = @(& $rustup.Source target list --installed --toolchain $toolchain)
         Write-Host "Rust installed targets ($toolchain): $($installedRustTargets -join ', ')"
-        $env:RUSTUP_TOOLCHAIN = $toolchain
     }
     $env:PNPM_HOME = if ($env:PNPM_HOME) { $env:PNPM_HOME } else { Join-Path $CacheDir "pnpm-home" }
 


### PR DESCRIPTION
## Summary
- install the stable-x86_64-pc-windows-msvc toolchain and add the MSVC target immediately after finding rustup, before resolving cargo/rustc
- this ensures the Rustup proxy shims (cargo.exe, rustc.exe) exist in .cargo\bin before Get-Command cargo resolves, so the build uses the Rustup-managed toolchain instead of Chocolatey's standalone cargo
- simplify the later block to just auto-self-update disable and target-list logging since the toolchain is already installed

## Root cause
The CircleCI Windows image has Chocolatey's standalone cargo/rustc at C:\ProgramData\chocolatey\bin\cargo.exe without the MSVC target sysroot. rustup.exe exists at C:\Users\circleci\.cargo\bin\rustup.exe but cargo.exe/rustc.exe proxy shims are only created after `rustup toolchain install`. Since cargo was resolved before the toolchain was installed, Chocolatey's cargo was used, which cannot find the MSVC target.

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->