### PR TITLE
Add cargo bin to PATH after rustup-init fallback

### DIFF
--- a/scripts/install-release-prerequisites.ps1
+++ b/scripts/install-release-prerequisites.ps1
@@ -247,6 +247,10 @@ function Install-PackageWithFallback {
             if ($rustupInitExit -ne 0) {
                 throw "rustup-init.exe exited with code $rustupInitExit."
             }
+            $cargoBin = Join-Path $env:USERPROFILE '.cargo\bin'
+            if (Test-Path -LiteralPath $cargoBin -PathType Container) {
+                Add-PrerequisitePath $cargoBin
+            }
             Refresh-PrerequisitePath
             return
         } catch {


### PR DESCRIPTION
## Summary
- after rustup-init.exe installs rustup to `~/.cargo/bin`, explicitly add that directory to PATH via `Add-PrerequisitePath` before `Refresh-PrerequisitePath`
- `--no-modify-path` flag (added in PR #320) prevents rustup-init from modifying PATH env vars, so the install directory was never on PATH when `Require-PrerequisiteCommand` checked for `rustup`

## Root cause
Pipeline #36: choco install rustup.install failed 3x (504 Gateway Timeout from Chocolatey community feed). The rustup-init.exe fallback ran but `rustup` was still not found on PATH because `--no-modify-path` prevented the install directory from being added to PATH, and `Refresh-PrerequisitePath` only refreshes from existing Machine+User PATH env vars.

## Validation
- PowerShell parser passed for all release scripts
- scripts/release-pipeline.tests.ps1 passed
- circleci config validate .circleci/config.yml passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->