### PR TITLE
Port upstream 0.55.0: Antigravity local spend

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/usage_spend.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/usage_spend.rs
@@ -322,6 +322,17 @@ fn build_usage_spend_summary(
                 }
                 spend
             }
+            "antigravity" => {
+                let seven = codexbar::providers::antigravity::local_sessions::summarize(7);
+                let thirty = codexbar::providers::antigravity::local_sessions::summarize(30);
+                let mut spend = cached_spend(cached_snapshot);
+                spend.seven_day_tokens = (seven.session_count > 0).then_some(seven.total_tokens);
+                spend.thirty_day_tokens = (thirty.session_count > 0).then_some(thirty.total_tokens);
+                if thirty.session_count > 0 {
+                    spend.source = "local Antigravity sessions".to_string();
+                }
+                spend
+            }
             _ => cached_spend(cached_snapshot),
         };
 

--- a/rust/src/providers/antigravity/local_sessions.rs
+++ b/rust/src/providers/antigravity/local_sessions.rs
@@ -1,0 +1,162 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Duration, Local, TimeZone, Utc};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LocalSessionSummary {
+    pub total_tokens: u64,
+    pub session_count: usize,
+}
+
+pub fn summarize(days: u32) -> LocalSessionSummary {
+    summarize_paths(&tokscale_paths(None), Utc::now(), days)
+}
+
+fn tokscale_paths(home: Option<&Path>) -> Vec<PathBuf> {
+    let base = if let Some(home) = home {
+        home.join(".config")
+            .join("tokscale")
+            .join("antigravity-cache")
+            .join("sessions")
+    } else if let Ok(root) = std::env::var("TOKSCALE_CONFIG_DIR") {
+        PathBuf::from(root)
+            .join("antigravity-cache")
+            .join("sessions")
+    } else {
+        let Some(home) = dirs::home_dir() else {
+            return Vec::new();
+        };
+        home.join(".config")
+            .join("tokscale")
+            .join("antigravity-cache")
+            .join("sessions")
+    };
+    let Ok(entries) = fs::read_dir(base) else {
+        return Vec::new();
+    };
+    let mut paths: Vec<_> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("jsonl"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn summarize_paths(paths: &[PathBuf], now: DateTime<Utc>, days: u32) -> LocalSessionSummary {
+    let first_day = now.with_timezone(&Local).date_naive()
+        - Duration::days(i64::from(days.clamp(1, 365).saturating_sub(1)));
+    let mut total_tokens = 0_u64;
+    let mut sessions_with_usage = HashSet::new();
+    let mut seen_response_ids = HashSet::new();
+
+    for path in paths {
+        let Ok(text) = fs::read_to_string(path) else {
+            continue;
+        };
+        let mut path_had_usage = false;
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let Ok(value) = serde_json::from_str::<Value>(line) else {
+                continue;
+            };
+            let kind = value.get("type").and_then(Value::as_str);
+            if kind != Some("usage") && value.get("input").is_none() {
+                continue;
+            }
+            if let Some(response_id) = value
+                .get("responseId")
+                .or_else(|| value.get("response_id"))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                && !seen_response_ids.insert(response_id.to_string())
+            {
+                continue;
+            }
+
+            let timestamp_ms = value
+                .get("timestamp")
+                .and_then(Value::as_i64)
+                .unwrap_or_default();
+            let Some(at) = Utc.timestamp_millis_opt(timestamp_ms).single() else {
+                continue;
+            };
+            if at > now || at.with_timezone(&Local).date_naive() < first_day {
+                continue;
+            }
+
+            let input = token_field(&value, &["input"]);
+            let output = token_field(&value, &["output"]);
+            let cache_read = token_field(&value, &["cacheRead", "cache_read"]);
+            let cache_write = token_field(&value, &["cacheWrite", "cache_write"]);
+            let total = input
+                .saturating_add(output)
+                .saturating_add(cache_read)
+                .saturating_add(cache_write);
+            if total == 0 {
+                continue;
+            }
+            total_tokens = total_tokens.saturating_add(total);
+            path_had_usage = true;
+        }
+        if path_had_usage {
+            sessions_with_usage.insert(path.clone());
+        }
+    }
+
+    LocalSessionSummary {
+        total_tokens,
+        session_count: sessions_with_usage.len(),
+    }
+}
+
+fn token_field(value: &Value, keys: &[&str]) -> u64 {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_u64))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summarizes_tokscale_jsonl_and_deduplicates_response_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-a.jsonl");
+        fs::write(&path, concat!(
+            "{\"type\":\"session_meta\",\"modelId\":\"test-model-antigravity-a\"}\n",
+            "{\"type\":\"usage\",\"responseId\":\"r1\",\"timestamp\":1787572800000,\"input\":100,\"output\":20,\"cacheRead\":10,\"cacheWrite\":5}\n",
+            "{\"type\":\"usage\",\"response_id\":\"r1\",\"timestamp\":1787572800000,\"input\":100,\"output\":20}\n"
+        )).unwrap();
+        let now = Utc.timestamp_millis_opt(1787576400000).single().unwrap();
+        let summary = summarize_paths(&[path], now, 7);
+        assert_eq!(summary.total_tokens, 135);
+        assert_eq!(summary.session_count, 1);
+    }
+
+    #[test]
+    fn excludes_usage_outside_requested_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-a.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"usage\",\"timestamp\":1787572800000,\"input\":10,\"output\":5}\n",
+                "{\"type\":\"usage\",\"timestamp\":1784894400000,\"input\":99,\"output\":99}\n"
+            ),
+        )
+        .unwrap();
+        let now = Utc.timestamp_millis_opt(1787576400000).single().unwrap();
+        let summary = summarize_paths(&[path], now, 7);
+        assert_eq!(summary.total_tokens, 15);
+        assert_eq!(summary.session_count, 1);
+    }
+}

