### PR TITLE
Fix Alibaba Personal/Solo workspace authorization

### DIFF
--- a/rust/src/providers/alibabatokenplan/mod.rs
+++ b/rust/src/providers/alibabatokenplan/mod.rs
@@ -394,7 +394,7 @@ pub(super) fn throw_if_error_payload(value: &Value) -> Result<(), ProviderError>
             &["errorMsg", "message", "msg", "Message", "errorMessage"],
         )
         .or_else(|| code.clone())
-            .unwrap_or_else(|| "request failed".to_string());
+        .unwrap_or_else(|| "request failed".to_string());
         let lower = message.to_lowercase();
         if lower.contains("needlogin")
             || lower.contains("login")

--- a/rust/src/providers/alibabatokenplan/mod.rs
+++ b/rust/src/providers/alibabatokenplan/mod.rs
@@ -5,7 +5,7 @@
 //! cookies or a manually pasted cookie header.
 //!
 //! Team path: `GetSubscriptionSummary` / BssOpenAPI-V3 (+ optional sec_token).
-//! Personal/Solo path: OneConsole personal token-plan APIs (no sec_token).
+//! Personal/Solo path: OneConsole personal token-plan APIs (+ best-effort sec_token).
 
 mod personal;
 mod region;
@@ -91,7 +91,15 @@ impl AlibabaTokenPlanProvider {
             .map_err(|e| ProviderError::Other(e.to_string()))?;
 
         let snapshot = if region.uses_personal_api() {
-            personal::fetch_personal_usage(&client, &cookie_header, region, ctx).await?
+            let sec_token = Self::resolve_sec_token(&client, &cookie_header, region, ctx).await;
+            personal::fetch_personal_usage(
+                &client,
+                &cookie_header,
+                region,
+                sec_token.as_deref(),
+                ctx,
+            )
+            .await?
         } else {
             self.fetch_team_usage(&client, &cookie_header, region, ctx)
                 .await?
@@ -379,10 +387,13 @@ pub(super) fn throw_if_error_payload(value: &Value) -> Result<(), ProviderError>
         )));
     }
 
-    if let Some(success) = find_first_bool(value, &["success", "Success"])
-        && !success
-    {
-        let message = find_first_string(value, &["message", "msg", "Message", "errorMessage"])
+    if let Some(frame) = find_failing_success_frame(value) {
+        let code = find_first_string(frame, &["errorCode", "Code", "code"]);
+        let message = find_first_string(
+            frame,
+            &["errorMsg", "message", "msg", "Message", "errorMessage"],
+        )
+        .or_else(|| code.clone())
             .unwrap_or_else(|| "request failed".to_string());
         let lower = message.to_lowercase();
         if lower.contains("needlogin")
@@ -411,6 +422,24 @@ pub(super) fn throw_if_error_payload(value: &Value) -> Result<(), ProviderError>
         return Err(ProviderError::AuthRequired);
     }
     Ok(())
+}
+
+fn find_failing_success_frame(value: &Value) -> Option<&Value> {
+    match value {
+        Value::Object(map) => {
+            let failed_here = ["success", "Success"]
+                .iter()
+                .filter_map(|key| map.get(*key))
+                .filter_map(|value| parse_bool(Some(value)))
+                .any(|success| !success);
+            if failed_here {
+                return Some(value);
+            }
+            map.values().find_map(find_failing_success_frame)
+        }
+        Value::Array(values) => values.iter().find_map(find_failing_success_frame),
+        _ => None,
+    }
 }
 
 fn normalize_cookie_header(raw: &str) -> Option<String> {
@@ -729,22 +758,6 @@ fn find_first_i64(value: &Value, keys: &[&str]) -> Option<i64> {
         Value::Array(values) => values
             .iter()
             .find_map(|nested| find_first_i64(nested, keys)),
-        _ => None,
-    }
-}
-
-fn find_first_bool(value: &Value, keys: &[&str]) -> Option<bool> {
-    match value {
-        Value::Object(map) => keys
-            .iter()
-            .find_map(|key| parse_bool(map.get(*key)))
-            .or_else(|| {
-                map.values()
-                    .find_map(|nested| find_first_bool(nested, keys))
-            }),
-        Value::Array(values) => values
-            .iter()
-            .find_map(|nested| find_first_bool(nested, keys)),
         _ => None,
     }
 }

