### PR TITLE
Fix log file filter regex in publish script

### DIFF
--- a/scripts/publish-github-release.ps1
+++ b/scripts/publish-github-release.ps1
@@ -157,7 +157,7 @@ function Assert-ManifestAndAssets {
     }
 
     $publishFiles = @(Get-ChildItem -LiteralPath $AssetsDir -File | Where-Object {
-        $_.Name -ne 'release-manifest.json' -and $_.Name -notmatch '\\.log$'
+        $_.Name -ne 'release-manifest.json' -and $_.Name -notmatch '\.log$'
     } | Select-Object -ExpandProperty Name | Sort-Object)
     if (($publishFiles -join '|') -ne ($expectedNames -join '|')) {
         throw "Persisted bundle contains unexpected publishable files: $($publishFiles -join ', ')."


### PR DESCRIPTION
## Summary
- fix regex in publish-github-release.ps1: change `-notmatch '\\\.log$'` to `-notmatch '\.log$'`
- the double backslash `\\` in a single-quoted PowerShell string becomes the regex `\\` which matches a literal backslash, not a dot — so `.log` files were never excluded from the publishable files check

## Root cause
The publish script filters out `.log` files from the assets directory before comparing against expected release assets. The regex `\.log` (in a single-quoted PS string) becomes `\.log$` as a regex, which matches a literal backslash followed by `.log` — filenames don't contain backslashes, so the filter never matched. The fix uses `.log` which correctly matches files ending in `.log`.

## Validation
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->