### PR TITLE
Create rustup proxy shims for cargo/rustc

### DIFF
--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -242,11 +242,21 @@ if ($rustupExitCode -ne 0) {
     throw "$($rustup.Source) target add $target --toolchain $toolchain exited with code $rustupExitCode"
 }
 $env:RUSTUP_TOOLCHAIN = $toolchain
-$cargo = Require-Command "cargo"
+$rustupBinDir = Split-Path -Parent $rustup.Source
+foreach ($proxy in @('cargo', 'rustc', 'rustfmt', 'clippy-driver', 'rls', 'rust-analyzer')) {
+    $proxyPath = Join-Path $rustupBinDir "$proxy.exe"
+    if (-not (Test-Path -LiteralPath $proxyPath)) {
+        Copy-Item -LiteralPath $rustup.Source -Destination $proxyPath -Force
+        Write-Host "Created rustup proxy: $proxyPath"
+    }
+}
+$env:Path = "$rustupBinDir;$env:Path"
+$cargo = Get-Command cargo -ErrorAction Stop
+$rustcCmd = Get-Command rustc -ErrorAction Stop
 $pnpm = Require-Command "pnpm"
 Write-Host "Rustup command: $($rustup.Source)"
 Write-Host "Cargo command: $($cargo.Source)"
-Write-Host "Rustc command: $((Get-Command rustc -ErrorAction Stop).Source)"
+Write-Host "Rustc command: $($rustcCmd.Source)"
 
 New-Item -ItemType Directory -Force $WorkRoot, $CacheDir, $DesktopCargoTargetDir, $CliCargoTargetDir, $PnpmStoreDir, $InstallerDepsDir, $AssetsDir | Out-Null
 


### PR DESCRIPTION
## Summary
- after `rustup toolchain install`, manually create rustup proxy shims (cargo.exe, rustc.exe, etc.) in `.cargo\bin` by copying `rustup.exe`
- prepend the rustup bin dir to PATH so the proxies take precedence over Chocolatey's standalone cargo/rustc
- resolve cargo/rustc via `Get-Command` after proxies are created, instead of `Require-Command` which was finding Chocolatey's cargo

## Root cause
The CircleCI Windows image has Chocolatey's standalone cargo/rustc at `C:\ProgramData\chocolatey\bin\` which lacks the MSVC target sysroot. `rustup.exe` exists at `C:\Users\circleci\.cargo\bin\rustup.exe` but the cargo.exe/rustc.exe proxy shims were never created — `rustup toolchain install` said "unchanged" because the toolchain was already installed by the Chocolatey `rust` package, so it skipped proxy creation. Both the CLI `cargo build` and `pnpm tauri build` (which calls cargo via PATH) used Chocolatey's cargo, causing E0463 "can't find crate for `core`".

Rustup proxy shims are literally copies of `rustup.exe` renamed to `cargo.exe`, `rustc.exe`, etc. When invoked, rustup intercepts and dispatches to the correct toolchain binary. Creating them manually ensures the rustup-managed toolchain (with the MSVC target) is used.

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->