### PR TITLE
Port upstream 0.55.0: clarify Chinese quota labels

### DIFF
--- a/apps/desktop-tauri/src/components/MenuCard.test.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.test.tsx
@@ -375,6 +375,31 @@ describe("MenuCard", () => {
     expect(screen.queryByText("Session")).not.toBeInTheDocument();
   });
 
+  it("uses explicit hourly quota labels in Simplified Chinese", async () => {
+    tauriMocks.getLocaleStrings.mockResolvedValue(buildBundle({}, "chinese"));
+    const snapshot = provider(null, 31);
+    snapshot.primary = rateWindow(31, { windowMinutes: 3 * 60 });
+    snapshot.selectedMetric = snapshot.primary;
+
+    renderCard(snapshot);
+
+    expect(await screen.findByText("3 小时")).toBeInTheDocument();
+    expect(screen.queryByText("Session")).not.toBeInTheDocument();
+  });
+
+  it("maps a Simplified Chinese session-labelled weekly window to Weekly", async () => {
+    tauriMocks.getLocaleStrings.mockResolvedValue(
+      buildBundle({ ProviderWeeklyLabel: "本周" }, "chinese"),
+    );
+    const snapshot = provider(null, 31);
+    snapshot.primary = rateWindow(31, { windowMinutes: 7 * 24 * 60 });
+    snapshot.selectedMetric = snapshot.primary;
+
+    renderCard(snapshot);
+
+    expect(await screen.findByText("本周")).toBeInTheDocument();
+  });
+
   it("notifies the tray panel after async local usage data loads", async () => {
     const onLayoutChange = vi.fn();
 

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -72,8 +72,16 @@ export function maskEmail(email: string): string {
 function localizeWindowLabel(
   raw: string | undefined,
   t: (key: LocaleKey) => string,
+  language?: string,
+  windowMinutes?: number | null,
 ): string {
   const normalized = raw?.trim().toLowerCase();
+  // Upstream 0.55.0 #3070: quota windows in Simplified Chinese use their
+  // actual duration instead of the conversational Session wording.
+  if (language === "chinese" && normalized === "session") {
+    if (windowMinutes === 5 * 60) return "5 小时";
+    if (windowMinutes === 7 * 24 * 60) return t("ProviderWeeklyLabel");
+  }
   if (normalized === "weekly") {
     return t("ProviderWeeklyLabel");
   }
@@ -127,7 +135,7 @@ export default function MenuCard({
     compactMetrics = false,
     costSummaryDisplayStyle,
   } = display;
-  const { t } = useLocale();
+  const { t, language } = useLocale();
   const [chartData, setChartData] = useState<ProviderChartData | null>(null);
   const [pricingStatus, setPricingStatus] = useState<DeepSeekPricingStatus | null>(null);
 
@@ -179,7 +187,7 @@ export default function MenuCard({
       : [
           {
             id: "primary",
-            label: provider.primaryLabel ?? t("DetailWindowPrimary"),
+            label: localizeWindowLabel(provider.primaryLabel, t, language, provider.primary.windowMinutes) || t("DetailWindowPrimary"),
             snap: provider.primary,
           },
         ]),

--- a/apps/desktop-tauri/src/components/MenuCard.tsx
+++ b/apps/desktop-tauri/src/components/MenuCard.tsx
@@ -78,9 +78,11 @@ function localizeWindowLabel(
   const normalized = raw?.trim().toLowerCase();
   // Upstream 0.55.0 #3070: quota windows in Simplified Chinese use their
   // actual duration instead of the conversational Session wording.
-  if (language === "chinese" && normalized === "session") {
-    if (windowMinutes === 5 * 60) return "5 小时";
+  if (language === "chinese" && normalized === "session" && windowMinutes != null) {
     if (windowMinutes === 7 * 24 * 60) return t("ProviderWeeklyLabel");
+    if (windowMinutes >= 60 && windowMinutes <= 12 * 60 && windowMinutes % 60 === 0) {
+      return `${windowMinutes / 60} 小时`;
+    }
   }
   if (normalized === "weekly") {
     return t("ProviderWeeklyLabel");


### PR DESCRIPTION
## Summary
- port upstream CodexBar v0.55.0 Simplified Chinese quota wording from #3070
- when a quota is the generic `Session` label and its real cadence is five hours, render `5 小时` for Simplified Chinese
- preserve the generic session wording for non-quota/conversation surfaces and other languages

## Upstream evidence
- target release: `v0.55.0`
- upstream commit: `1f77a5513` / #3070

## Validation
- `git diff --check` -> pass
- frontend test execution remains blocked locally by the broken pnpm/Corepack shim and is deferred to hosted CI/final frontend gate

## Scope
Isolated localization/presentation port. No provider semantics or version bump.
