### PR TITLE
Port upstream 0.55.0: scale single-quota tray icons

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -671,28 +671,14 @@ fn selected_tray_percents(
     snapshot: &crate::commands::ProviderUsageSnapshot,
     settings: &Settings,
 ) -> (f64, Option<f64>) {
-    let selected = crate::usage_metric::selected_usage_window(snapshot, settings);
-    let primary = display_metric_percent(selected.used_percent, settings.show_as_used);
-
-    let meaningful_count = std::iter::once(&snapshot.primary)
-        .chain(snapshot.secondary.iter())
-        .chain(snapshot.tertiary.iter())
-        .filter(|window| !window.is_informational)
-        .count();
-    if meaningful_count <= 1 {
-        // Upstream #3155: one meaningful quota should occupy the full meter instead
-        // of being rendered beside a reserved/duplicated empty lane. This also
-        // covers providers whose sole real quota arrives in the secondary slot.
-        return (primary, None);
-    }
-
-    let secondary = snapshot
-        .secondary
-        .as_ref()
-        .filter(|window| !window.is_informational)
-        .map(|window| display_metric_percent(window.used_percent, settings.show_as_used));
-
-    (primary, secondary)
+    let (selected, companion) =
+        crate::usage_metric::selected_usage_icon_windows(snapshot, settings);
+    (
+        display_metric_percent(selected.used_percent, settings.show_as_used),
+        companion
+            .as_ref()
+            .map(|window| display_metric_percent(window.used_percent, settings.show_as_used)),
+    )
 }
 
 fn display_metric_percent(used_percent: f64, show_as_used: bool) -> f64 {
@@ -1407,6 +1393,19 @@ mod tests {
 
         assert_eq!(primary, 42.0);
         assert_eq!(secondary, None);
+    }
+
+    #[test]
+    fn selected_secondary_quota_is_not_duplicated_when_tertiary_is_meaningful() {
+        let settings = Settings::default();
+        let mut snapshot =
+            fake_snapshot_with("claude", "Claude", 0.0, Some(42.0), Some(30.0), None);
+        snapshot.primary.is_informational = true;
+
+        let (primary, secondary) = selected_tray_percents(&snapshot, &settings);
+
+        assert_eq!(primary, 42.0);
+        assert_eq!(secondary, Some(30.0));
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -671,17 +671,28 @@ fn selected_tray_percents(
     snapshot: &crate::commands::ProviderUsageSnapshot,
     settings: &Settings,
 ) -> (f64, Option<f64>) {
-    let primary = crate::usage_metric::selected_usage_window(snapshot, settings).used_percent;
+    let selected = crate::usage_metric::selected_usage_window(snapshot, settings);
+    let primary = display_metric_percent(selected.used_percent, settings.show_as_used);
+
+    let meaningful_count = std::iter::once(&snapshot.primary)
+        .chain(snapshot.secondary.iter())
+        .chain(snapshot.tertiary.iter())
+        .filter(|window| !window.is_informational)
+        .count();
+    if meaningful_count <= 1 {
+        // Upstream #3155: one meaningful quota should occupy the full meter instead
+        // of being rendered beside a reserved/duplicated empty lane. This also
+        // covers providers whose sole real quota arrives in the secondary slot.
+        return (primary, None);
+    }
 
     let secondary = snapshot
         .secondary
         .as_ref()
-        .map(|w| display_metric_percent(w.used_percent, settings.show_as_used));
+        .filter(|window| !window.is_informational)
+        .map(|window| display_metric_percent(window.used_percent, settings.show_as_used));
 
-    (
-        display_metric_percent(primary, settings.show_as_used),
-        secondary,
-    )
+    (primary, secondary)
 }
 
 fn display_metric_percent(used_percent: f64, show_as_used: bool) -> f64 {
@@ -1384,6 +1395,30 @@ mod tests {
         let (primary, _) = selected_tray_percents(&snapshot, &settings);
 
         assert_eq!(primary, 72.0);
+    }
+
+    #[test]
+    fn single_meaningful_secondary_quota_uses_full_single_meter() {
+        let settings = Settings::default();
+        let mut snapshot = fake_snapshot_with("claude", "Claude", 0.0, Some(42.0), None, None);
+        snapshot.primary.is_informational = true;
+
+        let (primary, secondary) = selected_tray_percents(&snapshot, &settings);
+
+        assert_eq!(primary, 42.0);
+        assert_eq!(secondary, None);
+    }
+
+    #[test]
+    fn two_meaningful_quotas_keep_two_meter_layout() {
+        let mut settings = Settings::default();
+        settings.set_provider_metric(ProviderId::Cursor, MetricPreference::Session);
+        let snapshot = fake_snapshot_with("cursor", "Cursor", 15.0, Some(40.0), None, None);
+
+        let (primary, secondary) = selected_tray_percents(&snapshot, &settings);
+
+        assert_eq!(primary, 15.0);
+        assert_eq!(secondary, Some(40.0));
     }
 
     #[test]

--- a/apps/desktop-tauri/src-tauri/src/usage_metric.rs
+++ b/apps/desktop-tauri/src-tauri/src/usage_metric.rs
@@ -21,6 +21,42 @@ pub(crate) fn selected_usage_window(
         .unwrap_or_else(|| snapshot.primary.clone())
 }
 
+/// Select the primary tray metric and, when there are multiple meaningful core
+/// quotas, one distinct companion lane. Keeping this policy beside canonical
+/// metric selection prevents tray rendering from duplicating the selected lane.
+pub(crate) fn selected_usage_icon_windows(
+    snapshot: &ProviderUsageSnapshot,
+    settings: &Settings,
+) -> (RateWindowSnapshot, Option<RateWindowSnapshot>) {
+    let selected = selected_usage_window(snapshot, settings);
+    let meaningful_count = std::iter::once(&snapshot.primary)
+        .chain(snapshot.secondary.iter())
+        .chain(snapshot.tertiary.iter())
+        .filter(|window| !window.is_informational)
+        .count();
+    if meaningful_count <= 1 {
+        return (selected, None);
+    }
+
+    let companion = snapshot
+        .secondary
+        .iter()
+        .chain(std::iter::once(&snapshot.primary))
+        .chain(snapshot.tertiary.iter())
+        .filter(|window| !window.is_informational)
+        .find(|window| !same_window(window, &selected))
+        .cloned();
+    (selected, companion)
+}
+
+fn same_window(left: &RateWindowSnapshot, right: &RateWindowSnapshot) -> bool {
+    left.used_percent.to_bits() == right.used_percent.to_bits()
+        && left.window_minutes == right.window_minutes
+        && left.resets_at == right.resets_at
+        && left.reset_description == right.reset_description
+        && left.is_informational == right.is_informational
+}
+
 fn preferred_window(
     snapshot: &ProviderUsageSnapshot,
     provider: Option<ProviderId>,


### PR DESCRIPTION
## Summary
- port upstream CodexBar v0.55.0 single-quota icon scaling from #3155
- when a provider has only one meaningful quota, render it as one full-width tray meter instead of pairing it with an unavailable/duplicated second lane
- cover the case where the sole meaningful quota arrives in the secondary slot

## Upstream evidence
- target release: `v0.55.0`
- upstream commit: `daa16fb84` / #3155

## Validation
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml selected_tray_percent --no-fail-fast` -> 4 passed
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml meaningful --no-fail-fast` -> 2 passed
- focused rustfmt and `git diff --check` -> pass

## Scope
Isolated Windows tray presentation port. Fresh Windows CUA proof remains part of the final v0.55 UI closure gate.
