### PR TITLE
Port upstream 0.55.0: Command Code Pro tier

### DIFF
--- a/rust/src/providers/commandcode/mod.rs
+++ b/rust/src/providers/commandcode/mod.rs
@@ -65,6 +65,11 @@ const PLANS: &[CommandCodePlan] = &[
         monthly_credits_usd: 30.0,
     },
     CommandCodePlan {
+        id: "individual-pro-v1",
+        display_name: "Pro",
+        monthly_credits_usd: 80.0,
+    },
+    CommandCodePlan {
         id: "individual-max",
         display_name: "Max",
         monthly_credits_usd: 150.0,
@@ -712,6 +717,10 @@ mod tests {
         assert_eq!(
             find_plan("individual-goat").unwrap().monthly_credits_usd,
             70.0
+        );
+        assert_eq!(
+            find_plan("individual-pro-v1").unwrap().monthly_credits_usd,
+            80.0
         );
         assert_eq!(find_plan("Individual-ULTRA").unwrap().display_name, "Ultra");
         assert!(find_plan("team").is_none());


### PR DESCRIPTION
## Summary
- port upstream CodexBar v0.54.1 Command Code `individual-pro-v1` plan support
- map the repriced Pro tier to an $80 monthly credit grant while preserving legacy `individual-pro` at $30
- extend focused plan-catalog regression coverage

## Upstream evidence
- tag: `v0.54.1`
- upstream commit: `5506a78a4` / #3116

## Validation
- `C:/Users/mac/.cargo/bin/cargo.exe test -p codexbar commandcode` -> 15 passed
- focused rustfmt on `rust/src/providers/commandcode/mod.rs`
- full `cargo fmt --all --check` is currently blocked by unrelated formatting drift already present on `origin/main`; this PR does not touch those files

## Scope
This is one isolated upstream-port workstream. No Win-CodexBar version bump and no unrelated provider/UI changes.
