### PR TITLE
Port upstream 0.55.0: refresh spend on provider updates

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/usage_spend.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/usage_spend.rs
@@ -141,7 +141,18 @@ fn usage_spend_cache_key(cached: &[ProviderUsageSnapshot], selected_days: u32) -
             let cost = snapshot
                 .cost
                 .as_ref()
-                .map(|cost| format!("{:.8}:{}", cost.used, cost.period))
+                .map(|cost| {
+                    let daily = cost
+                        .daily
+                        .iter()
+                        .map(|point| format!("{}:{:.8}", point.day, point.amount))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    format!(
+                        "{:.8}:{:?}:{:?}:{}:{}:{}",
+                        cost.used, cost.limit, cost.balance, cost.currency_code, cost.period, daily
+                    )
+                })
                 .unwrap_or_default();
             format!(
                 "{}:{}:{}:{}",

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/UsageSpendTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/UsageSpendTab.tsx
@@ -164,19 +164,20 @@ export default function UsageSpendTab(_props: TabProps) {
       });
   }, []);
 
-  const load = useCallback((forceRefresh = false) => {
-    setLoading(true);
-    setError(null);
-    void getUsageSpendSummary({ historyDays: selectedDays, forceRefresh })
-      .then((data) => {
-        setSummary(data);
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        setError(err instanceof Error ? err.message : String(err));
-        setLoading(false);
-      });
-  }, [includeOpenCodex, selectedDays]);
+  const load = useCallback(async (forceRefresh = false, silent = false) => {
+    if (!silent) {
+      setLoading(true);
+      setError(null);
+    }
+    try {
+      const data = await getUsageSpendSummary({ historyDays: selectedDays, forceRefresh });
+      setSummary(data);
+    } catch (err: unknown) {
+      if (!silent) setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (!silent) setLoading(false);
+    }
+  }, [hideNativeCodex, includeOpenCodex, selectedDays]);
 
   useEffect(() => {
     load(false);
@@ -192,11 +193,7 @@ export default function UsageSpendTab(_props: TabProps) {
     void listen("provider-updated", () => {
       if (timer) clearTimeout(timer);
       timer = setTimeout(() => {
-        void getUsageSpendSummary({ historyDays: selectedDays })
-          .then((data) => {
-            if (!cancelled) setSummary(data);
-          })
-          .catch(() => {});
+        if (!cancelled) void load(false, true);
       }, 200);
     }).then((fn) => {
       if (cancelled) fn();
@@ -207,7 +204,7 @@ export default function UsageSpendTab(_props: TabProps) {
       if (timer) clearTimeout(timer);
       unlisten?.();
     };
-  }, [selectedDays]);
+  }, [load]);
 
   const onShare = useCallback(() => {
     setShareError(null);

--- a/apps/desktop-tauri/src/surfaces/settings/tabs/UsageSpendTab.tsx
+++ b/apps/desktop-tauri/src/surfaces/settings/tabs/UsageSpendTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { save } from "@tauri-apps/plugin-dialog";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useLocale } from "../../../hooks/useLocale";
 import {
   getSettingsSnapshot,
@@ -180,6 +181,33 @@ export default function UsageSpendTab(_props: TabProps) {
   useEffect(() => {
     load(false);
   }, [load]);
+
+  // Upstream 0.55.0 #3106 parity: provider token/cost publications refresh
+  // Usage & Spend silently while the pane is open. Coalesce bursts so a
+  // multi-provider refresh does not trigger one dashboard rebuild per event.
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
+    void listen("provider-updated", () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        void getUsageSpendSummary({ historyDays: selectedDays })
+          .then((data) => {
+            if (!cancelled) setSummary(data);
+          })
+          .catch(() => {});
+      }, 200);
+    }).then((fn) => {
+      if (cancelled) fn();
+      else unlisten = fn;
+    }).catch(() => {});
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      unlisten?.();
+    };
+  }, [selectedDays]);
 
   const onShare = useCallback(() => {
     setShareError(null);


### PR DESCRIPTION
## Summary
- port upstream CodexBar v0.55.0 Usage & Spend publication/invalidation behavior from #3106
- silently refresh the open Usage & Spend pane when provider snapshots publish updates
- debounce provider-update bursts so one multi-provider refresh does not trigger one dashboard rebuild per event
- strengthen the backend summary cache revision with limit/balance/currency and exact daily spend points

## Upstream evidence
- target release: `v0.55.0`
- upstream commit: `6538ac345` / #3106

## Validation
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml usage_spend --no-fail-fast` -> compile/test pass
- focused rustfmt and `git diff --check` -> pass
- frontend Vitest remains blocked locally by the existing pnpm/Corepack shim failure; hosted CI/final frontend gate must exercise the listener path

## Scope
Usage & Spend refresh/invalidation only. No provider-auth or version bump changes.
