### PR TITLE
Wrap rustup target add in ErrorActionPreference Continue

### DIFF
--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -230,21 +230,23 @@ if ($rustupExitCode -ne 0) {
 $toolchain = 'stable-x86_64-pc-windows-msvc'
 $target = if ($env:CARGO_BUILD_TARGET) { $env:CARGO_BUILD_TARGET } else { 'x86_64-pc-windows-msvc' }
 Invoke-Native $rustup.Source @('toolchain', 'install', $toolchain, '--profile', 'default')
-& $rustup.Source target add $target --toolchain $toolchain 2>&1 | ForEach-Object { Write-Host $_ }
-if ($LASTEXITCODE -ne 0) {
-    throw "$($rustup.Source) target add $target --toolchain $toolchain exited with code $LASTEXITCODE"
+$previousErrorActionPreference = $ErrorActionPreference
+try {
+    $ErrorActionPreference = 'Continue'
+    & $rustup.Source target add $target --toolchain $toolchain 2>&1 | ForEach-Object { Write-Host $_ }
+    $rustupExitCode = $LASTEXITCODE
+} finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+}
+if ($rustupExitCode -ne 0) {
+    throw "$($rustup.Source) target add $target --toolchain $toolchain exited with code $rustupExitCode"
 }
 $env:RUSTUP_TOOLCHAIN = $toolchain
-Write-Host "DEBUG: about to resolve cargo"
 $cargo = Require-Command "cargo"
-Write-Host "DEBUG: cargo resolved to $($cargo.Source)"
-Write-Host "DEBUG: about to resolve pnpm"
 $pnpm = Require-Command "pnpm"
-Write-Host "DEBUG: pnpm resolved to $($pnpm.Source)"
 Write-Host "Rustup command: $($rustup.Source)"
 Write-Host "Cargo command: $($cargo.Source)"
 Write-Host "Rustc command: $((Get-Command rustc -ErrorAction Stop).Source)"
-Write-Host "DEBUG: PATH = $env:Path"
 
 New-Item -ItemType Directory -Force $WorkRoot, $CacheDir, $DesktopCargoTargetDir, $CliCargoTargetDir, $PnpmStoreDir, $InstallerDepsDir, $AssetsDir | Out-Null
 


### PR DESCRIPTION
## Summary
- wrap `rustup target add` call in `try/finally` with `$ErrorActionPreference = 'Continue'`, matching the pattern already used for `rustup set auto-self-update disable`
- remove debug `Write-Host` lines added in PR #314 (they did not appear in CircleCI output because PS 5.1 `Write-Host` bypasses the `2>&1 | Tee-Object` pipeline)

## Root cause
The script sets `$ErrorActionPreference = "Stop"` at the top (line 51). The `rustup target add` call on line 233 ran directly (not via `Invoke-Native`) with `Stop` still active. When `rustup` wrote informational messages to stderr (e.g. `info: component 'rust-std' for target 'x86_64-pc-windows-msvc' is up to date`), PowerShell 5.1 treated the stderr output as an error record and immediately threw — before the `$LASTEXITCODE` check or any subsequent `Write-Host`/`Require-Command` could execute.

The `2>&1` redirect captured the output into the log, but the `Stop` preference threw on the first error record, terminating the script with exit code 1. The throw message was not visible because `Write-Host` output (including the error message path) bypasses the Tee-Object pipeline in PS 5.1.

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->