### PR TITLE
Wrap gh API calls in ErrorActionPreference Continue

### DIFF
--- a/scripts/publish-github-release.ps1
+++ b/scripts/publish-github-release.ps1
@@ -35,8 +35,14 @@ function Invoke-GhJson {
     $stdoutPath = [IO.Path]::GetTempFileName()
     $stderrPath = [IO.Path]::GetTempFileName()
     try {
-        & $gh.Source @Arguments 1>$stdoutPath 2>$stderrPath
-        $exitCode = $LASTEXITCODE
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Continue'
+            & $gh.Source @Arguments 1>$stdoutPath 2>$stderrPath
+            $exitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
         if ($exitCode -ne 0) {
             $errorText = Get-Content -Raw -LiteralPath $stderrPath -ErrorAction SilentlyContinue
             throw "gh $($Arguments -join ' ') failed with exit code $($exitCode): $errorText"
@@ -51,10 +57,16 @@ function Invoke-GhJson {
 function Invoke-GhUpload {
     param([Parameter(Mandatory)][string]$Path)
 
-    $gh = Get-Command gh -ErrorAction Stop
-    & $gh.Source release upload $Tag $Path '--repo' $Repository
-    if ($LASTEXITCODE -ne 0) {
-        throw "gh release upload failed for $(Split-Path $Path -Leaf) with exit code $LASTEXITCODE"
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        & $gh.Source release upload $Tag $Path '--repo' $Repository 2>&1 | ForEach-Object { Write-Host $_ }
+        $uploadExitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    if ($uploadExitCode -ne 0) {
+        throw "gh release upload failed for $(Split-Path $Path -Leaf) with exit code $uploadExitCode"
     }
 }
 
@@ -63,8 +75,15 @@ function Get-Release {
     $stdoutPath = [IO.Path]::GetTempFileName()
     $stderrPath = [IO.Path]::GetTempFileName()
     try {
-        & $gh.Source api "repos/$Repository/releases/tags/$Tag" 1>$stdoutPath 2>$stderrPath
-        if ($LASTEXITCODE -eq 0) {
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Continue'
+            & $gh.Source api "repos/$Repository/releases/tags/$Tag" 1>$stdoutPath 2>$stderrPath
+            $ghExitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+        if ($ghExitCode -eq 0) {
             return Get-Content -Raw -LiteralPath $stdoutPath | ConvertFrom-Json
         }
         $errorText = Get-Content -Raw -LiteralPath $stderrPath -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- wrap all gh CLI invocations in Get-Release, Invoke-GhJson, and Invoke-GhUpload with try/finally ErrorActionPreference=Continue
- gh writes errors to stderr (e.g. HTTP 404 when querying a non-existent release); with script-level ErrorActionPreference=Stop, stderr triggers a terminating error before LASTEXITCODE can be checked

## Root cause
Pipeline #40: gh was found and invoked successfully. Get-Release queried repos/nesszer/Win-CodexBar/releases/tags/v0.49.2 and got HTTP 404 (no release exists yet). gh wrote the 404 to stderr, and ErrorActionPreference=Stop threw immediately instead of checking the 404 and returning null to create a new draft release.

## Validation
- release-pipeline.tests.ps1 passed
- circleci config validate passed
- no version files changed