--- a/rust/src/providers/antigravity/local_sessions.rs
+++ b/rust/src/providers/antigravity/local_sessions.rs
@@ -15,6 +15,43 @@ pub fn summarize(days: u32) -> LocalSessionSummary {
     summarize_paths(&tokscale_paths(None), Utc::now(), days)
 }
 
+/// Count local Antigravity conversation artifacts for the quota provider's
+/// offline fallback. Mirrors upstream #3119 without opening SQLite files.
+pub fn offline_conversation_count() -> usize {
+    let Some(home) = dirs::home_dir() else {
+        return 0;
+    };
+    offline_conversation_count_in(&home)
+}
+
+fn offline_conversation_count_in(home: &Path) -> usize {
+    let gemini = home.join(".gemini");
+    let roots = [
+        gemini.join("antigravity-cli").join("conversations"),
+        gemini.join("antigravity"),
+        gemini.join("antigravity").join("conversations"),
+    ];
+    let db_count = roots
+        .iter()
+        .map(|root| count_extension(root, "db"))
+        .sum::<usize>();
+    if db_count > 0 {
+        return db_count;
+    }
+    tokscale_paths(Some(home)).len()
+}
+
+fn count_extension(root: &Path, extension: &str) -> usize {
+    fs::read_dir(root)
+        .ok()
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some(extension))
+        .count()
+}
+
 fn tokscale_paths(home: Option<&Path>) -> Vec<PathBuf> {
     let base = if let Some(home) = home {
         home.join(".config")
@@ -140,6 +177,36 @@ mod tests {
         let summary = summarize_paths(&[path], now, 7);
         assert_eq!(summary.total_tokens, 135);
         assert_eq!(summary.session_count, 1);
+    }
+
+    #[test]
+    fn offline_count_prefers_cli_and_app_db_artifacts_then_tokscale() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir
+            .path()
+            .join(".gemini")
+            .join("antigravity")
+            .join("conversations");
+        fs::create_dir_all(&app).unwrap();
+        fs::write(app.join("a.db"), b"").unwrap();
+        fs::write(app.join("a.db-wal"), b"").unwrap();
+        assert_eq!(offline_conversation_count_in(dir.path()), 1);
+
+        fs::remove_file(app.join("a.db")).unwrap();
+        let cache = dir
+            .path()
+            .join(".config")
+            .join("tokscale")
+            .join("antigravity-cache")
+            .join("sessions");
+        fs::create_dir_all(&cache).unwrap();
+        fs::write(
+            cache.join("one.jsonl"),
+            b"{}
+",
+        )
+        .unwrap();
+        assert_eq!(offline_conversation_count_in(dir.path()), 1);
     }
 
     #[test]

--- a/rust/src/providers/antigravity/local_sessions.rs
+++ b/rust/src/providers/antigravity/local_sessions.rs
@@ -1,9 +1,14 @@
 use std::collections::HashSet;
-use std::fs;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Duration, Local, TimeZone, Utc};
 use serde_json::Value;
