### PR TITLE
Install GitHub CLI in release-publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,28 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Install GitHub CLI
+          shell: powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass
+          command: |
+            $ErrorActionPreference = 'Stop'
+            $gh = Get-Command gh -ErrorAction SilentlyContinue
+            if ($gh) { Write-Host "gh already installed at $($gh.Source)"; exit 0 }
+            $ghDir = Join-Path $env:LOCALAPPDATA 'gh'
+            New-Item -ItemType Directory -Force -Path $ghDir | Out-Null
+            $zipPath = Join-Path ([IO.Path]::GetTempPath()) 'gh.zip'
+            $apiUri = 'https://api.github.com/repos/cli/cli/releases/latest'
+            $release = Invoke-RestMethod -Uri $apiUri -Headers @{ 'User-Agent' = 'circleci' }
+            $asset = $release.assets | Where-Object { $_.name -match 'windows_amd64\.zip$' } | Select-Object -First 1
+            if (-not $asset) { throw 'Could not find GitHub CLI Windows amd64 zip in latest release' }
+            Write-Host "Downloading $($asset.name)"
+            Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath
+            Expand-Archive -LiteralPath $zipPath -DestinationPath $ghDir -Force
+            $ghExe = Get-ChildItem -Path $ghDir -Recurse -Filter 'gh.exe' | Select-Object -First 1
+            if (-not $ghExe) { throw "gh.exe not found after extracting $zipPath" }
+            $env:Path = "$($ghExe.DirectoryName);$env:Path"
+            [Environment]::SetEnvironmentVariable('Path', $env:Path, 'User')
+            Write-Host "Installed gh at $($ghExe.FullName)"
+      - run:
           name: Upload matching assets to a draft GitHub Release
           shell: powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass
           command: |


### PR DESCRIPTION
## Summary
- add a new Install GitHub CLI step before the upload step in the release-publish job
- downloads the latest gh Windows amd64 zip from GitHub releases, extracts it, and adds it to PATH
- skips installation if gh is already available

## Root cause
The publish script uses gh (GitHub CLI) for all GitHub API operations. The CircleCI Windows runner does not have gh pre-installed.

## Validation
- circleci config validate passed
- release-pipeline.tests.ps1 passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->