### PR TITLE
Fix CircleCI context name and GH_TOKEN env var case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           shell: powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass
           command: |
             $ErrorActionPreference = 'Stop'
-            if ([string]::IsNullOrWhiteSpace($env:GH_TOKEN)) { throw 'GH_TOKEN is required only in the restricted publisher context.' }
+            $env:GH_TOKEN = if ($env:GH_TOKEN) { $env:GH_TOKEN } elseif ($env:gh_token) { $env:gh_token } else { '' }; if ([string]::IsNullOrWhiteSpace($env:GH_TOKEN)) { throw 'GH_TOKEN is required only in the restricted publisher context.' }
             $root = (Get-Location).Path
             $manifestPath = Join-Path $root 'release-output\release-manifest.json'
             if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) { throw "Missing persisted release manifest: $manifestPath" }
@@ -98,7 +98,7 @@ workflows:
             - release-build
           filters: *release-tag-filter
       - release-publish:
-          context: github-release-publisher
+          context: gh-release-publisher
           requires:
             - release-approval
           filters: *release-tag-filter

--- a/scripts/publish-github-release.ps1
+++ b/scripts/publish-github-release.ps1
@@ -182,6 +182,7 @@ function Assert-ManifestAndAssets {
     Write-Host '[ok] manifest, exact four asset names, SHA-256 values, and sidecars verified before API access'
 }
 
+$env:GH_TOKEN = if ($env:GH_TOKEN) { $env:GH_TOKEN } elseif ($env:gh_token) { $env:gh_token } else { '' }
 if ([string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
     throw 'GH_TOKEN is required and must be provided only by the restricted CircleCI publisher context.'
 }


### PR DESCRIPTION
## Summary
- change `context: github-release-publisher` to `context: gh-release-publisher` in .circleci/config.yml to match the actual context name in CircleCI
- add `gh_token` fallback in both config.yml inline check and publish-github-release.ps1: `$env:GH_TOKEN = if ($env:GH_TOKEN) { $env:GH_TOKEN } elseif ($env:gh_token) { $env:gh_token } else { '' }`

## Problem
The CircleCI context was created as `gh-release-publisher` with env var `gh_token` (lowercase), but config.yml referenced `github-release-publisher` with `GH_TOKEN` (uppercase). Both mismatches would cause the publish job to fail.

## Validation
- circleci config validate .circleci/config.yml passed
- scripts/release-pipeline.tests.ps1 passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->