### PR TITLE
Persist gh PATH at Machine level for cross-step visibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,13 @@ jobs:
             $ghExe = Get-ChildItem -Path $ghDir -Recurse -Filter 'gh.exe' | Select-Object -First 1
             if (-not $ghExe) { throw "gh.exe not found after extracting $zipPath" }
             $env:Path = "$($ghExe.DirectoryName);$env:Path"
-            [Environment]::SetEnvironmentVariable('Path', $env:Path, 'User')
+            foreach ($scope in @('Machine', 'User')) {
+                $scopePath = [Environment]::GetEnvironmentVariable('Path', $scope)
+                $scopeEntries = @($scopePath -split ';' | Where-Object { $_ })
+                if ($scopeEntries -notcontains $ghExe.DirectoryName) {
+                    [Environment]::SetEnvironmentVariable('Path', "$($ghExe.DirectoryName);$scopePath", $scope)
+                }
+            }
             Write-Host "Installed gh at $($ghExe.FullName)"
       - run:
           name: Upload matching assets to a draft GitHub Release


### PR DESCRIPTION
## Summary
- persist gh install directory to both Machine and User PATH env vars (not just User)
- CircleCI runs each run step as a separate shell process; User-level PATH changes don't propagate to the next step
- Machine-level PATH is picked up by all new processes on the runner

## Root cause
Pipeline #38: gh install step (102) succeeded and installed gh.exe to C:\Users\circleci\AppData\Local\gh\bin\gh.exe. But the publish step (103) could not find gh because the PATH change from the install step did not persist across CircleCI run steps. Setting only User-level PATH was insufficient.

## Validation
- circleci config validate passed
- no version files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/Win-CodexBar/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->