### PR TITLE
ci: add build caching to release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,15 @@ jobs:
             $root = (Get-Location).Path
             & powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File (Join-Path $root 'scripts\install-release-prerequisites.ps1') -RepoRoot $root
             if ($LASTEXITCODE -ne 0) { throw "install-release-prerequisites.ps1 failed with exit code $LASTEXITCODE" }
+      - restore_cache:
+          name: Restore Cargo registry cache
+          keys:
+            - cargo-registry-{{ checksum "Cargo.lock" }}
+      - restore_cache:
+          name: Restore Cargo target and pnpm store cache
+          keys:
+            - release-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust/Cargo.toml" }}-{{ checksum "apps/desktop-tauri/src-tauri/Cargo.toml" }}
+            - release-cache-{{ checksum "Cargo.lock" }}-
       - run:
           name: Build, smoke-install, and emit verified assets
           no_output_timeout: 90m
@@ -47,6 +56,16 @@ jobs:
             $output = Join-Path $root 'release-output'
             & powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File (Join-Path $root 'scripts\circleci-release-build.ps1') -Tag $env:CIRCLE_TAG -Sha $env:CIRCLE_SHA1 -RepoRoot $root -OutputDir $output
             if ($LASTEXITCODE -ne 0) { throw "circleci-release-build.ps1 failed with exit code $LASTEXITCODE" }
+      - save_cache:
+          name: Save Cargo registry cache
+          key: cargo-registry-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo/registry
+      - save_cache:
+          name: Save Cargo target and pnpm store cache
+          key: release-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust/Cargo.toml" }}-{{ checksum "apps/desktop-tauri/src-tauri/Cargo.toml" }}
+          paths:
+            - ~/cb/release/cache
       - persist_to_workspace:
           root: .
           paths:

--- a/scripts/circleci-release-build.ps1
+++ b/scripts/circleci-release-build.ps1
@@ -82,6 +82,9 @@ if (-not (Test-Path -LiteralPath $RepoRoot -PathType Container)) { throw "Missin
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 Clear-DirectoryContents $OutputDir
 $version = Get-ReleaseVersionFromTag $Tag
+# Use a fixed WorkRoot so the Cargo target and pnpm store caches persist
+# across runs (restored via CircleCI save_cache/restore_cache).  The
+# source checkout inside WorkRoot is cleaned before each build.
 $tempRoot = if ($env:USERPROFILE) {
     Join-Path $env:USERPROFILE 'cb'
 } elseif ($env:TEMP) {
@@ -89,8 +92,7 @@ $tempRoot = if ($env:USERPROFILE) {
 } else {
     Join-Path ([IO.Path]::GetTempPath()) 'cb'
 }
-New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
-$workRoot = Join-Path $tempRoot ('r-' + [guid]::NewGuid().ToString('N'))
+$workRoot = Join-Path $tempRoot 'release'
 $assetsDir = Join-Path $workRoot 'assets'
 $doctorLog = Join-Path $OutputDir 'release-doctor.log'
 $buildLog = Join-Path $OutputDir 'windows-release-build.log'
@@ -110,14 +112,19 @@ try {
     ) (Join-Path $OutputDir 'emit-release-manifest.log')
     Write-Host "Credential-free release build passed for $Tag ($Sha)."
 } finally {
-    if (Test-Path -LiteralPath $workRoot -PathType Container) {
-        foreach ($entry in @(Get-ChildItem -LiteralPath $workRoot -Force -Recurse -ErrorAction SilentlyContinue)) {
-            if ($entry -is [IO.FileInfo]) {
-                try { $entry.IsReadOnly = $false } catch { }
+    # Preserve the cache/ subdirectory (Cargo target + pnpm store) for
+    # the next run; clean only source/ and assets/ which are rebuilt fresh.
+    foreach ($sub in @('source', 'assets')) {
+        $subPath = Join-Path $workRoot $sub
+        if (Test-Path -LiteralPath $subPath -PathType Container) {
+            foreach ($entry in @(Get-ChildItem -LiteralPath $subPath -Force -Recurse -ErrorAction SilentlyContinue)) {
+                if ($entry -is [IO.FileInfo]) {
+                    try { $entry.IsReadOnly = $false } catch { }
+                }
             }
-        }
-        try {
-            [IO.Directory]::Delete($workRoot, $true)
-        } catch { }
+            try {
+                [IO.Directory]::Delete($subPath, $true)
+            } catch { }
         }
     }
+}


### PR DESCRIPTION
## Summary

Add three CircleCI caches to the `release-build` job to speed up builds:

### 1. Cargo registry cache (`~/.cargo/registry`)
- Keyed on `Cargo.lock` checksum
- Saves downloaded crate sources between runs
- Biggest single win — avoids re-downloading all dependencies

### 2. Cargo target cache (`~/cb/release/cache/cargo-target` + `cargo-target-cli`)
- Keyed on `Cargo.lock` + both `Cargo.toml` checksums
- Fallback key `release-cache-{Cargo.lock}-` for partial hits when versions change
- `circleci-release-build.ps1` now uses a fixed WorkRoot (`~/cb/release`) instead of a random GUID
- The `finally` block preserves `cache/` while cleaning only `source/` and `assets/`

### 3. pnpm store cache (`~/cb/release/cache/pnpm-store`)
- Same cache key as cargo target (both live under `~/cb/release/cache`)
- Saves `node_modules` store between runs

### Files changed
- `.circleci/config.yml` — add `restore_cache`/`save_cache` steps
- `scripts/circleci-release-build.ps1` — fixed WorkRoot, preserve cache in finally

### Validation
- `circleci config validate` → valid
- PowerShell parser → `PARSE_OK`