### PR TITLE
fix(tray): label the tooltip from the headline lane, not the raw primary

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -583,19 +583,29 @@ fn provider_status_label(
         );
     }
 
-    // F5 (upstream 0.48.0): for Codex, prefer the first non-informational lane so
-    // a monthly-only plan shows the monthly window with its reset countdown
-    // instead of the informational "No active 5h session" placeholder.
-    let window = if snapshot.provider_id == "codex" {
-        codex_lane_headline_window(snapshot)
-    } else {
-        &snapshot.primary
-    };
-    let label = crate::commands::compact_tray_status_label(window, lang);
+    let label = crate::commands::compact_tray_status_label(headline_window(snapshot), lang);
     (
         snapshot.provider_id.clone(),
         format!("{} {}", snapshot.display_name, label),
     )
+}
+
+/// Window that headline tray surfaces should label for a provider.
+///
+/// F5 (upstream 0.48.0): for Codex, prefer the first non-informational lane so
+/// a monthly-only plan shows the monthly window with its reset countdown
+/// instead of the informational "No active 5h session" placeholder.
+///
+/// Shared by the tray menu rows (`provider_status_label`) and the tray tooltip
+/// (`build_tooltip`) so the two cannot drift apart.
+fn headline_window(
+    snapshot: &crate::commands::ProviderUsageSnapshot,
+) -> &crate::commands::RateWindowSnapshot {
+    if snapshot.provider_id == "codex" {
+        codex_lane_headline_window(snapshot)
+    } else {
+        &snapshot.primary
+    }
 }
 
 /// F5 (upstream 0.48.0): pick the first non-informational Codex lane in
@@ -697,7 +707,7 @@ fn build_tooltip(
             let short = truncate_tooltip_text(err, 36);
             format!("{}: {} ({})", s.display_name, error_label, short)
         } else {
-            let label = crate::commands::compact_tray_status_label(&s.primary, lang);
+            let label = crate::commands::compact_tray_status_label(headline_window(s), lang);
             format!("{}: {}", s.display_name, truncate_tooltip_text(&label, 42))
         };
         lines.push(status);
@@ -1229,6 +1239,21 @@ mod tests {
             tooltip,
             "CodexBar\nClaude: 13% • Resets in 2h 05m\nCodex: 8% • Resets in 4h 10m"
         );
