### PR TITLE
Fix Grok OAuth when cookies are off

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/providers.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/providers.rs
@@ -48,7 +48,7 @@ pub(crate) fn build_fetch_context(
     } else {
         match cookie_source {
             _ if active_token_env.is_some() => (SourceMode::OAuth, None),
-            "off" if id == ProviderId::Claude && usage_source != SourceMode::Cli => {
+            "off" if provider_uses_oauth_without_cookies(id, usage_source) => {
                 (SourceMode::OAuth, None)
             }
             "off"
@@ -69,7 +69,7 @@ pub(crate) fn build_fetch_context(
                     SourceMode::Auto
                 } else if cookie_header.is_some() {
                     SourceMode::Web
-                } else if id == ProviderId::Claude && usage_source != SourceMode::Cli {
+                } else if provider_uses_oauth_without_cookies(id, usage_source) {
                     SourceMode::OAuth
                 } else {
                     SourceMode::Cli
@@ -132,6 +132,14 @@ pub(crate) fn build_fetch_context(
         gateway_url,
         auto_prefer_web,
         ..FetchContext::default()
+    }
+}
+
+fn provider_uses_oauth_without_cookies(id: ProviderId, usage_source: SourceMode) -> bool {
+    match id {
+        ProviderId::Claude => usage_source != SourceMode::Cli,
+        ProviderId::Grok => matches!(usage_source, SourceMode::Auto | SourceMode::OAuth),
+        _ => false,
     }
 }
 

--- a/apps/desktop-tauri/src-tauri/src/commands/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/tests.rs
@@ -325,6 +325,74 @@ fn fetch_context_cursor_cookie_off_stays_cli() {
 }
 
 #[test]
+fn fetch_context_grok_cookie_off_preserves_auto_oauth() {
+    let mut settings = Settings::default();
+    settings.set_cookie_source(ProviderId::Grok, "off");
+    settings.set_usage_source(ProviderId::Grok, "auto");
+    let ctx = super::build_fetch_context(
+        ProviderId::Grok,
+        &settings,
+        &ManualCookies::default(),
+        &ApiKeys::default(),
+        &HashMap::new(),
+    );
+
+    assert_eq!(ctx.source_mode, SourceMode::OAuth);
+    assert!(ctx.manual_cookie_header.is_none());
+}
+
+#[test]
+fn fetch_context_grok_cookie_off_preserves_explicit_oauth() {
+    let mut settings = Settings::default();
+    settings.set_cookie_source(ProviderId::Grok, "off");
+    settings.set_usage_source(ProviderId::Grok, "oauth");
+    let ctx = super::build_fetch_context(
+        ProviderId::Grok,
+        &settings,
+        &ManualCookies::default(),
+        &ApiKeys::default(),
+        &HashMap::new(),
+    );
+
+    assert_eq!(ctx.source_mode, SourceMode::OAuth);
+    assert!(ctx.manual_cookie_header.is_none());
+}
+
+#[test]
+fn fetch_context_grok_cookie_off_keeps_explicit_cli() {
+    let mut settings = Settings::default();
+    settings.set_cookie_source(ProviderId::Grok, "off");
+    settings.set_usage_source(ProviderId::Grok, "cli");
+    let ctx = super::build_fetch_context(
+        ProviderId::Grok,
+        &settings,
+        &ManualCookies::default(),
+        &ApiKeys::default(),
+        &HashMap::new(),
+    );
+
+    assert_eq!(ctx.source_mode, SourceMode::Cli);
+    assert!(ctx.manual_cookie_header.is_none());
+}
+
+#[test]
+fn fetch_context_grok_empty_manual_preserves_oauth_without_browser_import() {
+    let mut settings = Settings::default();
+    settings.set_cookie_source(ProviderId::Grok, "manual");
+    settings.set_usage_source(ProviderId::Grok, "auto");
+    let ctx = super::build_fetch_context(
+        ProviderId::Grok,
+        &settings,
+        &ManualCookies::default(),
+        &ApiKeys::default(),
+        &HashMap::new(),
+    );
+
+    assert_eq!(ctx.source_mode, SourceMode::OAuth);
+    assert!(ctx.manual_cookie_header.is_none());
+}
+
+#[test]
 fn fetch_context_opencode_empty_manual_remaps_to_web() {
     let settings = Settings::default();
     let cookies = ManualCookies::default();


### PR DESCRIPTION
## Summary
- fix #362 so Grok keeps its OAuth credential path when browser cookies are explicitly disabled
- preserve Grok `Auto` and `OAuth` usage-source selections as `SourceMode::OAuth` for cookie source `off`
- apply the same OAuth fallback when cookie source is `manual` but no manual cookie is stored
- keep explicit Grok `Cli` mode unchanged and never re-enable browser-cookie extraction

## Root cause
`build_fetch_context` treated cookie source `off` as a provider-agnostic request for `SourceMode::Cli`. Grok's CLI credential selector rejects OIDC entries created by `grok login`, so the desktop shell returned `AuthRequired` even though the same `~/.grok/auth.json` entry worked through the CLI diagnose path.

## Validation
- `cargo fmt --all --check` PASS
- `cargo test -p codexbar-desktop-tauri fetch_context_grok -- --nocapture` PASS, 4/4
- `cargo clippy -p codexbar-desktop-tauri --all-targets -- -D warnings` PASS

## Regression coverage
- cookie off + Grok Auto -> OAuth, no cookie header
- cookie off + explicit Grok OAuth -> OAuth, no cookie header
- cookie off + explicit Grok CLI -> CLI
- manual cookie source + no stored cookie + Grok Auto -> OAuth without browser import

Closes #362.
