### PR TITLE
fix(publish): define $gh in Invoke-GhUpload

### DIFF
--- a/scripts/publish-github-release.ps1
+++ b/scripts/publish-github-release.ps1
@@ -57,6 +57,7 @@ function Invoke-GhJson {
 function Invoke-GhUpload {
     param([Parameter(Mandatory)][string]$Path)
 
+    $gh = Get-Command gh -ErrorAction Stop
     $previousErrorActionPreference = $ErrorActionPreference
     try {
         $ErrorActionPreference = 'Continue'


### PR DESCRIPTION
## Bug

`Invoke-GhUpload` in `scripts/publish-github-release.ps1` referenced `.Source` (line 63) without ever defining ``. The three sibling functions all define it:

- `Invoke-GhJson` → ` = Get-Command gh -ErrorAction Stop`
- `Get-Release` → ` = Get-Command gh -ErrorAction Stop`
- `Get-RemoteAssetSha256` → ` = Get-Command gh -ErrorAction Stop`

`Invoke-GhUpload` forgot to.

## Impact

Under `Set-StrictMode -Version Latest` (line 21), the publish job throws at the first asset upload:

```
Invoke-GhUpload : The variable '$gh' cannot be retrieved because it has not been set.
```

This broke the `release-publish` CircleCI job for tag v0.49.2.

## Fix

Add the missing ` = Get-Command gh -ErrorAction Stop` at the start of `Invoke-GhUpload`, matching the sibling functions.

Verified: PowerShell parser check passes (`PARSE_OK`).