+    }
+
+    #[test]
+    fn tooltip_skips_informational_codex_primary() {
+        // Weekly-only Codex plan: the 5h lane is an informational placeholder,
+        // so the tooltip must label the real weekly lane instead of echoing
+        // "No active 5h session" back at the user.
+        let mut codex = fake_snapshot_with("codex", "Codex", 0.0, Some(16.0), None, None);
+        codex.primary.is_informational = true;
+        codex.primary.reset_description = Some("No active 5h session".to_string());
+        codex.secondary.as_mut().unwrap().reset_description = Some("3d 17h".to_string());
+
+        let tooltip = build_tooltip(&[codex], codexbar::settings::Language::English);
+
+        assert_eq!(tooltip, "CodexBar\nCodex: 16% • Resets in 3d 17h");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The native tray tooltip labelled `snapshot.primary` directly, so a Codex account on a weekly-only plan showed the informational placeholder — `Codex: No active 5h session` — instead of the real weekly window.

`provider_status_label` already routed Codex through `codex_lane_headline_window` to skip informational lanes (the F5 / upstream-0.48.0 fix). `build_tooltip`, 111 lines further down the same file, never got the same treatment: #277 covered the React surfaces and the FloatBar, and the Rust tray tooltip was left behind. That is why the icon, the tray menu rows, the Providers sidebar, the FloatBar and the CLI were all correct while only the hover tooltip was wrong.

Rather than repeat the `provider_id == "codex"` conditional at a second call site, this extracts it into `headline_window` and calls it from both, so the two surfaces cannot drift apart again. Net effect on behaviour is limited to the tooltip; `provider_status_label` keeps its existing semantics.

Before:

```
CodexBar
Codex: No active 5h session
```

After:

```
CodexBar
Codex: 16% • Resets in 3d 17h
```

## Related issue

Fixes #356

## Affected areas

- [x] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [ ] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` — **not run.** No Rust toolchain on my machine (no `cargo`/`rustc`, no MSVC Build Tools), and installing the MSVC stack plus a first full build of the Tauri dependency tree was not something I could do here. Flagging this openly rather than ticking a box I did not exercise.
- [ ] For full pre-release validation — not applicable; no release artifacts touched.
- [ ] For installer/release changes — not applicable.
- [ ] Thermo-nuclear code quality review — **not run as the linked skill.** I did review the final diff for the structural issue it targets: the duplicated lane-selection conditional was the actual root cause here, so the fix removes the duplication instead of adding a second copy. Happy to rerun properly if you want the formal pass.
- [x] Other: hosted `pr-check.yml` is the validation path for this PR. The change is Rust-only in one file, so `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` cover it. Please let CI run before merging — if anything is red I will fix it.

## UI / tray proof

- [ ] Not applicable
- [ ] CUA Driver visual proof attached
- [x] CUA Driver could not be used; equivalent manual proof and explanation attached

CUA Driver needs a built desktop shell, which needs the same toolchain I do not have. Manual proof instead, from the released v0.54.0 installer on a live weekly-only account:

**The payload** — `codexbar-cli.exe usage -p codex --json`, informational primary plus a real weekly secondary:

```json
{
  "primary":   { "is_informational": true,  "used_percent": 0.0,  "window_minutes": 300,
                 "reset_description": "No active 5h session" },
  "secondary": { "is_informational": false, "used_percent": 14.0, "window_minutes": 10080,
                 "reset_description": "3d 17h", "resets_at": "2026-08-27T10:47:41Z" }
}
```

**The split** — same account, same moment, v0.54.0:

| Surface | Code path | Rendered |
| --- | --- | --- |
| Tray icon | `selected_tray_percents` → `selected_usage_window` | 16% ✅ |
| Tray menu rows | `provider_status_label` → `codex_lane_headline_window` | 16% ✅ |
| Providers sidebar / FloatBar | shared policy from #277 | 16% ✅ |
| **Tray tooltip** | `build_tooltip` → `&s.primary` | **"No active 5h session"** ❌ |

**The regression test** — `tooltip_skips_informational_codex_primary` builds the same shape (informational primary, weekly secondary at 16% resetting in `3d 17h`) and asserts the tooltip reads `CodexBar\nCodex: 16% • Resets in 3d 17h`. On `main` that call returns the placeholder instead, so the test pins the regression. To be clear about what I actually did and did not do: I traced the expected string through `compact_tray_status_label` → `normalize_reset_description` → `ResetsInShort` by reading, but I have not executed the test (see Validation) — CI is the confirmation. The existing `tooltip_uses_compact_status_labels` only builds non-informational primaries, which is why this path was uncovered.

## Notes for reviewers

- The behaviour change is one line in `build_tooltip`; everything else is the extraction and the test.
- `headline_window` deliberately keeps the `provider_id == "codex"` check rather than generalising to all providers. Widening it would change Claude and others too, and that is a bigger call than this bug needs — happy to widen it if you would rather the policy be provider-agnostic.
- The tooltip still ignores `provider_metrics`, so pinning Codex to Weekly in Settings has no effect on it. Using `usage_metric::selected_usage_window` here instead would fix that too, but it changes the tooltip for every provider, so I kept this PR to the reported bug. Say the word and I will follow up separately.
- Context on why the account has no 5h window: OpenAI switched this ChatGPT Plus account to a weekly-only limit shape in mid-July 2026. Scanning every `token_count` event in `~/.codex/sessions` that carries a populated `rate_limits.primary`:

  ```
  last record with a 300-minute window : 2026-07-12T03:43:35.847Z   (1182 records, primary=300 + secondary=10080)
  first weekly-only record             : 2026-07-17T06:21:47.367Z   (1200+ records, primary=10080 + secondary=null)
  300-minute records after the switch  : 0
  ```

  The weekly-only count keeps growing with use; the two boundary timestamps and the zero do not. Same payload shape as #267 and #275.
