### PR TITLE
Disable rustup self-update before toolchain install

### DIFF
--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -216,6 +216,17 @@ $rustup = Get-Command rustup -ErrorAction SilentlyContinue
 if (-not $rustup) {
     throw 'rustup is required for Windows release builds.'
 }
+$previousErrorActionPreference = $ErrorActionPreference
+try {
+    $ErrorActionPreference = 'Continue'
+    & $rustup.Source set auto-self-update disable 2>&1 | ForEach-Object { Write-Host $_ }
+    $rustupExitCode = $LASTEXITCODE
+} finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+}
+if ($rustupExitCode -ne 0) {
+    Write-Host "Warning: rustup auto-self-update disable failed with exit code $rustupExitCode"
+}
 $toolchain = 'stable-x86_64-pc-windows-msvc'
 $target = if ($env:CARGO_BUILD_TARGET) { $env:CARGO_BUILD_TARGET } else { 'x86_64-pc-windows-msvc' }
 Invoke-Native $rustup.Source @('toolchain', 'install', $toolchain, '--profile', 'minimal')
@@ -257,17 +268,6 @@ try {
         $env:CARGO_BUILD_TARGET = "x86_64-pc-windows-msvc"
     }
     if ($env:CARGO_BUILD_TARGET -and $rustup) {
-        $previousErrorActionPreference = $ErrorActionPreference
-        try {
-            $ErrorActionPreference = 'Continue'
-            & $rustup.Source set auto-self-update disable 2>&1 | ForEach-Object { Write-Host $_ }
-            $rustupExitCode = $LASTEXITCODE
-        } finally {
-            $ErrorActionPreference = $previousErrorActionPreference
-        }
-        if ($rustupExitCode -ne 0) {
-            Write-Host "Warning: rustup auto-self-update disable failed with exit code $rustupExitCode"
-        }
         $installedRustTargets = @(& $rustup.Source target list --installed --toolchain $toolchain)
         Write-Host "Rust installed targets ($toolchain): $($installedRustTargets -join ', ')"
     }


### PR DESCRIPTION
## Summary
- move `rustup set auto-self-update disable` before the early `rustup toolchain install` call
- prevents rustup from attempting a self-update during toolchain install, which fails in the restricted CircleCI environment
- remove the duplicate auto-self-update disable from the later build-setup block

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->