### PR TITLE
Fix quoted agy.exe detection on Windows

### DIFF
--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -52,11 +52,12 @@ enum ProcessSource {
 /// names (e.g. `notantigravity-cli`) from matching.
 fn is_agy_cli_command(command_line: &str) -> bool {
     static CLI_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(^|[\\/])(antigravity-cli|antigravity_cli)([\s/\\]|$)")
+        Regex::new(r#"(^|[\\/])(antigravity-cli|antigravity_cli)(?:"|[\s/\\]|$)"#)
             .expect("valid antigravity-cli pattern")
     });
-    static AGY_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(^|[\\/])agy(\.exe)?(\s|$)").expect("valid agy pattern"));
+    static AGY_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"(^|[\\/])agy(\.exe)?(?:"|\s|$)"#).expect("valid agy pattern")
+    });
     let lower = command_line.to_ascii_lowercase();
     CLI_PATH_RE.is_match(&lower) || AGY_RE.is_match(&lower)
 }
@@ -196,7 +197,10 @@ impl AntigravityProvider {
         // SECURITY: TLS verification is disabled because the local language server uses a
         // self-signed certificate. This is scoped to 127.0.0.1 only; we confirm a port by
         // checking that it answers the expected gRPC endpoint.
+        // The language server is a local loopback endpoint. Do not route it
+        // through the app-wide outbound proxy.
         let client = crate::core::credentialed_http_client_builder()
+            .no_proxy()
             .timeout(std::time::Duration::from_secs(2))
             .danger_accept_invalid_certs(true)
             .redirect(reqwest::redirect::Policy::none())
@@ -303,7 +307,10 @@ impl AntigravityProvider {
         let api_port = Self::find_api_port(process_info.extension_port, process_info.pid).await?;
 
         // SECURITY: TLS verification disabled for local language server (see find_api_port)
+        // The language server is a local loopback endpoint. Do not route it
+        // through the app-wide outbound proxy.
         let client = crate::core::credentialed_http_client_builder()
+            .no_proxy()
             .timeout(std::time::Duration::from_secs(8))
             .danger_accept_invalid_certs(true)
             .redirect(reqwest::redirect::Policy::none())

--- a/rust/src/providers/antigravity/tests.rs
+++ b/rust/src/providers/antigravity/tests.rs
@@ -226,6 +226,19 @@ fn detects_agy_exe_cli_process_with_empty_csrf() {
 }
 
 #[test]
+fn detects_quoted_agy_exe_cli_process() {
+    // Windows CIM quotes an executable path that contains path separators.
+    let output = "7777\t\"C:\\Users\\user\\AppData\\Local\\agy\\bin\\agy.exe\" --model gemini-3.7-flash-high";
+
+    let process = AntigravityProvider::parse_process_info(output)
+        .expect("quoted agy CLI process should be detected");
+
+    assert_eq!(process.pid, Some(7777));
+    assert_eq!(process.source, ProcessSource::Cli);
+    assert!(process.csrf_token.is_empty());
+}
+
+#[test]
 fn detects_bare_agy_command() {
     // The CLI may appear under the bare `agy` name (no .exe suffix).
     let output = "8888\tagy serve";
@@ -294,14 +307,29 @@ fn is_agy_cli_command_matches_known_names() {
     assert!(is_agy_cli_command(
         "C:\\Users\\test\\AppData\\Local\\agy\\bin\\agy.exe session"
     ));
+    assert!(is_agy_cli_command(
+        "C:\\Users\\user\\AppData\\Local\\agy\\bin\\AGY.EXE --model gemini-3.7-flash-high"
+    ));
+    assert!(is_agy_cli_command(
+        "\"C:\\Users\\user\\AppData\\Local\\agy\\bin\\agy.exe\" --model gemini-3.7-flash-high"
+    ));
     assert!(is_agy_cli_command("/usr/local/bin/antigravity-cli status"));
     assert!(is_agy_cli_command("/opt/antigravity_cli run"));
+    assert!(is_agy_cli_command("\"C:\\Tools\\antigravity-cli\" status"));
+    assert!(is_agy_cli_command("\"C:\\Tools\\antigravity_cli\" run"));
 }
 
 #[test]
 fn is_agy_cli_command_rejects_unrelated_names() {
     // A leading path separator prevents `notantigravity-cli` from matching.
+    assert!(!is_agy_cli_command(
+        "notagy.exe --model gemini-3.7-flash-high"
+    ));
+    assert!(!is_agy_cli_command(
+        "C:\\Tools\\someagy.exe --model gemini-3.7-flash-high"
+    ));
     assert!(!is_agy_cli_command("notantigravity-cli status"));
+    assert!(!is_agy_cli_command("C:\\Tools\\notantigravity-cli status"));
     assert!(!is_agy_cli_command("C:\\Windows\\System32\\notepad.exe"));
     assert!(!is_agy_cli_command("language_server.exe --csrf_token abc"));
     assert!(!is_agy_cli_command(""));


### PR DESCRIPTION
## Summary

- Follow-up to #282 and #333.
- Windows CIM can return a quoted executable path, so the closing quote after `agy.exe` was rejected by the CLI process matcher.
- Keeps Antigravity language-server requests on `127.0.0.1` out of the app-wide outbound proxy.

## Related issue

Follow-up to #282 and #333

## Affected areas

- [ ] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [x] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` (ran; upstream baseline failures reproduced: a proxy-sensitive Codex mock returned 502 and an unrelated Tauri OpenCode Go assertion failed before the subsequent upstream fix)
- [ ] For full pre-release validation: not applicable to this provider-only change
- [ ] For installer/release changes: not applicable
- [ ] Thermo-nuclear code quality review completed before submitting (not run; completed a rigorous local diff and self-review instead)
- [x] Other: pre-fix quoted-`agy.exe` regression failed as expected; 22 Antigravity tests passed; shared and Tauri clippy with `-D warnings` passed; targeted rustfmt passed; patched native-Windows CLI detected the live local Antigravity service and returned quota buckets.

## UI / tray proof

- [x] Not applicable
- [ ] CUA Driver visual proof attached
- [ ] CUA Driver could not be used; equivalent manual proof and explanation attached

## Notes for reviewers

The executable match stays token-bound and retains negative coverage for similarly named executables. The proxy bypass is limited to the provider's fixed loopback language-server clients; no credentials or quota payloads are included.