--- a/rust/src/providers/alibabatokenplan/personal.rs
+++ b/rust/src/providers/alibabatokenplan/personal.rs
@@ -12,23 +12,29 @@ use super::{
 };
 use crate::core::{FetchContext, ProviderError};
 
+struct PersonalApiContext<'a> {
+    client: &'a reqwest::Client,
+    cookie_header: &'a str,
+    region: AlibabaTokenPlanRegion,
+    sec_token: Option<&'a str>,
+    fetch_context: &'a FetchContext,
+}
+
 pub(super) async fn fetch_personal_usage(
     client: &reqwest::Client,
     cookie_header: &str,
     region: AlibabaTokenPlanRegion,
     sec_token: Option<&str>,
-    ctx: &FetchContext,
+    fetch_context: &FetchContext,
 ) -> Result<TokenPlanSnapshot, ProviderError> {
-    let usage_body = post_personal_api(
+    let context = PersonalApiContext {
         client,
-        PERSONAL_USAGE_API,
-        Map::new(),
         cookie_header,
         region,
         sec_token,
-        ctx,
-    )
-    .await?;
+        fetch_context,
+    };
+    let usage_body = post_personal_api(&context, PERSONAL_USAGE_API, Map::new()).await?;
 
     let mut subscription_params = Map::new();
     subscription_params.insert(
@@ -36,26 +42,14 @@ pub(super) async fn fetch_personal_usage(
         Value::String(region.product_code().to_string()),
     );
     let subscription_body = post_personal_api_optional(
-        client,
+        &context,
         PERSONAL_SUBSCRIPTION_API,
         subscription_params,
-        cookie_header,
-        region,
-        sec_token,
-        ctx,
     )
     .await;
 
-    let quota_config_body = post_personal_api_optional(
-        client,
-        PERSONAL_QUOTA_CONFIG_API,
-        Map::new(),
-        cookie_header,
-        region,
-        sec_token,
-        ctx,
-    )
-    .await;
+    let quota_config_body =
+        post_personal_api_optional(&context, PERSONAL_QUOTA_CONFIG_API, Map::new()).await;
 
     parse_personal_usage(
         &usage_body,
@@ -65,31 +59,36 @@ pub(super) async fn fetch_personal_usage(
 }
 
 async fn post_personal_api(
-    client: &reqwest::Client,
+    context: &PersonalApiContext<'_>,
     api: &str,
     data_parameters: Map<String, Value>,
-    cookie_header: &str,
-    region: AlibabaTokenPlanRegion,
-    sec_token: Option<&str>,
-    ctx: &FetchContext,
 ) -> Result<Vec<u8>, ProviderError> {
-    let url = personal_api_url(api, region);
-    let form = build_personal_form(api, data_parameters, cookie_header, region, sec_token);
+    let url = personal_api_url(api, context.region);
+    let form = build_personal_form(
+        api,
+        data_parameters,
+        context.cookie_header,
+        context.region,
+        context.sec_token,
+    );
 
-    let mut request = client
+    let mut request = context
+        .client
         .post(&url)
-        .timeout(std::time::Duration::from_secs(ctx.web_timeout.max(1)))
-        .header("Cookie", cookie_header)
+        .timeout(std::time::Duration::from_secs(
+            context.fetch_context.web_timeout.max(1),
+        ))
+        .header("Cookie", context.cookie_header)
         .header("Accept", "application/json, text/plain, */*")
         .header("Content-Type", "application/x-www-form-urlencoded")
-        .header("Origin", region.gateway_base_url())
-        .header("Referer", region.dashboard_url())
+        .header("Origin", context.region.gateway_base_url())
+        .header("Referer", context.region.dashboard_url())
         .header("User-Agent", USER_AGENT)
         .header("X-Requested-With", "XMLHttpRequest")
         .form(&form);
 
-    if let Some(csrf) = cookie_value("login_aliyunid_csrf", cookie_header)
-        .or_else(|| cookie_value("csrf", cookie_header))
+    if let Some(csrf) = cookie_value("login_aliyunid_csrf", context.cookie_header)
+        .or_else(|| cookie_value("csrf", context.cookie_header))
     {
         request = request
             .header("x-xsrf-token", csrf.clone())
@@ -111,25 +110,11 @@ async fn post_personal_api(
 }
 
 async fn post_personal_api_optional(
-    client: &reqwest::Client,
+    context: &PersonalApiContext<'_>,
     api: &str,
     data_parameters: Map<String, Value>,
-    cookie_header: &str,
-    region: AlibabaTokenPlanRegion,
-    sec_token: Option<&str>,
-    ctx: &FetchContext,
 ) -> Option<Vec<u8>> {
-    post_personal_api(
-        client,
-        api,
-        data_parameters,
-        cookie_header,
-        region,
-        sec_token,
-        ctx,
-    )
-        .await
-        .ok()
+    post_personal_api(context, api, data_parameters).await.ok()
 }
 
 fn build_personal_form(

--- a/rust/src/providers/alibabatokenplan/personal.rs
+++ b/rust/src/providers/alibabatokenplan/personal.rs
@@ -16,6 +16,7 @@ pub(super) async fn fetch_personal_usage(
     client: &reqwest::Client,
     cookie_header: &str,
     region: AlibabaTokenPlanRegion,
+    sec_token: Option<&str>,
     ctx: &FetchContext,
 ) -> Result<TokenPlanSnapshot, ProviderError> {
     let usage_body = post_personal_api(
@@ -24,6 +25,7 @@ pub(super) async fn fetch_personal_usage(
         Map::new(),
         cookie_header,
         region,
+        sec_token,
         ctx,
     )
     .await?;
@@ -39,6 +41,7 @@ pub(super) async fn fetch_personal_usage(
         subscription_params,
         cookie_header,
         region,
+        sec_token,
         ctx,
     )
     .await;
@@ -49,6 +52,7 @@ pub(super) async fn fetch_personal_usage(
         Map::new(),
         cookie_header,
         region,
+        sec_token,
         ctx,
     )
     .await;
@@ -66,17 +70,11 @@ async fn post_personal_api(
     data_parameters: Map<String, Value>,
     cookie_header: &str,
     region: AlibabaTokenPlanRegion,
+    sec_token: Option<&str>,
     ctx: &FetchContext,
 ) -> Result<Vec<u8>, ProviderError> {
     let url = personal_api_url(api, region);
-    let params_json = build_personal_params_json(api, data_parameters, cookie_header, region);
-    let form = [
-        ("product", PERSONAL_CONSOLE_PRODUCT.to_string()),
-        ("action", region.personal_api_action().to_string()),
-        ("region", region.current_region_id().to_string()),
-        ("language", LANGUAGE.to_string()),
-        ("params", params_json),
-    ];
+    let form = build_personal_form(api, data_parameters, cookie_header, region, sec_token);
 
     let mut request = client
         .post(&url)
@@ -118,11 +116,41 @@ async fn post_personal_api_optional(
     data_parameters: Map<String, Value>,
     cookie_header: &str,
     region: AlibabaTokenPlanRegion,
+    sec_token: Option<&str>,
     ctx: &FetchContext,
 ) -> Option<Vec<u8>> {
-    post_personal_api(client, api, data_parameters, cookie_header, region, ctx)
+    post_personal_api(
+        client,
+        api,
+        data_parameters,
+        cookie_header,
+        region,
+        sec_token,
+        ctx,
+    )
         .await
         .ok()
+}
+
+fn build_personal_form(
+    api: &str,
+    data_parameters: Map<String, Value>,
+    cookie_header: &str,
+    region: AlibabaTokenPlanRegion,
+    sec_token: Option<&str>,
+) -> Vec<(&'static str, String)> {
+    let params_json = build_personal_params_json(api, data_parameters, cookie_header, region);
+    let mut form = vec![
+        ("product", PERSONAL_CONSOLE_PRODUCT.to_string()),
+        ("action", region.personal_api_action().to_string()),
+        ("region", region.current_region_id().to_string()),
+        ("language", LANGUAGE.to_string()),
+        ("params", params_json),
+    ];
+    if let Some(token) = sec_token.filter(|token| !token.trim().is_empty()) {
+        form.push(("sec_token", token.to_string()));
+    }
+    form
 }
 
 fn personal_api_url(api: &str, region: AlibabaTokenPlanRegion) -> String {
@@ -157,7 +185,8 @@ fn build_personal_params_json(
     cornerstone.insert("protocol".into(), Value::String("V2".into()));
     cornerstone.insert("console".into(), Value::String("ONE_CONSOLE".into()));
     cornerstone.insert("productCode".into(), Value::String("p_efm".into()));
-    cornerstone.insert("switchAgent".into(), json!(1_233_135));
+    // Let the gateway resolve the Personal/Solo session workspace. A captured
+    // Teams switchAgent is workspace-bound and rejects other accounts.
     cornerstone.insert("switchUserType".into(), json!(3));
     cornerstone.insert("domain".into(), Value::String(domain.to_string()));
     cornerstone.insert(
@@ -304,6 +333,88 @@ mod tests {
     use super::*;
     use crate::core::UsageSnapshot;
     use crate::providers::alibabatokenplan::AlibabaTokenPlanProvider;
+
+    #[test]
+    fn personal_form_forwards_optional_sec_token() {
+        let with_token = build_personal_form(
+            PERSONAL_USAGE_API,
+            Map::new(),
+            "cna=test-anon",
+            AlibabaTokenPlanRegion::IntlPersonal,
+            Some("personal-sec-token"),
+        );
+        assert!(with_token.iter().any(|(key, value)| {
+            *key == "sec_token" && value == "personal-sec-token"
+        }));
+
+        let without_token = build_personal_form(
+            PERSONAL_USAGE_API,
+            Map::new(),
+            "cna=test-anon",
+            AlibabaTokenPlanRegion::IntlPersonal,
+            None,
+        );
+        assert!(!without_token.iter().any(|(key, _)| *key == "sec_token"));
+    }
+
+    #[test]
+    fn personal_request_omits_captured_workspace_agent() {
+        let params = build_personal_params_json(
+            PERSONAL_USAGE_API,
+            Map::new(),
+            "cna=test-anon",
+            AlibabaTokenPlanRegion::IntlPersonal,
+        );
+        let value: Value = serde_json::from_str(&params).unwrap();
+        let cornerstone = value
+            .get("Data")
+            .and_then(|data| data.get("cornerstoneParam"))
+            .and_then(Value::as_object)
+            .unwrap();
+
+        assert!(!cornerstone.contains_key("switchAgent"));
+        assert_eq!(cornerstone.get("switchUserType"), Some(&json!(3)));
+    }
+
+    #[test]
+    fn nested_workspace_error_surfaces_real_code_without_auth_eviction() {
+        let payload = json!({
+            "code": "200",
+            "successResponse": true,
+            "data": {
+                "success": false,
+                "httpStatus": 200,
+                "errorCode": "BailianGateway.Workspace.NotAuthorised"
+            }
+        });
+
+        let error = crate::providers::alibabatokenplan::throw_if_error_payload(&payload).unwrap_err();
+        assert!(matches!(
+            error,
+            ProviderError::Other(message)
+                if message.contains("BailianGateway.Workspace.NotAuthorised")
+        ));
+    }
+
+    #[test]
+    fn nested_gateway_error_prefers_error_message() {
+        let payload = json!({
+            "code": "200",
+            "successResponse": true,
+            "data": {
+                "success": false,
+                "httpStatus": 200,
+                "errorCode": "BailianGateway.Quota.ServiceUnavailable",
+                "errorMsg": "quota service unavailable"
+            }
+        });
+
+        let error = crate::providers::alibabatokenplan::throw_if_error_payload(&payload).unwrap_err();
+        assert!(matches!(
+            error,
+            ProviderError::Other(message) if message.contains("quota service unavailable")
+        ));
+    }
 
     #[test]
     fn parses_personal_usage_fixture_with_plan_name() {

--- a/rust/src/providers/alibabatokenplan/personal.rs
+++ b/rust/src/providers/alibabatokenplan/personal.rs
@@ -41,12 +41,8 @@ pub(super) async fn fetch_personal_usage(
         "commodityCode".into(),
         Value::String(region.product_code().to_string()),
     );
-    let subscription_body = post_personal_api_optional(
-        &context,
-        PERSONAL_SUBSCRIPTION_API,
-        subscription_params,
-    )
-    .await;
+    let subscription_body =
+        post_personal_api_optional(&context, PERSONAL_SUBSCRIPTION_API, subscription_params).await;
 
     let quota_config_body =
         post_personal_api_optional(&context, PERSONAL_QUOTA_CONFIG_API, Map::new()).await;
@@ -328,9 +324,11 @@ mod tests {
             AlibabaTokenPlanRegion::IntlPersonal,
             Some("personal-sec-token"),
         );
-        assert!(with_token.iter().any(|(key, value)| {
-            *key == "sec_token" && value == "personal-sec-token"
-        }));
+        assert!(
+            with_token
+                .iter()
+                .any(|(key, value)| { *key == "sec_token" && value == "personal-sec-token" })
+        );
 
         let without_token = build_personal_form(
             PERSONAL_USAGE_API,
@@ -373,7 +371,8 @@ mod tests {
             }
         });
 
-        let error = crate::providers::alibabatokenplan::throw_if_error_payload(&payload).unwrap_err();
+        let error =
+            crate::providers::alibabatokenplan::throw_if_error_payload(&payload).unwrap_err();
         assert!(matches!(
             error,
             ProviderError::Other(message)
@@ -394,7 +393,8 @@ mod tests {
             }
         });
 
-        let error = crate::providers::alibabatokenplan::throw_if_error_payload(&payload).unwrap_err();
+        let error =
+            crate::providers::alibabatokenplan::throw_if_error_payload(&payload).unwrap_err();
         assert!(matches!(
             error,
             ProviderError::Other(message) if message.contains("quota service unavailable")


### PR DESCRIPTION
Fixes #350 by porting the applicable behavior from upstream CodexBar #2533 into the Windows Rust provider.

## Ported
- remove the captured hardcoded Personal/Solo switchAgent workspace selector
- resolve and forward best-effort sec_token on Personal/Solo requests
- inspect the exact nested success:false gateway frame and surface errorCode / errorMsg instead of generic request failed
- preserve Workspace.NotAuthorised as a provider permission error rather than converting it to AuthRequired
- add direct regression coverage for omitted switchAgent, optional sec_token, nested workspace authorization errors, and nested gateway messages

## Skipped
- upstream Swift-specific fetch-strategy/cache-injection refactors do not apply to the Rust provider architecture
- no macOS Keychain behavior is ported

## Deferred
- live CN/Singapore account verification requires a reporter account/session; deterministic request/error regressions cover the observed gateway contract locally

## Verification
- cargo test -p codexbar alibabatokenplan: 13/13 PASS
- cargo clippy -p codexbar --all-targets -- -D warnings: PASS
- full cargo test -p codexbar --all-targets: 1291/1292 PASS; only the known CodexPro environment failure cli::tty_runner::tests::test_run_sends_script_through_pty -> BinaryNotFound(cmd)
- git diff --check: PASS
- local rustfmt check unavailable because the Rustfmt component is not installed; hosted PR CI remains authoritative for fmt
