### PR TITLE
Fix rustup-init fallback: wrap in ErrorActionPreference Continue

### DIFF
--- a/scripts/install-release-prerequisites.ps1
+++ b/scripts/install-release-prerequisites.ps1
@@ -236,9 +236,16 @@ function Install-PackageWithFallback {
             $rustupInit = Join-Path ([IO.Path]::GetTempPath()) 'rustup-init.exe'
             Invoke-PrerequisiteDownload 'https://win.rustup.rs/x86_64' $rustupInit
             Write-Host 'Installing rustup via official rustup-init.exe'
-            & $rustupInit '-y' '--default-toolchain' 'stable-x86_64-pc-windows-msvc' '--profile' 'default' 2>&1 | ForEach-Object { Write-Host $_ }
-            if ($LASTEXITCODE -ne 0) {
-                throw "rustup-init.exe exited with code $LASTEXITCODE."
+            $previousErrorActionPreference = $ErrorActionPreference
+            try {
+                $ErrorActionPreference = 'Continue'
+                & $rustupInit '-y' '--default-toolchain' 'stable-x86_64-pc-windows-msvc' '--profile' 'default' '--no-modify-path' 2>&1 | ForEach-Object { Write-Host $_ }
+                $rustupInitExit = $LASTEXITCODE
+            } finally {
+                $ErrorActionPreference = $previousErrorActionPreference
+            }
+            if ($rustupInitExit -ne 0) {
+                throw "rustup-init.exe exited with code $rustupInitExit."
             }
             Refresh-PrerequisitePath
             return


### PR DESCRIPTION
## Summary
- wrap rustup-init.exe invocation in `try/finally` with `$ErrorActionPreference = 'Continue'` — the script default is `Stop`, and rustup-init writes warnings to stderr (e.g. "It looks like you have an existing installation of Rust at:") which triggered an immediate throw under `Stop`
- add `--no-modify-path` flag to avoid PATH conflicts with existing Chocolatey Rust installation

## Root cause
Pipeline #35: choco install rustup.install failed (package not found on community feed), then rustup-init.exe fallback triggered but failed because rustup-init wrote a warning to stderr about the existing Rust installation. With `$ErrorActionPreference = Stop` at the script level, the stderr warning was treated as a terminating error, throwing before rustup-init could complete.

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->