### PR TITLE
Debug cargo/pnpm resolution after toolchain install

### DIFF
--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -235,11 +235,16 @@ if ($LASTEXITCODE -ne 0) {
     throw "$($rustup.Source) target add $target --toolchain $toolchain exited with code $LASTEXITCODE"
 }
 $env:RUSTUP_TOOLCHAIN = $toolchain
+Write-Host "DEBUG: about to resolve cargo"
 $cargo = Require-Command "cargo"
+Write-Host "DEBUG: cargo resolved to $($cargo.Source)"
+Write-Host "DEBUG: about to resolve pnpm"
 $pnpm = Require-Command "pnpm"
+Write-Host "DEBUG: pnpm resolved to $($pnpm.Source)"
 Write-Host "Rustup command: $($rustup.Source)"
 Write-Host "Cargo command: $($cargo.Source)"
 Write-Host "Rustc command: $((Get-Command rustc -ErrorAction Stop).Source)"
+Write-Host "DEBUG: PATH = $env:Path"
 
 New-Item -ItemType Directory -Force $WorkRoot, $CacheDir, $DesktopCargoTargetDir, $CliCargoTargetDir, $PnpmStoreDir, $InstallerDepsDir, $AssetsDir | Out-Null
 


### PR DESCRIPTION
## Summary
- Add debug logging (Write-Host) before and after each `Require-Command` call for cargo and pnpm
- Log the full PATH after toolchain install to diagnose what is available
- The build fails silently after `rustup target add` succeeds but before any cargo/pnpm path logging appears

## Purpose
Diagnostic PR to identify exactly where the script fails after toolchain setup. Will be followed by a fix PR once the failure point is known.

## Validation
- PowerShell parser passed
- release-pipeline.tests.ps1 passed
- circleci config validate passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->