### PR TITLE
Port upstream 0.55.0: parallelize spend baselines

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/usage_spend.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/usage_spend.rs
@@ -180,12 +180,28 @@ fn build_usage_spend_summary(
         })
         .flatten();
 
-    // Scan the local-log sources once per canonical window; all downstream
-    // surfaces consume the same immutable row catalog built below.
-    let codex_7_summary = CostScanner::new(7).scan_codex();
-    let codex_30_summary = CostScanner::new(30).scan_codex();
-    let claude_7_summary = CostScanner::new(7).scan_claude();
-    let claude_30_summary = CostScanner::new(30).scan_claude();
+    // Upstream 0.55.0 #3105: independent provider baselines load in parallel.
+    // Keep each provider's 7d/30d scans serial so they can safely share that
+    // provider's incremental cache, while Codex and Claude run concurrently.
+    let ((codex_7_summary, codex_30_summary), (claude_7_summary, claude_30_summary)) =
+        std::thread::scope(|scope| {
+            let codex = scope.spawn(|| {
+                (
+                    CostScanner::new(7).scan_codex(),
+                    CostScanner::new(30).scan_codex(),
+                )
+            });
+            let claude = scope.spawn(|| {
+                (
+                    CostScanner::new(7).scan_claude(),
+                    CostScanner::new(30).scan_claude(),
+                )
+            });
+            (
+                codex.join().expect("Codex spend scan worker panicked"),
+                claude.join().expect("Claude spend scan worker panicked"),
+            )
+        });
 
     let codex_7_contract = build_local_spend_contract_from_summary(
         "codex",


### PR DESCRIPTION
## Summary
- port upstream CodexBar v0.55.0 spend-dashboard baseline parallelism from #3105
- run independent Codex and Claude baseline scans concurrently while keeping each provider's own 7d/30d scans serial
- preserve the existing per-provider incremental cache assumptions and downstream spend contract semantics

## Upstream evidence
- target release: `v0.55.0`
- upstream commit: `1cf98b330` / #3105

## Validation
- `cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml usage_spend --no-fail-fast` -> compile/test pass
- focused rustfmt and `git diff --check` -> pass

## Scope
Usage & Spend baseline load performance only. No provider-auth, UI, or version bump changes.
