### PR TITLE
docs(adr): update ADR 0004 for compiled-output caching

### DIFF
--- a/docs/adr/0004-circleci-release-trust-boundary.md
+++ b/docs/adr/0004-circleci-release-trust-boundary.md
@@ -20,10 +20,13 @@ boundary: it validates the canonical remote, full immutable tag SHA, protected
 `main` ancestry, and all project version files.
 
 The `release-build` job uses hosted Windows without a GitHub write credential.
-It provisions/asserts pinned-enough prerequisites, uses a fresh temporary
-WorkRoot, runs release-doctor, and invokes `windows-release-build.ps1` with the
-immutable SHA and `-SmokeInstall`. It emits four expected assets, a manifest,
-and logs into a persisted workspace. The builder has no publication path.
+It provisions/asserts pinned-enough prerequisites, uses a fixed WorkRoot
+(`~/cb/release`) with persistent caches (Cargo registry, Cargo target, and
+pnpm store), runs release-doctor, and invokes `windows-release-build.ps1` with
+the immutable SHA and `-SmokeInstall`. The WorkRoot's `cache/` subdirectory
+survives between runs while `source/` and `assets/` are cleaned fresh. It emits
+four expected assets, a manifest, and logs into a persisted workspace. The
+builder has no publication path.
 
 A required CircleCI approval separates build from `release-publish`. Only that
 job receives the project-restricted `github-release-publisher` context with a
@@ -37,7 +40,8 @@ on a digest mismatch, and never clobbers or finalizes a release.
 - **Blacksmith Actions:** primary PR/push validation; unchanged permissions and
   runner responsibilities.
 - **CircleCI build:** untrusted/reproducible packaging boundary; no GitHub write
-  secret, no release API calls, immutable source, temporary WorkRoot.
+  secret, no release API calls, immutable source, fixed WorkRoot with
+  persistent build caches (see "Compiled-output caching" below).
 - **Human approval:** reviews persisted manifest/logs before publication.
 - **CircleCI publisher context:** sole release write capability; draft-only,
   hash-safe, idempotent publisher.
@@ -53,3 +57,37 @@ on a digest mismatch, and never clobbers or finalizes a release.
 - Final release publication remains a deliberate GitHub action.
 - CircleCI project/context creation, token storage, tag rulesets, and billing
   alerts remain manual administrator setup.
+
+## Compiled-output caching
+
+The initial design avoided persistent compiled-output caches for OSS fork
+safety: a random GUID-based WorkRoot was created and deleted per run, ensuring
+no state carried between builds. This is now **superseded** — the pipeline
+enables Cargo registry, Cargo target, and pnpm store caching via CircleCI
+`save_cache`/`restore_cache` and a fixed WorkRoot (`~/cb/release`).
+
+### What is cached
+
+1. **Cargo registry** (`~/.cargo/registry`) — downloaded crate sources, keyed
+   on `Cargo.lock` checksum.
+2. **Cargo target** (`~/cb/release/cache/cargo-target` +
+   `cargo-target-cli`) — compiled build artifacts, keyed on `Cargo.lock` +
+   both `Cargo.toml` checksums, with a partial-match fallback key.
+3. **pnpm store** (`~/cb/release/cache/pnpm-store`) — content-addressable
+   node_modules store, cached alongside the cargo target under the same key.
+
+### Why it is safe
+
+- **Tag-only pipeline:** the workflow filters accept only `vX.Y.Z` semver tags
+  and ignore all branches. A fork cannot trigger the pipeline because pushes
+  to a fork do not create tags in the canonical repo.
+- **Protected tags:** the `v*` tag namespace is governed by a GitHub ruleset
+  that restricts tag creation to administrators.
+- **Preflight validation:** `release-preflight.ps1` validates the canonical
+  remote (`git origin`), immutable tag-to-SHA identity, and `main` ancestry
+  before any build step runs.
+- **Cache-key sensitivity:** the cache key includes `Cargo.lock` and both
+  `Cargo.toml` checksums, so a different dependency set or version bump
+  produces a cache miss rather than a stale-artifact build.
+- **No poisoning surface:** cache poisoning from a fork is not possible
+  because forks cannot trigger the tag-only pipeline or create protected tags.


### PR DESCRIPTION
Update ADR 0004 to document the decision change from cache avoidance to compiled-output caching.

## Changes

- **Decision section**: updated from "fresh temporary WorkRoot" to "fixed WorkRoot with persistent caches"; describes cache/ surviving between runs while source/ and assets/ are cleaned fresh.
- **Trust boundaries**: updated CircleCI build line from "temporary WorkRoot" to "fixed WorkRoot with persistent build caches" with cross-reference to the new section.
- **New section: Compiled-output caching**: documents what is cached (cargo registry, cargo target, pnpm store) and why it is safe (tag-only pipeline, protected tags, preflight validation, cache-key sensitivity, no poisoning surface).

## Why

PR #329 added CircleCI save_cache/restore_cache for cargo registry, cargo target, and pnpm store. The original ADR said the design avoided persistent caches for OSS fork safety. This ADR update supersedes that decision with the mitigations that make caching safe.