### PR TITLE
Use default Rust profile with std library

### DIFF
--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -229,7 +229,7 @@ if ($rustupExitCode -ne 0) {
 }
 $toolchain = 'stable-x86_64-pc-windows-msvc'
 $target = if ($env:CARGO_BUILD_TARGET) { $env:CARGO_BUILD_TARGET } else { 'x86_64-pc-windows-msvc' }
-Invoke-Native $rustup.Source @('toolchain', 'install', $toolchain, '--profile', 'minimal')
+Invoke-Native $rustup.Source @('toolchain', 'install', $toolchain, '--profile', 'default')
 & $rustup.Source target add $target --toolchain $toolchain 2>&1 | ForEach-Object { Write-Host $_ }
 if ($LASTEXITCODE -ne 0) {
     throw "$($rustup.Source) target add $target --toolchain $toolchain exited with code $LASTEXITCODE"

--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -216,6 +216,17 @@ $rustup = Get-Command rustup -ErrorAction SilentlyContinue
 if (-not $rustup) {
     throw 'rustup is required for Windows release builds.'
 }
+$previousErrorActionPreference = $ErrorActionPreference
+try {
+    $ErrorActionPreference = 'Continue'
+    & $rustup.Source set auto-self-update disable 2>&1 | ForEach-Object { Write-Host $_ }
+    $rustupExitCode = $LASTEXITCODE
+} finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+}
+if ($rustupExitCode -ne 0) {
+    Write-Host "Warning: rustup auto-self-update disable failed with exit code $rustupExitCode"
+}
 $toolchain = 'stable-x86_64-pc-windows-msvc'
 $target = if ($env:CARGO_BUILD_TARGET) { $env:CARGO_BUILD_TARGET } else { 'x86_64-pc-windows-msvc' }
 Invoke-Native $rustup.Source @('toolchain', 'install', $toolchain, '--profile', 'minimal')
@@ -257,17 +268,6 @@ try {
         $env:CARGO_BUILD_TARGET = "x86_64-pc-windows-msvc"
     }
     if ($env:CARGO_BUILD_TARGET -and $rustup) {
-        $previousErrorActionPreference = $ErrorActionPreference
-        try {
-            $ErrorActionPreference = 'Continue'
-            & $rustup.Source set auto-self-update disable 2>&1 | ForEach-Object { Write-Host $_ }
-            $rustupExitCode = $LASTEXITCODE
-        } finally {
-            $ErrorActionPreference = $previousErrorActionPreference
-        }
-        if ($rustupExitCode -ne 0) {
-            Write-Host "Warning: rustup auto-self-update disable failed with exit code $rustupExitCode"
-        }
         $installedRustTargets = @(& $rustup.Source target list --installed --toolchain $toolchain)
         Write-Host "Rust installed targets ($toolchain): $($installedRustTargets -join ', ')"
     }


### PR DESCRIPTION
## Summary
- change `rustup toolchain install --profile minimal` to `--profile default`
- the `minimal` profile installs only rustc/cargo but skips `rust-std` (the Rust standard library), causing the build to fail because there is no standard library to link against
- the `default` profile includes `rust-std` for the host target plus rust-docs/rustfmt/clippy

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->