### PR TITLE
Sync Cargo.lock to 0.54.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codexbar"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "codexbar-desktop-tauri"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "chrono",
  "codexbar",


### PR DESCRIPTION
## Summary

Commit 21a7b7fac bumped the `codexbar` and `codexbar-desktop-tauri` manifest versions to 0.54.0, but `Cargo.lock` was not updated. As a result, every cargo build regenerates the lock file and dirties the working tree.

This commit syncs only the two version entries in `Cargo.lock` from 0.53.0 to 0.54.0. No dependencies were changed — `cargo metadata --no-deps` confirms the lock is consistent with the manifests.