### PR TITLE
fix(claude): prefer limits[] session over stale five_hour after 5h rollover

### DIFF
--- a/rust/src/providers/claude/oauth/mod.rs
+++ b/rust/src/providers/claude/oauth/mod.rs
@@ -502,11 +502,18 @@ impl ClaudeOAuthFetcher {
         credentials: &ClaudeOAuthCredentials,
         show_routines: bool,
     ) -> UsageSnapshot {
-        // Primary: 5-hour session window
-        let primary = response
-            .five_hour
-            .as_ref()
-            .and_then(|w| Self::to_rate_window(w, Some(300)))
+        // Primary: prefer limits[] session over legacy five_hour (mirrors the
+        // weekly lane preferring weekly_all over seven_day). A stale
+        // five_hour.utilization can transiently report 1.0 (100%) right after
+        // a window rollover while the limits[] entry already reflects the
+        // fresh value (#279, same bug class as #210).
+        let primary = super::scoped_weekly::session_window(&response.limits)
+            .or_else(|| {
+                response
+                    .five_hour
+                    .as_ref()
+                    .and_then(|w| Self::to_rate_window(w, Some(300)))
+            })
             .unwrap_or_else(|| RateWindow::new(0.0));
 
         let mut usage = UsageSnapshot::new(primary);
@@ -801,6 +808,82 @@ mod tests {
             .find(|w| w.title.contains("Fable"))
             .expect("Fable only window");
         assert!((fable.window.used_percent - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn issue_279_session_limits_win_over_stale_five_hour_after_rollover() {
+        // Right after a 5h window rollover the legacy five_hour.utilization
+        // can transiently report 1.0 (normalizes to 100%) even though
+        // claude.ai shows only 5% for the fresh window. The limits[] entry
+        // (kind=="session") carries the true value and must win.
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": 1.0, "resets_at": "2026-08-13T12:49:59.578826Z"},
+                "seven_day": {"utilization": 0.01, "resets_at": "2026-07-26T22:59:59Z"},
+                "limits": [
+                    {
+                        "kind": "session",
+                        "group": "session",
+                        "percent": 5,
+                        "resets_at": "2026-08-13T12:49:59.578826Z"
+                    },
+                    {
+                        "kind": "weekly_all",
+                        "group": "weekly",
+                        "percent": 1,
+                        "resets_at": "2026-07-26T22:59:59Z"
+                    }
+                ]
+            }"#,
+        )
+        .expect("issue 279 body");
+
+        let credentials = ClaudeOAuthCredentials {
+            access_token: "token".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            scopes: vec![],
+            rate_limit_tier: Some("default_claude_max_5x".to_string()),
+        };
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &credentials);
+
+        // Primary session must be 5%, not the stale 100%.
+        assert!(
+            (usage.primary.used_percent - 5.0).abs() < f64::EPSILON,
+            "primary was {}, expected 5% (not 100%)",
+            usage.primary.used_percent
+        );
+        assert!((usage.primary.used_percent - 100.0).abs() > 1.0);
+        assert_eq!(usage.primary.window_minutes, Some(300));
+        assert!(usage.primary.resets_at.is_some());
+
+        // Weekly lane is unaffected (still prefers limits weekly_all).
+        let weekly = usage.secondary.expect("weekly");
+        assert!((weekly.used_percent - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn session_falls_back_to_legacy_five_hour_without_limits_entry() {
+        // When no limits[] session entry exists, the legacy five_hour field
+        // is still the source of truth (backwards compatible).
+        let response: OAuthUsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": 10.0, "resets_at": "2026-08-13T12:49:59Z"}
+            }"#,
+        )
+        .expect("legacy-only body");
+
+        let credentials = ClaudeOAuthCredentials {
+            access_token: "token".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            scopes: vec![],
+            rate_limit_tier: None,
+        };
+        let usage = ClaudeOAuthFetcher::new().build_usage_snapshot(&response, &credentials);
+
+        assert!((usage.primary.used_percent - 10.0).abs() < f64::EPSILON);
+        assert_eq!(usage.primary.window_minutes, Some(300));
     }
 
     #[test]

--- a/rust/src/providers/claude/scoped_weekly.rs
+++ b/rust/src/providers/claude/scoped_weekly.rs
@@ -88,6 +88,30 @@ pub(super) fn weekly_all_window(limits: &[ScopedWeeklyLimit]) -> Option<RateWind
     })
 }
 
