### PR TITLE
fix(tray): stop auto-fit ResizeObserver feedback loop

### DIFF
--- a/apps/desktop-tauri/src/hooks/useTrayPanelLayout.sizing.test.tsx
+++ b/apps/desktop-tauri/src/hooks/useTrayPanelLayout.sizing.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TrayPanelLayoutOptions } from "./useTrayPanelLayout";
 
@@ -38,6 +38,33 @@ vi.mock("@tauri-apps/api/window", () => windowMocks);
 import { useTrayPanelLayout } from "./useTrayPanelLayout";
 
 let surface: HTMLElement;
+let feedbackObserverCallbacks = 0;
+
+class StyleFeedbackResizeObserver {
+  private mutationObserver: MutationObserver | null = null;
+
+  constructor(private readonly callback: ResizeObserverCallback) {}
+
+  observe(target: Element): void {
+    this.mutationObserver = new MutationObserver(() => {
+      feedbackObserverCallbacks += 1;
+      this.callback([], this as unknown as ResizeObserver);
+    });
+    this.mutationObserver.observe(target, {
+      attributes: true,
+      attributeFilter: ["style"],
+    });
+  }
+
+  unobserve(): void {
+    this.disconnect();
+  }
+
+  disconnect(): void {
+    this.mutationObserver?.disconnect();
+    this.mutationObserver = null;
+  }
+}
 
 function mountSurface(): void {
   document.body.innerHTML = [
@@ -79,9 +106,10 @@ function hookResult(result: unknown): { current: { requestLayout: () => void } }
   return result as { current: { requestLayout: () => void } };
 }
 
-describe("useTrayPanelLayout two-state cycle detection (#261)", () => {
+describe("useTrayPanelLayout sizing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    feedbackObserverCallbacks = 0;
     mountSurface();
     Object.defineProperty(window, "devicePixelRatio", {
       configurable: true,
@@ -106,6 +134,7 @@ describe("useTrayPanelLayout two-state cycle detection (#261)", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     document.body.innerHTML = "";
   });
 
@@ -133,6 +162,30 @@ describe("useTrayPanelLayout two-state cycle detection (#261)", () => {
       { timeout: 3000 },
     );
   }
+
+  it("does not feed measurement style changes back into another auto-fit pass", async () => {
+    vi.stubGlobal("ResizeObserver", StyleFeedbackResizeObserver);
+    setScrollHeight(1_200);
+
+    const { result } = renderHook(() => useTrayPanelLayout(hookProps()));
+    await waitFor(() => expect(result.current.layoutReady).toBe(true), {
+      timeout: 3000,
+    });
+    await waitFor(() => expect(feedbackObserverCallbacks).toBeGreaterThan(0));
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 300));
+    });
+    const settledRevealCount =
+      tauriMocks.revealTrayPanelWindow.mock.calls.length;
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 500));
+    });
+
+    expect(tauriMocks.revealTrayPanelWindow.mock.calls.length).toBe(
+      settledRevealCount,
+    );
+  });
 
   it("commits stable small changes, locks the reporter pair on the larger member, tracks retained height in the DOM", async () => {
     setScrollHeight(535); // → 539 logical → 674 physical

--- a/apps/desktop-tauri/src/hooks/useTrayPanelLayout.ts
+++ b/apps/desktop-tauri/src/hooks/useTrayPanelLayout.ts
@@ -188,7 +188,19 @@ export function useTrayPanelLayout({
   useEffect(() => {
     const surface = document.querySelector<HTMLElement>(".menu-surface--tray");
     if (!surface || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => requestLayout());
+    const observer = new ResizeObserver(() => {
+      // Measuring temporarily removes the surface/body constraints, which
+      // resizes the observed surface. Do not feed that programmatic change
+      // back into another pass or the capped flyout flashes between its
+      // measured and committed layouts forever.
+      if (
+        layoutReadyRef.current &&
+        programmaticInFlightRef.current > 0
+      ) {
+        return;
+      }
+      requestLayout();
+    });
     observer.observe(surface);
     return () => observer.disconnect();
   }, [requestLayout]);


### PR DESCRIPTION
## Summary

- Stop auto-fit measurement style changes from recursively scheduling another layout pass through the tray surface's `ResizeObserver`.
- Keep observer-driven sizing enabled until the initial layout converges, so a newly created flyout still reaches its normal size.
- Add a deterministic style-feedback regression test that fails on `main` before the hook fix and settles after it.

The auto-fit pass temporarily removes height and overflow constraints to measure the full surface. On the affected Windows/WebView2 setup, the observer saw those programmatic changes and re-entered auto-fit indefinitely, making the Pop Out Dashboard alternate between measured and committed layouts. This is a separate feedback path from the fractional-DPI native-size cycle handled in #272.

## Related issue

Follow-up to #261 and #272.

## Affected areas

- [x] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [ ] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [x] Other: detached Pop Out Dashboard flyout

## Validation

- [x] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1`
  - Shared Rust: 1,293 tests passed
  - Tauri Rust: 353 tests passed
  - Frontend: 44 files / 269 tests passed
  - Frontend TypeScript/Vite build passed
  - Formatting and clippy gates passed
- [ ] Full pre-release validation: not applicable; no packaging or release changes
- [ ] Installer/release validation: not applicable
- [x] Thermo-nuclear code quality review completed before submitting
- [x] Focused red/green test: the new test fails before the hook change (`3` reveal calls instead of settled `2`) and all 3 sizing tests pass afterward
- [x] Fresh Windows debug build: `pnpm --dir apps\desktop-tauri run tauri:build:debug`

## UI / tray proof

- [ ] Not applicable
- [ ] CUA Driver visual proof attached
- [x] CUA Driver could not be used; equivalent manual proof and explanation attached

CUA Driver is not installed on the test machine (`%LOCALAPPDATA%\Programs\Cua\cua-driver\bin\cua-driver.exe` is absent), so I used equivalent native Windows/WebView2 proof against a fresh debug build from this branch:

- 12-second CDP sample, 2,160 animation frames: **0** body, surface, max-height, or native inner-height transitions; **1** `ResizeObserver` callback
- 14-second desktop capture, 180 frames: **1** unique frame, **0** frame transitions, **0** single-frame flicker pulses, **1** native window geometry
- Flyout remained `328 x 920`
- No bogus tiny remembered flyout size was persisted

For comparison, the affected build produced roughly 160 body/surface height transitions and about 240 observer callbacks in 12 seconds, plus 37 one-frame visual pulses in 12.6 seconds.

## Notes for reviewers

The `layoutReadyRef.current` guard is intentional: observer callbacks remain active during first-open convergence, then callbacks caused by the hook's own measurement pass are ignored while `programmaticInFlightRef` is active. This preserves initial auto-fit and avoids misclassifying the hidden window's tiny bootstrap frame as a user-resized size.

The diff is limited to `useTrayPanelLayout.ts` and its sizing test; it contains no Rust/backend or local process-discovery changes.
