### PR TITLE
fix(publish): verify release by id after upload, not by tag

### DIFF
--- a/scripts/publish-github-release.ps1
+++ b/scripts/publish-github-release.ps1
@@ -98,6 +98,12 @@ function Get-Release {
     }
 }
 
+function Get-ReleaseById {
+    param([Parameter(Mandatory)][string]$Id)
+
+    return Invoke-GhJson @('api', "repos/$Repository/releases/$Id")
+}
+
 function New-DraftRelease {
     return Invoke-GhJson @(
         'api', '--method', 'POST', "repos/$Repository/releases",
@@ -264,7 +270,7 @@ foreach ($path in $assetPaths) {
         }
         throw
     }
-    $release = Get-Release
+    $release = Get-ReleaseById ([string]$release.id)
     if (-not $release -or -not [bool]$release.draft) {
         throw "Release $Tag disappeared or is no longer draft after uploading $name."
     }


### PR DESCRIPTION
## Bug

After `gh release upload` succeeds, the script re-queried the release by tag (`releases/tags/{tag}`) to confirm it was still a draft. GitHub's API can 404 transiently on the by-tag endpoint immediately after an asset upload (eventual consistency). This caused:

```
Release v0.49.2 disappeared or is no longer draft after uploading CodexBar-0.49.2-Setup.exe.
```

…even though the draft release still existed and the asset uploaded fine.

## Fix

Add `Get-ReleaseById` (`repos/{repo}/releases/{id}`) and use it for the post-upload verification. The release id is already known from the in-progress `` object, so by-id is deterministic and avoids the transient by-tag 404.

Verified: PowerShell parser check passes (`PARSE_OK`).