+/// 5-hour session window from `limits[]` (`kind == "session"`).
+///
+/// Prefer this over legacy `five_hour.utilization` when Anthropic migrates
+/// the session total into the limits array (avoids phantom 100% from a stale
+/// field right after a window rollover — same bug class as #210/#279).
+pub(super) fn session_window(limits: &[ScopedWeeklyLimit]) -> Option<RateWindow> {
+    limits.iter().find_map(|limit| {
+        if limit.kind.as_deref()? != "session" {
+            return None;
+        }
+        if limit.group.as_deref().is_some_and(|g| g != "session") {
+            return None;
+        }
+        let percent = limit.percent.filter(|value| value.is_finite())?;
+        let resets_at = limit_resets_at(limit);
+        Some(RateWindow::with_details(
+            percent.clamp(0.0, 100.0),
+            Some(5 * 60),
+            resets_at,
+            None,
+        ))
+    })
+}
+
 fn limit_resets_at(limit: &ScopedWeeklyLimit) -> Option<DateTime<Utc>> {
     limit
         .resets_at
@@ -149,5 +173,49 @@ mod tests {
         let scoped = scoped_weekly_windows(&limits);
         assert_eq!(scoped.len(), 1);
         assert!((scoped[0].window.used_percent - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn session_window_prefers_limits_percent_over_stale_five_hour() {
+        // Mirrors issue #279: right after a 5h window rollover the legacy
+        // five_hour.utilization can transiently report 1.0 (would normalize
+        // to 100%), while the limits[] entry already carries the fresh 5%.
+        let limits: Vec<ScopedWeeklyLimit> = serde_json::from_str(
+            r#"[
+                {"kind":"session","group":"session","percent":5,"resets_at":"2026-08-13T12:49:59Z"},
+                {"kind":"weekly_all","group":"weekly","percent":1,"resets_at":"2026-07-26T22:59:59Z"}
+            ]"#,
+        )
+        .unwrap();
+
+        let session = session_window(&limits).expect("session window");
+        assert!((session.used_percent - 5.0).abs() < f64::EPSILON);
+        assert_eq!(session.window_minutes, Some(5 * 60));
+        assert!(session.resets_at.is_some());
+
+        // weekly_all is unaffected.
+        let weekly = weekly_all_window(&limits).expect("weekly_all");
+        assert!((weekly.used_percent - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn session_window_ignores_mismatched_group_and_null_percent() {
+        let limits: Vec<ScopedWeeklyLimit> = serde_json::from_str(
+            r#"[
+                {"kind":"session","group":"weekly","percent":42},
+                {"kind":"weekly_scoped","group":"session","percent":7,"scope":{"model":{"display_name":"Fable"}}},
+                {"kind":"session","group":"session","percent":null}
+            ]"#,
+        )
+        .unwrap();
+
+        // No qualifying session/session entry with a finite percent -> None.
+        assert!(session_window(&limits).is_none());
+
+        // A valid session/session entry wins.
+        let valid: Vec<ScopedWeeklyLimit> =
+            serde_json::from_str(r#"[{"kind":"session","group":"session","percent":12}]"#).unwrap();
+        let session = session_window(&valid).expect("session window");
+        assert!((session.used_percent - 12.0).abs() < f64::EPSILON);
     }
 }

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -310,13 +310,19 @@ impl ClaudeWebApiFetcher {
         // Step 4: Fetch account info - optional
         let account = self.get_account_info(&headers).await.ok();
 
-        // Build the result. When five_hour is null (enterprise/credit accounts with no live
-        // session), emit a fixed 5h 0% placeholder and mark it informational so notifications
-        // and automatic metrics can skip the phantom session lane.
-        let primary = usage
-            .five_hour
-            .as_ref()
-            .map(|w| self.to_rate_window(w, Some(300))) // 5 hours = 300 minutes
+        // Prefer limits[] session over legacy five_hour (mirrors the weekly
+        // lane preferring weekly_all over seven_day). A stale
+        // five_hour.utilization can transiently report 1.0 (100%) right after
+        // a window rollover while the limits[] entry already reflects the
+        // fresh value (#279, same bug class as #210). When both are absent,
+        // fall back to the informational 5h placeholder below.
+        let primary = super::scoped_weekly::session_window(&usage.limits)
+            .or_else(|| {
+                usage
+                    .five_hour
+                    .as_ref()
+                    .map(|w| self.to_rate_window(w, Some(300))) // 5 hours = 300 minutes
+            })
             .unwrap_or_else(RateWindow::no_active_session);
 
         // Prefer limits[] weekly_all over legacy seven_day (same as OAuth path).
@@ -1022,6 +1028,94 @@ mod tests {
         assert_eq!(extra.is_enabled, Some(true));
         assert_eq!(extra.monthly_credit_limit, Some(2000.0));
         assert_eq!(extra.used_credits, Some(550.0));
+    }
+
+    #[test]
+    fn issue_279_session_limits_win_over_stale_five_hour_after_rollover() {
+        // Right after a 5h window rollover the legacy five_hour.utilization
+        // can transiently report 1.0 (normalizes to 100%) even though
+        // claude.ai shows only 5% for the fresh window. The limits[] entry
+        // (kind=="session") carries the true value and must win. This mirrors
+        // the web_api primary-building chain in fetch_with_cookie_header.
+        let usage: super::UsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": 1.0, "resets_at": "2026-08-13T12:49:59.578826Z"},
+                "seven_day": {"utilization": 0.01, "resets_at": "2026-07-26T22:59:59Z"},
+                "limits": [
+                    {
+                        "kind": "session",
+                        "group": "session",
+                        "percent": 5,
+                        "resets_at": "2026-08-13T12:49:59.578826Z"
+                    },
+                    {
+                        "kind": "weekly_all",
+                        "group": "weekly",
+                        "percent": 1,
+                        "resets_at": "2026-07-26T22:59:59Z"
+                    }
+                ]
+            }"#,
+        )
+        .expect("issue 279 body");
+
+        let fetcher = ClaudeWebApiFetcher::new();
+
+        // Reproduce the exact primary preference chain from production:
+        // limits[] session → legacy five_hour → informational placeholder.
+        let primary = super::super::scoped_weekly::session_window(&usage.limits)
+            .or_else(|| {
+                usage
+                    .five_hour
+                    .as_ref()
+                    .map(|w| fetcher.to_rate_window(w, Some(300)))
+            })
+            .unwrap_or_else(crate::core::RateWindow::no_active_session);
+
+        assert!(
+            (primary.used_percent - 5.0).abs() < f64::EPSILON,
+            "primary was {}, expected 5% (not 100%)",
+            primary.used_percent
+        );
+        assert!((primary.used_percent - 100.0).abs() > 1.0);
+        assert_eq!(primary.window_minutes, Some(300));
+        assert!(primary.resets_at.is_some());
+
+        // Weekly lane is unaffected (still prefers limits weekly_all).
+        let weekly = super::super::scoped_weekly::weekly_all_window(&usage.limits)
+            .or_else(|| {
+                usage
+                    .seven_day
+                    .as_ref()
+                    .map(|w| fetcher.to_rate_window(w, Some(10080)))
+            })
+            .expect("weekly");
+        assert!((weekly.used_percent - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn session_falls_back_to_legacy_five_hour_without_limits_entry() {
+        // When no limits[] session entry exists, the legacy five_hour field
+        // is still the source of truth (backwards compatible).
+        let usage: super::UsageResponse = serde_json::from_str(
+            r#"{
+                "five_hour": {"utilization": 10.0, "resets_at": "2026-08-13T12:49:59Z"}
+            }"#,
+        )
+        .expect("legacy-only body");
+
+        let fetcher = ClaudeWebApiFetcher::new();
+        let primary = super::super::scoped_weekly::session_window(&usage.limits)
+            .or_else(|| {
+                usage
+                    .five_hour
+                    .as_ref()
+                    .map(|w| fetcher.to_rate_window(w, Some(300)))
+            })
+            .unwrap_or_else(crate::core::RateWindow::no_active_session);
+
+        assert!((primary.used_percent - 10.0).abs() < f64::EPSILON);
+        assert_eq!(primary.window_minutes, Some(300));
     }
 
     #[test]

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -310,33 +310,7 @@ impl ClaudeWebApiFetcher {
         // Step 4: Fetch account info - optional
         let account = self.get_account_info(&headers).await.ok();
 
-        // Prefer limits[] session over legacy five_hour (mirrors the weekly
-        // lane preferring weekly_all over seven_day). A stale
-        // five_hour.utilization can transiently report 1.0 (100%) right after
-        // a window rollover while the limits[] entry already reflects the
-        // fresh value (#279, same bug class as #210). When both are absent,
-        // fall back to the informational 5h placeholder below.
-        let primary = super::scoped_weekly::session_window(&usage.limits)
-            .or_else(|| {
-                usage
-                    .five_hour
-                    .as_ref()
-                    .map(|w| self.to_rate_window(w, Some(300))) // 5 hours = 300 minutes
-            })
-            .unwrap_or_else(RateWindow::no_active_session);
-
-        // Prefer limits[] weekly_all over legacy seven_day (same as OAuth path).
-        let secondary = super::scoped_weekly::weekly_all_window(&usage.limits).or_else(|| {
-            usage
-                .seven_day
-                .as_ref()
-                .map(|w| self.to_rate_window(w, Some(10080))) // 7 days = 10080 minutes
-        });
-
-        let model_specific = usage
-            .seven_day_opus
-            .as_ref()
-            .map(|w| self.to_rate_window(w, Some(10080)));
+        let (primary, secondary, model_specific) = self.build_rate_windows(&usage);
 
         let mut snapshot = UsageSnapshot::new(primary);
 
@@ -627,6 +601,47 @@ impl ClaudeWebApiFetcher {
         let reset_description = resets_at.map(Self::format_reset_time);
 
         RateWindow::with_details(used_percent, window_minutes, resets_at, reset_description)
+    }
+
+    /// Build (primary, secondary, model_specific) rate windows from a usage
+    /// response, applying the limits[]-over-legacy preference chain.
+    ///
+    /// Extracted so the exact chain tested in `issue_279_session_limits_win_*`
+    /// and `session_falls_back_*` is the same code production runs — no
+    /// duplicated inline copy in tests can silently drift.
+    fn build_rate_windows(
+        &self,
+        usage: &UsageResponse,
+    ) -> (RateWindow, Option<RateWindow>, Option<RateWindow>) {
+        // Prefer limits[] session over legacy five_hour (mirrors the weekly
+        // lane preferring weekly_all over seven_day). A stale
+        // five_hour.utilization can transiently report 1.0 (100%) right after
+        // a window rollover while the limits[] entry already reflects the
+        // fresh value (#279, same bug class as #210). When both are absent,
+        // fall back to the informational 5h placeholder below.
+        let primary = super::scoped_weekly::session_window(&usage.limits)
+            .or_else(|| {
+                usage
+                    .five_hour
+                    .as_ref()
+                    .map(|w| self.to_rate_window(w, Some(300))) // 5 hours = 300 minutes
+            })
+            .unwrap_or_else(RateWindow::no_active_session);
+
+        // Prefer limits[] weekly_all over legacy seven_day (same as OAuth path).
+        let secondary = super::scoped_weekly::weekly_all_window(&usage.limits).or_else(|| {
+            usage
+                .seven_day
+                .as_ref()
+                .map(|w| self.to_rate_window(w, Some(10080))) // 7 days = 10080 minutes
+        });
+
+        let model_specific = usage
+            .seven_day_opus
+            .as_ref()
+            .map(|w| self.to_rate_window(w, Some(10080)));
+
+        (primary, secondary, model_specific)
     }
 
     /// Parse ISO8601 date string
@@ -1035,8 +1050,7 @@ mod tests {
         // Right after a 5h window rollover the legacy five_hour.utilization
         // can transiently report 1.0 (normalizes to 100%) even though
         // claude.ai shows only 5% for the fresh window. The limits[] entry
-        // (kind=="session") carries the true value and must win. This mirrors
-        // the web_api primary-building chain in fetch_with_cookie_header.
+        // (kind=="session") carries the true value and must win.
         let usage: super::UsageResponse = serde_json::from_str(
             r#"{
                 "five_hour": {"utilization": 1.0, "resets_at": "2026-08-13T12:49:59.578826Z"},
@@ -1060,18 +1074,9 @@ mod tests {
         .expect("issue 279 body");
 
         let fetcher = ClaudeWebApiFetcher::new();
+        let (primary, secondary, _) = fetcher.build_rate_windows(&usage);
 
-        // Reproduce the exact primary preference chain from production:
-        // limits[] session → legacy five_hour → informational placeholder.
-        let primary = super::super::scoped_weekly::session_window(&usage.limits)
-            .or_else(|| {
-                usage
-                    .five_hour
-                    .as_ref()
-                    .map(|w| fetcher.to_rate_window(w, Some(300)))
-            })
-            .unwrap_or_else(crate::core::RateWindow::no_active_session);
-
+        // Primary session must be 5%, not the stale 100%.
         assert!(
             (primary.used_percent - 5.0).abs() < f64::EPSILON,
             "primary was {}, expected 5% (not 100%)",
@@ -1082,14 +1087,7 @@ mod tests {
         assert!(primary.resets_at.is_some());
 
         // Weekly lane is unaffected (still prefers limits weekly_all).
-        let weekly = super::super::scoped_weekly::weekly_all_window(&usage.limits)
-            .or_else(|| {
-                usage
-                    .seven_day
-                    .as_ref()
-                    .map(|w| fetcher.to_rate_window(w, Some(10080)))
-            })
-            .expect("weekly");
+        let weekly = secondary.expect("weekly");
         assert!((weekly.used_percent - 1.0).abs() < f64::EPSILON);
     }
 
@@ -1105,14 +1103,7 @@ mod tests {
         .expect("legacy-only body");
 
         let fetcher = ClaudeWebApiFetcher::new();
-        let primary = super::super::scoped_weekly::session_window(&usage.limits)
-            .or_else(|| {
-                usage
-                    .five_hour
-                    .as_ref()
-                    .map(|w| fetcher.to_rate_window(w, Some(300)))
-            })
-            .unwrap_or_else(crate::core::RateWindow::no_active_session);
+        let (primary, _, _) = fetcher.build_rate_windows(&usage);
 
         assert!((primary.used_percent - 10.0).abs() < f64::EPSILON);
         assert_eq!(primary.window_minutes, Some(300));


### PR DESCRIPTION
## Summary

Fixes #279.

After a session (5h) window resets, the legacy `five_hour.utilization` field can transiently report `1.0` (normalized to `100%`) for the new window, even though claude.ai shows only `5%`. This is the **same bug class as #210**, which was fixed for the weekly/all-models lane in 0.48.0 by preferring the `limits[]` `weekly_all` entry over legacy `seven_day.utilization`.

This PR applies the identical pattern to the **session (5h) lane**, in both the OAuth and web API paths.

### Root cause
Right after a window rollover, Anthropic leaves the legacy `five_hour.utilization` field stale (reporting `1.0` → `100%`) while the `limits[]` array already carries the fresh value as an entry with `kind == "session"`, `group == "session"`. The legacy field was read directly, so the stale `100%` won transiently until the legacy field caught up.

### Fix
- **`scoped_weekly.rs`**: add `session_window(limits)` — reads the 5h session window from the `limits[]` array (`kind == "session"`, `group == "session"`), mirroring `weekly_all_window`.
- **`web_api.rs`**: the primary lane now prefers `session_window(&usage.limits)` over legacy `five_hour`, falling back to the legacy field, then the informational 5h placeholder.
- **`oauth/mod.rs`**: the primary lane now prefers `session_window(&response.limits)` over legacy `five_hour`, falling back to the legacy field, then `0%`.

Provider-specific logic stays inside `rust/src/providers/claude/` (no cross-provider branching). No secrets/tokens are logged.

### Backwards compatible
When no `limits[]` session entry is present (older API shape), the legacy `five_hour` field is still the source of truth — verified by a dedicated fallback test in each path.

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml` — 1220 passed, 0 failed
- [x] `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New unit tests reproduce the transient-100% scenario and assert the limits[] value (5%) wins over the stale legacy field (100%):
  - `scoped_weekly::tests::session_window_prefers_limits_percent_over_stale_five_hour`
  - `scoped_weekly::tests::session_window_ignores_mismatched_group_and_null_percent`
  - `web_api::tests::issue_279_session_limits_win_over_stale_five_hour_after_rollover`
  - `web_api::tests::session_falls_back_to_legacy_five_hour_without_limits_entry`
  - `oauth::tests::issue_279_session_limits_win_over_stale_five_hour_after_rollover`
  - `oauth::tests::session_falls_back_to_legacy_five_hour_without_limits_entry`

No UI/tray/float-bar behavior changed; no CUA proof needed (backend parser fix only).

Fixes #279.