### PR TITLE
Port upstream 0.55.0: truncate agent session names

### DIFF
--- a/apps/desktop-tauri/src/components/AgentSessions.test.tsx
+++ b/apps/desktop-tauri/src/components/AgentSessions.test.tsx
@@ -83,7 +83,10 @@ describe("AgentSessions", () => {
     expect(await screen.findByText("AgentSessionsProviderPi")).toBeTruthy();
     expect(await screen.findByText("AgentSessionsProviderOmp")).toBeTruthy();
     // sessionName shown when present; project fallback otherwise.
-    expect(await screen.findByText("OMP fixture")).toBeTruthy();
+    const ompName = await screen.findByText("OMP fixture");
+    expect(ompName).toBeTruthy();
+    expect(ompName.getAttribute("title")).toBe("OMP fixture");
+    expect(ompName.className).toContain("agent-sessions__name");
     expect(
       (await screen.findAllByText("proj")).length > 0,
     ).toBeTruthy();

--- a/apps/desktop-tauri/src/components/AgentSessions.tsx
+++ b/apps/desktop-tauri/src/components/AgentSessions.tsx
@@ -61,7 +61,10 @@ export default function AgentSessions() {
           onClick={() => focus(session)}
         >
           <span>{sessionLabel(session)}</span>
-          <span>
+          <span
+            className="agent-sessions__name"
+            title={session.sessionName ?? session.workspace.projectName ?? session.host}
+          >
             {session.sessionName ?? session.workspace.projectName ?? session.host}
           </span>
           <span>{session.state}</span>

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -5918,6 +5918,15 @@ html:has(.menu-surface--tray) {
   cursor: pointer;
 }
 
+.agent-sessions__name {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+}
+
 .agent-sessions__error {
   color: var(--provider-status-error);
 }


### PR DESCRIPTION
## Summary
- port upstream CodexBar v0.55.0 agent-session width fix from #3096
- truncate long session names inside the Windows tray panel instead of allowing them to stretch the menu
- keep the full session name available via the native tooltip/title

## Upstream evidence
- target release: `v0.55.0`
- upstream commit: `36e2be4a7` / #3096

## Validation
- `git diff --check` -> pass
- focused Vitest invocation is currently blocked by the local pnpm/Corepack shim missing its bundled `pnpm.js`; test coverage was updated and will run in hosted CI/final local gate
- fresh Windows CUA proof remains required before final 0.55 closure because this changes tray UI presentation

## Scope
Isolated tray-panel presentation port. No provider/accounting semantics or version bump.
