### PR TITLE
fix(config): validate protected cookie stores

### DIFF
--- a/rust/src/cli/config.rs
+++ b/rust/src/cli/config.rs
@@ -496,7 +496,10 @@ mod tests {
         let raw = std::fs::read_to_string(&path).expect("read protected wrapper");
         assert!(raw.contains("\"format\": \"codexbar.secure-file\""));
         assert!(!raw.contains(expected));
-        read_json_config::<ManualCookies>(&path).expect("validate protected cookies");
+        assert!(
+            read_json_config::<ManualCookies>(&path).is_ok(),
+            "valid protected cookies should validate"
+        );
     }
 
     #[test]

--- a/rust/src/cli/config.rs
+++ b/rust/src/cli/config.rs
@@ -164,7 +164,9 @@ fn read_json_config<T>(path: &Path) -> Result<(), ConfigFileError>
 where
     T: DeserializeOwned,
 {
-    let content = std::fs::read_to_string(path).map_err(ConfigFileError::Read)?;
+    // Match the application loaders so validation supports DPAPI-protected
+    // config files without materializing plaintext on disk.
+    let content = crate::secure_file::read_string(path).map_err(ConfigFileError::Read)?;
     serde_json::from_str::<T>(&content)
         .map(|_| ())
         .map_err(ConfigFileError::Parse)
@@ -476,8 +478,46 @@ async fn show_paths() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::sanitize_settings_for_dump;
+    use super::{ConfigFileError, read_json_config, sanitize_settings_for_dump};
+    #[cfg(windows)]
+    use crate::secure_file;
+    use crate::settings::ManualCookies;
     use serde_json::json;
+
+    #[cfg(windows)]
+    #[test]
+    fn validates_dpapi_protected_manual_cookies_without_plaintext() {
+        let dir = tempfile::tempdir().expect("create temporary directory");
+        let path = dir.path().join("manual_cookies.json");
+        let expected = r#"{"cookies":{}}"#;
+
+        secure_file::write_string(&path, expected).expect("write protected cookies");
+
+        let raw = std::fs::read_to_string(&path).expect("read protected wrapper");
+        assert!(raw.contains("\"format\": \"codexbar.secure-file\""));
+        assert!(!raw.contains(expected));
+        read_json_config::<ManualCookies>(&path).expect("validate protected cookies");
+    }
+
+    #[test]
+    fn rejects_malformed_secure_wrapper_without_echoing_payload() {
+        let dir = tempfile::tempdir().expect("create temporary directory");
+        let path = dir.path().join("manual_cookies.json");
+        let payload = "AA==";
+        let malformed = format!(
+            r#"{{"format":"codexbar.secure-file","version":1,"protection":"unsupported","payload":"{payload}"}}"#
+        );
+        std::fs::write(&path, malformed).expect("write malformed wrapper");
+
+        let error = read_json_config::<ManualCookies>(&path)
+            .expect_err("reject malformed protected wrapper");
+        let ConfigFileError::Read(error) = error else {
+            panic!("malformed protected wrapper must be a read error");
+        };
+        let message = error.to_string();
+        assert!(message.contains("unsupported secure file protection"));
+        assert!(!message.contains(payload));
+    }
 
     #[test]
     fn sanitize_settings_for_dump_redacts_secret_fields() {


### PR DESCRIPTION
## Summary

- Validate configuration through the same secure-file reader used by the application.
- Accept Windows DPAPI-protected manual-cookie stores without converting them to plaintext.
- Add focused coverage for a valid protected store and malformed-wrapper error redaction.

## Validation

- `git diff --check`
- `cargo fmt --all --check`
- `gitleaks protect --staged --redact`
- Focused Rust test compilation is currently blocked locally before tests start: Cargo returns Windows `os error 2` while copying the `num-traits` build script. The failed build cache and logs were preserved; no security product or source data was changed.
- The upstream `PR check` workflow is awaiting maintainer approval because this is a first-time fork contribution.

## Privacy

This change does not include account cookies, credential values, personal paths, or local configuration data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now supports protected configuration files.
  * Invalid secure file wrappers are rejected safely without exposing protected contents.
  * Improved error reporting for secure file access failures.

* **Tests**
  * Added Windows coverage for validating DPAPI-protected manual cookie configurations without storing plaintext data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->