### PR TITLE
Fix OpenCodeGo API key not preserving Auto source mode

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -51,10 +51,9 @@ pub(crate) fn build_fetch_context(
             "off" if id == ProviderId::Claude && usage_source != SourceMode::Cli => {
                 (SourceMode::OAuth, None)
             }
-            "off" if has_kimi_code_api_key && usage_source == SourceMode::Auto => {
-                (SourceMode::Auto, None)
-            }
-            "off" if has_opencodego_api_key && usage_source == SourceMode::Auto => {
+            "off" if (has_kimi_code_api_key || has_opencodego_api_key)
+                && usage_source == SourceMode::Auto =>
+            {
                 (SourceMode::Auto, None)
             }
             // Droid/Factory: cookie-off must never scrape browser cookies. Map to
@@ -63,7 +62,9 @@ pub(crate) fn build_fetch_context(
             "off" => (SourceMode::Cli, None),
             "manual" => {
                 let cookie_header = active_token_cookie.or(stored_cookie);
-                let source_mode = if has_kimi_code_api_key && usage_source == SourceMode::Auto {
+                let source_mode = if (has_kimi_code_api_key || has_opencodego_api_key)
+                    && usage_source == SourceMode::Auto
+                {
                     SourceMode::Auto
                 } else if cookie_header.is_some() {
                     SourceMode::Web


### PR DESCRIPTION
## Summary

The "manual" and "off" branches of build_fetch_context in providers.rs checked has_kimi_code_api_key to preserve SourceMode::Auto when a Kimi API key was set, but omitted the same check for has_opencodego_api_key. With an OpenCodeGo API key and Auto source mode, it fell through to SourceMode::Cli instead of Auto.

This was introduced by PR #353 (port 0.54.0) which added has_opencodego_api_key and the "off"-branch check plus the test, but forgot the "manual" branch.

Fixes #359

## The fix

Adds has_opencodego_api_key to both the "manual" and "off" branches, combined with has_kimi_code_api_key via `||` since the two flags are mutually exclusive by provider id. This satisfies clippy's if_same_then_else lint, which rejects two consecutive if-arms with identical bodies.

## Before

```rust
"off" if has_kimi_code_api_key && usage_source == SourceMode::Auto => {
    (SourceMode::Auto, None)
}
"off" if has_opencodego_api_key && usage_source == SourceMode::Auto => {  // only in "off"
    (SourceMode::Auto, None)
}
...
"manual" => {
    let source_mode = if has_kimi_code_api_key && usage_source == SourceMode::Auto {
        SourceMode::Auto
    } else if cookie_header.is_some() {  // OpenCodeGo falls through to Cli
```

## After

```rust
"off" if (has_kimi_code_api_key || has_opencodego_api_key)
    && usage_source == SourceMode::Auto =>
{
    (SourceMode::Auto, None)
}
...
"manual" => {
    let source_mode = if (has_kimi_code_api_key || has_opencodego_api_key)
        && usage_source == SourceMode::Auto
    {
        SourceMode::Auto
    } else if cookie_header.is_some() {
```

## Validation

- [x] cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml — 354 passed, 0 failed
- [x] cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml --all-targets -- -D warnings — clean
- [x] cargo fmt --all -- --check — clean for providers.rs (pre-existing fmt issue in rust/src/providers/opencodego/usage_api.rs:116 is unrelated and present on main)
- [x] Previously-failing test fetch_context_opencodego_api_key_preserves_auto_for_api_overlay now passes

## Advisory verification

Confirmed that Settings::default() uses cookie_source = "manual" (DEFAULT_COOKIE_SOURCE in rust/src/settings.rs:464), so the test enters the "manual" branch — the correct location for this fix.

## Affected areas

- [x] Provider-specific behavior (OpenCodeGo)
- [ ] Settings UI
- [ ] CLI
- [ ] Tray panel
- [ ] Installer / release packaging
- [ ] Documentation