+
+const MAX_SESSION_FILES: usize = 2048;
+const MAX_SESSION_FILE_BYTES: usize = 32 * 1024 * 1024;
+const MAX_JSONL_LINE_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct LocalSessionSummary {
@@ -80,6 +85,9 @@ fn tokscale_paths(home: Option<&Path>) -> Vec<PathBuf> {
         .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("jsonl"))
         .collect();
     paths.sort();
+    if paths.len() > MAX_SESSION_FILES {
+        paths.drain(..paths.len() - MAX_SESSION_FILES);
+    }
     paths
 }
 
@@ -90,17 +98,18 @@ fn summarize_paths(paths: &[PathBuf], now: DateTime<Utc>, days: u32) -> LocalSes
     let mut sessions_with_usage = HashSet::new();
     let mut seen_response_ids = HashSet::new();
 
-    for path in paths {
-        let Ok(text) = fs::read_to_string(path) else {
+    for path in paths.iter().take(MAX_SESSION_FILES) {
+        let Ok(file) = File::open(path) else {
             continue;
         };
+        let mut reader = BufReader::new(file);
+        let mut remaining = MAX_SESSION_FILE_BYTES;
         let mut path_had_usage = false;
-        for line in text.lines() {
-            let line = line.trim();
+        while let Ok(Some(line)) = read_bounded_jsonl_line(&mut reader, &mut remaining) {
             if line.is_empty() {
                 continue;
             }
-            let Ok(value) = serde_json::from_str::<Value>(line) else {
+            let Ok(value) = serde_json::from_slice::<Value>(&line) else {
                 continue;
             };
             let kind = value.get("type").and_then(Value::as_str);
@@ -151,6 +160,51 @@ fn summarize_paths(paths: &[PathBuf], now: DateTime<Utc>, days: u32) -> LocalSes
     LocalSessionSummary {
         total_tokens,
         session_count: sessions_with_usage.len(),
+    }
+}
+
+fn read_bounded_jsonl_line<R: BufRead>(
+    reader: &mut R,
+    remaining_file_bytes: &mut usize,
+) -> std::io::Result<Option<Vec<u8>>> {
+    if *remaining_file_bytes == 0 {
+        return Ok(None);
+    }
+    let mut line = Vec::new();
+    let mut saw_input = false;
+    let mut discarding = false;
+
+    loop {
+        let chunk = reader.fill_buf()?;
+        if chunk.is_empty() {
+            return Ok(saw_input.then_some(if discarding { Vec::new() } else { line }));
+        }
+        let bounded_len = chunk.len().min(*remaining_file_bytes);
+        if bounded_len == 0 {
+            return Ok(None);
+        }
+        let bounded = &chunk[..bounded_len];
+        let newline = bounded.iter().position(|byte| *byte == b'\n');
+        let segment_end = newline.unwrap_or(bounded.len());
+        let segment = &bounded[..segment_end];
+        saw_input = saw_input || !segment.is_empty() || newline.is_some();
+        if !discarding {
+            if line.len().saturating_add(segment.len()) <= MAX_JSONL_LINE_BYTES {
+                line.extend_from_slice(segment);
+            } else {
+                line.clear();
+                discarding = true;
+            }
+        }
+        let consumed = segment_end + usize::from(newline.is_some());
+        reader.consume(consumed);
+        *remaining_file_bytes = remaining_file_bytes.saturating_sub(consumed);
+        if newline.is_some() {
+            return Ok(Some(if discarding { Vec::new() } else { line }));
+        }
+        if *remaining_file_bytes == 0 {
+            return Ok(Some(Vec::new()));
+        }
     }
 }
 
@@ -221,6 +275,24 @@ mod tests {
             ),
         )
         .unwrap();
+        let now = Utc.timestamp_millis_opt(1787576400000).single().unwrap();
+        let summary = summarize_paths(&[path], now, 7);
+        assert_eq!(summary.total_tokens, 15);
+        assert_eq!(summary.session_count, 1);
+    }
+
+    #[test]
+    fn oversized_jsonl_line_is_discarded_and_next_usage_row_is_counted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-a.jsonl");
+        let mut text = format!(
+            r#"{{"type":"usage","padding":"{}"}}"#,
+            "x".repeat(MAX_JSONL_LINE_BYTES + 32)
+        );
+        text.push('\n');
+        text.push_str(r#"{"type":"usage","timestamp":1787572800000,"input":10,"output":5}"#);
+        text.push('\n');
+        fs::write(&path, text).unwrap();
         let now = Utc.timestamp_millis_opt(1787576400000).single().unwrap();
         let summary = summarize_paths(&[path], now, 7);
         assert_eq!(summary.total_tokens, 15);

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -3,6 +3,8 @@
 //! Fetches usage data from Antigravity's local language server probe
 //! Uses Windows process detection to find CSRF token
 
+pub mod local_sessions;
+
 use async_trait::async_trait;
 use regex_lite::Regex;
 use serde::Deserialize;

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -531,6 +531,19 @@ impl Provider for AntigravityProvider {
         match self.fetch_user_status().await {
             Ok(usage) => Ok(ProviderFetchResult::new(usage, "local")),
             Err(e) => {
+                let count = local_sessions::offline_conversation_count();
+                if count > 0 {
+                    let noun = if count == 1 {
+                        "conversation"
+                    } else {
+                        "conversations"
+                    };
+                    let usage = UsageSnapshot::new(RateWindow::informational(format!(
+                        "Offline · {count} {noun}"
+                    )))
+                    .with_login_method("offline");
+                    return Ok(ProviderFetchResult::new(usage, "offline"));
+                }
                 tracing::warn!("Antigravity probe failed: {}", e);
                 Err(e)
             }

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -383,6 +383,15 @@ impl AntigravityProvider {
 
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
+            if process_info.source == ProcessSource::Cli
+                && (status == reqwest::StatusCode::UNAUTHORIZED
+                    || status == reqwest::StatusCode::FORBIDDEN
+                    || text.to_ascii_lowercase().contains("not logged")
+                    || text.to_ascii_lowercase().contains("login method")
+                    || text.to_ascii_lowercase().contains("keyring"))
+            {
+                return Err(ProviderError::AuthRequired);
+            }
             return Err(ProviderError::Other(format!(
                 "API error {}: {}",
                 status, text

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -763,12 +763,28 @@ fn model_label(config: &ModelConfig) -> &str {
     }
 }
 
+fn canonical_model_id(raw: &str) -> &str {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "gemini-3.6-flash"
+        | "gemini-3.6-flash-low"
+        | "gemini-3.6-flash-medium"
+        | "gemini-3.6-flash-high"
+        | "gemini-3.5-flash-extra-low"
+        | "gemini-3.5-flash-low"
+        | "gemini-3.5-flash-mid"
+        | "gemini-3.5-flash-high"
+        | "gemini-3-flash-agent" => "gemini-3.7-flash",
+        _ => raw,
+    }
+}
+
 fn model_window_id(config: &ModelConfig) -> String {
     let raw = config
         .model_id
         .as_deref()
         .or(config.id.as_deref())
         .unwrap_or_else(|| model_label(config));
+    let raw = canonical_model_id(raw);
     let slug = raw
         .chars()
         .map(|ch| {

--- a/rust/src/providers/antigravity/tests.rs
+++ b/rust/src/providers/antigravity/tests.rs
@@ -23,6 +23,19 @@ fn test_classify_model_families() {
 }
 
 #[test]
+fn retired_flash_ids_collapse_to_current_wire_id() {
+    for id in [
+        "gemini-3.6-flash",
+        "gemini-3.6-flash-high",
+        "gemini-3.5-flash-extra-low",
+        "gemini-3-flash-agent",
+    ] {
+        assert_eq!(canonical_model_id(id), "gemini-3.7-flash");
+    }
+    assert_eq!(canonical_model_id("gemini-3.7-flash"), "gemini-3.7-flash");
+}
+
+#[test]
 fn parses_current_language_server_process() {
     let output = r"4242	C:\Users\test\AppData\Local\Programs\Antigravity\resources\bin\language_server.exe --csrf_token 11111111-2222-3333-4444-555555555555 --extension_server_port 54123";
 


### PR DESCRIPTION
## Summary
- port upstream CodexBar v0.55.0 Antigravity tokscale-compatible local spend reader from #3113
- read `~/.config/tokscale/antigravity-cache/sessions/*.jsonl` (or `TOKSCALE_CONFIG_DIR`) without auth
- deduplicate repeated usage rows by response ID and publish 7-day / 30-day token totals into Usage & Spend
- keep Antigravity local usage unpriced, matching upstream: token evidence is surfaced without inventing cost

## Upstream evidence
- target release: `v0.55.0`
- upstream commit: `7427660af` / #3113

## Validation
- `cargo test -p codexbar antigravity::local_sessions` -> 2 passed
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml usage_spend --no-fail-fast` -> compile/test pass
- focused rustfmt and `git diff --check` -> pass

## Scope
Antigravity local-spend publication only. Direct Antigravity CLI SQLite parsing remains outside this phase, matching upstream's own stubbed direct-DB reader in #3113.