### PR TITLE
Fix missing light theme toggle in Settings

### DIFF
--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.test.tsx
@@ -299,3 +299,33 @@ describe("GeneralTab language picker", () => {
     expect(set).toHaveBeenLastCalledWith({ providerUsageThresholds: {} });
   });
 });
+
+
+  it("renders the theme picker with auto/light/dark options in general mode", () => {
+    render(<GeneralTab settings={settings} set={vi.fn()} saving={false} />);
+
+    const select = screen.getByRole("combobox", { name: "ThemeLabel" });
+    expect(select).toBeInTheDocument();
+    expect(select.querySelectorAll("option")).toHaveLength(3);
+    expect(select.querySelector('option[value="light"]')).not.toBeNull();
+    expect(select.querySelector('option[value="dark"]')).not.toBeNull();
+    expect(select.querySelector('option[value="auto"]')).not.toBeNull();
+  });
+
+  it("persists a light theme choice via updateSettings", () => {
+    const set = vi.fn();
+    render(<GeneralTab settings={settings} set={set} saving={false} />);
+
+    const select = screen.getByRole("combobox", { name: "ThemeLabel" });
+    fireEvent.change(select, { target: { value: "light" } });
+
+    expect(set).toHaveBeenCalledWith({ theme: "light" });
+  });
+
+  it("does not render the theme picker in notifications mode", () => {
+    render(
+      <GeneralTab mode="notifications" settings={settings} set={vi.fn()} saving={false} />,
+    );
+
+    expect(screen.queryByRole("combobox", { name: "ThemeLabel" })).toBeNull();
+  });

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/GeneralTab.tsx
@@ -10,6 +10,7 @@ import type {
   NotificationSoundEvent,
   NotificationSoundPaths,
   NotificationSoundTheme,
+  ThemePreference,
   UsageThresholdOverride,
 } from "../../../types/bridge";
 import type { LocaleKey } from "../../../i18n/keys";
@@ -98,6 +99,13 @@ const NOTIFICATION_SOUND_EVENTS: {
 
 const NOTIFICATION_SOUND_THEME_SELECT_MIN_WIDTH = 180;
 const NOTIFICATION_SOUND_PREVIEW_DURATION_MS = 1500;
+
+
+const THEME_OPTIONS: { value: ThemePreference; labelKey: LocaleKey }[] = [
+  { value: "auto", labelKey: "ThemeAutoOption" },
+  { value: "light", labelKey: "ThemeLightOption" },
+  { value: "dark", labelKey: "ThemeDarkOption" },
+]
 
 function fileName(path: string): string {
   return path.split(/[\\/]/).pop() ?? path;
@@ -261,6 +269,23 @@ export default function GeneralTab({
         </div>
       </section>}
 
+      {mode === "general" && <section className="settings-section">
+        <h3 className="settings-section__title">{t("SectionTheme")}</h3>
+        <div className="settings-section__group">
+          <Field label={t("ThemeLabel")} description={t("ThemeHelper")}>
+            <Select
+              value={settings.theme}
+              disabled={saving}
+              ariaLabel={t("ThemeLabel")}
+              options={THEME_OPTIONS.map((option) => ({
+                value: option.value,
+                label: t(option.labelKey),
+              }))}
+              onChange={(value) => set({ theme: value as ThemePreference })}
+            />
+          </Field>
+        </div>
+      </section>}
       {mode === "general" && <section className="settings-section">
         <h3 className="settings-section__title">{t("StartupSettings")}</h3>
         <div className="settings-section__group">


### PR DESCRIPTION
Fixes #340. The theme toggle button was not rendered in the Settings UI, preventing users from switching to light mode. Users with keratoconus or other light sensitivity conditions need light mode.

## Root cause

The theme system was complete end-to-end except for the UI control that lets the user pick a theme:

- Backend: `ThemePreference` enum (`auto`/`light`/`dark`) and the `theme` settings field exist and round-trip in `rust/src/settings`.
- Frontend: `useTheme` applies `data-theme="light"/"dark"` and subscribes to `prefers-color-scheme` for `auto`.
- CSS: `[data-theme="light"]` and `[data-theme="dark"]` blocks are fully defined in `styles.css`.
- i18n: `SectionTheme`, `ThemeLabel`, `ThemeHelper`, `ThemeAutoOption`, `ThemeLightOption`, `ThemeDarkOption` are defined in all 7 locale `.ftl` files.

**But no Settings tab rendered a theme selector**, so users could never change the theme — the app stayed on the default (`auto`) with no visible control.

## Fix

Add a Theme (Appearance) section to the **General** settings tab with a `Select` bound to `settings.theme` (Auto / Light / Dark). Selecting an option calls `set({ theme })`, which `updateSettings` persists and `App.tsx` applies via `useTheme`.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` — clean
- `cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings` — clean
- `cargo test --manifest-path rust/Cargo.toml --lib` — 1266 passed
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` — 342 passed
- `pnpm install && pnpm test` — 264 passed (43 files); 3 new theme-picker tests added in `GeneralTab.test.tsx`
- `pnpm run build` — builds clean; locale-drift check OK (771 keys match)

## Tests added

`GeneralTab.test.tsx`: renders the theme picker with all three options in general mode; persists a `light` choice via `set({ theme: "light" })`; confirms the picker is absent in notifications mode.