### PR TITLE
Port upstream 0.55.0: resolve Alibaba SEC_TOKEN

### DIFF
--- a/rust/src/providers/alibabatokenplan/mod.rs
+++ b/rust/src/providers/alibabatokenplan/mod.rs
@@ -134,6 +134,11 @@ impl AlibabaTokenPlanProvider {
             .header("Content-Type", "application/x-www-form-urlencoded")
             .header("Origin", region.gateway_base_url())
             .header("Referer", region.dashboard_url())
+            .header("Referer", region.dashboard_url())
+            .header("Sec-Fetch-Site", "same-origin")
+            .header("Sec-Fetch-Mode", "navigate")
+            .header("Sec-Fetch-Dest", "document")
+            .header("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
             .header("User-Agent", USER_AGENT)
             .header("X-Requested-With", "XMLHttpRequest")
             .form(&form);
@@ -468,6 +473,7 @@ fn extract_sec_token(html: &str) -> Option<String> {
         r#""sec_token"\s*:\s*"([^"]+)""#,
         r#"secToken['"]?\s*[:=]\s*['"]([^'"]+)['"]"#,
         r#"sec_token['"]?\s*[:=]\s*['"]([^'"]+)['"]"#,
+        r#"SEC_TOKEN['"]?\s*[:=]\s*['"]([^'"]+)['"]"#,
     ] {
         let Ok(regex) = Regex::new(pattern) else {
             continue;
@@ -1047,6 +1053,13 @@ mod tests {
         assert_eq!(
             extract_sec_token(r#"<script>{"secToken":"abc123"}</script>"#).as_deref(),
             Some("abc123")
+        );
+        assert_eq!(
+            extract_sec_token(
+                r#"<script>window.ALIYUN_CONSOLE_CONFIG = { SEC_TOKEN: "upper123" };</script>"#
+            )
+            .as_deref(),
+            Some("upper123")
         );
         assert_eq!(
             cookie_value("sec_token", "foo=bar; sec_token=xyz"),

--- a/rust/src/providers/alibabatokenplan/mod.rs
+++ b/rust/src/providers/alibabatokenplan/mod.rs
@@ -134,11 +134,6 @@ impl AlibabaTokenPlanProvider {
             .header("Content-Type", "application/x-www-form-urlencoded")
             .header("Origin", region.gateway_base_url())
             .header("Referer", region.dashboard_url())
-            .header("Referer", region.dashboard_url())
-            .header("Sec-Fetch-Site", "same-origin")
-            .header("Sec-Fetch-Mode", "navigate")
-            .header("Sec-Fetch-Dest", "document")
-            .header("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
             .header("User-Agent", USER_AGENT)
             .header("X-Requested-With", "XMLHttpRequest")
             .form(&form);
@@ -205,6 +200,11 @@ impl AlibabaTokenPlanProvider {
                 "Accept",
                 "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             )
+            .header("Referer", dashboard_referer(region))
+            .header("Sec-Fetch-Site", "same-origin")
+            .header("Sec-Fetch-Mode", "navigate")
+            .header("Sec-Fetch-Dest", "document")
+            .header("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
             .header("User-Agent", USER_AGENT)
             .send()
             .await
@@ -465,6 +465,10 @@ pub(super) fn cookie_value(name: &str, cookie_header: &str) -> Option<String> {
             .then(|| value.trim().to_string())
             .filter(|value| !value.is_empty())
     })
+}
+
+fn dashboard_referer(region: Region) -> String {
+    format!("{}/", region.gateway_base_url().trim_end_matches('/'))
 }
 
 fn extract_sec_token(html: &str) -> Option<String> {
@@ -1064,6 +1068,18 @@ mod tests {
         assert_eq!(
             cookie_value("sec_token", "foo=bar; sec_token=xyz"),
             Some("xyz".to_string())
+        );
+    }
+
+    #[test]
+    fn sec_token_shell_referer_uses_same_origin_root() {
+        assert_eq!(
+            dashboard_referer(Region::CnPersonal),
+            "https://bailian.console.aliyun.com/"
+        );
+        assert_eq!(
+            dashboard_referer(Region::IntlPersonal),
+            "https://modelstudio.console.alibabacloud.com/"
         );
     }
 


### PR DESCRIPTION
## Summary
- port upstream CodexBar v0.55.0 Alibaba mainland Personal/Solo `SEC_TOKEN` discovery from #3098
- send browser-navigation headers when loading the OneConsole shell so it server-renders the security token
- recognize the uppercase `SEC_TOKEN` shell shape while preserving existing lowercase token shapes

## Upstream evidence
- target release: `v0.55.0`
- upstream commit: `4933e2301` / #3098

## Validation
- `C:/Users/mac/.cargo/bin/cargo.exe test -p codexbar alibabatokenplan` -> 13 passed
- focused rustfmt on `rust/src/providers/alibabatokenplan/mod.rs`

## Scope
Isolated provider-auth compatibility port. No UI, version bump, or unrelated provider changes.
