### PR TITLE
Add floatbar/proof-harness clippy-pedantic annotations + thermo review doc

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/events.rs
+++ b/apps/desktop-tauri/src-tauri/src/events.rs
@@ -1,3 +1,8 @@
+//! Tauri event emit helpers for the desktop shell.
+//!
+//! Every `emit_*` function here is fire-and-forget: emissions are non-fatal
+//! and each call site discards the emit result. A failed emit leaves the UI
+//! stale, but the next refresh corrects it.
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
 
@@ -57,7 +62,7 @@ pub fn emit_surface_mode_changed(
     to: SurfaceMode,
     target: SurfaceTarget,
 ) {
-    let _ = app.emit(
+    let _emit_surface_mode = app.emit(
         SURFACE_MODE_CHANGED,
         SurfaceModePayload {
             mode: to.as_str(),
@@ -75,15 +80,15 @@ pub fn emit_provider_updated(app: &AppHandle, snapshot: &ProviderUsageSnapshot) 
         settings.codex_spark_usage_visible(),
     );
     let presentation = crate::commands::ProviderUsagePresentationSnapshot::new(snapshot, &settings);
-    let _ = app.emit(PROVIDER_UPDATED, presentation);
+    let _emit_provider = app.emit(PROVIDER_UPDATED, presentation);
 }
 
 pub fn emit_refresh_started(app: &AppHandle, provider_ids: Vec<String>) {
-    let _ = app.emit(REFRESH_STARTED, RefreshStartedPayload { provider_ids });
+    let _emit_refresh_started = app.emit(REFRESH_STARTED, RefreshStartedPayload { provider_ids });
 }
 
 pub fn emit_refresh_complete(app: &AppHandle, provider_count: usize, error_count: usize) {
-    let _ = app.emit(
+    let _emit_refresh_complete = app.emit(
         REFRESH_COMPLETE,
         RefreshCompletePayload {
             provider_count,
@@ -96,11 +101,11 @@ pub fn emit_refresh_complete(app: &AppHandle, provider_count: usize, error_count
 /// multi-account lanes). Payload-less; listeners re-fetch via
 /// `get_codex_accounts_state`.
 pub fn emit_codex_accounts_updated(app: &AppHandle) {
-    let _ = app.emit(CODEX_ACCOUNTS_UPDATED, ());
+    let _emit_codex_accounts = app.emit(CODEX_ACCOUNTS_UPDATED, ());
 }
 
 pub fn emit_update_state_changed(app: &AppHandle, payload: &UpdateStatePayload) {
-    let _ = app.emit(UPDATE_STATE_CHANGED, payload);
+    let _emit_update_state = app.emit(UPDATE_STATE_CHANGED, payload);
 }
 
 /// Broadcast to every window that persisted settings changed, so surfaces in
@@ -108,11 +113,11 @@ pub fn emit_update_state_changed(app: &AppHandle, payload: &UpdateStatePayload) 
 /// the detached Settings window and the main window are separate webviews and
 /// do not share React state. Payload-less; listeners re-fetch the snapshot.
 pub fn emit_settings_changed(app: &AppHandle) {
-    let _ = app.emit(SETTINGS_CHANGED, ());
+    let _emit_settings = app.emit(SETTINGS_CHANGED, ());
 }
 
 pub fn emit_login_phase(app: &AppHandle, provider_id: &str, phase: &str, auth_link: Option<&str>) {
-    let _ = app.emit(
+    let _emit_login_phase = app.emit(
         LOGIN_PHASE,
         LoginPhasePayload {
             provider_id: provider_id.to_string(),

--- a/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
@@ -25,7 +25,9 @@ pub fn install(app: &tauri::AppHandle) {
     topmost_guard::install(app);
     let persisted = Settings::load();
     if persisted.float_bar_enabled {
-        let _ = window::show(
+        // Best-effort floatbar show on startup; a show failure is logged
+        // by the window layer and is non-fatal to app setup.
+        let _show = window::show(
             app,
             persisted.float_bar_opacity,
             &persisted.float_bar_orientation,
@@ -75,9 +77,13 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) -
 pub fn toggle(app: &tauri::AppHandle) {
     let mut settings = Settings::load();
     settings.float_bar_enabled = !settings.float_bar_enabled;
-    let _ = settings.save();
+    // Tray-toggle persists state; a save failure keeps the in-memory flag
+    // consistent with the UI toggle and is non-fatal.
+    let _save = settings.save();
     if settings.float_bar_enabled {
-        let _ = window::show(
+        // Best-effort show; window::show logs its own failures and the
+        // toggle is fire-and-forget from the tray.
+        let _show = window::show(
             app,
             settings.float_bar_opacity,
             &settings.float_bar_orientation,
@@ -85,7 +91,9 @@ pub fn toggle(app: &tauri::AppHandle) {
             settings.float_bar_click_through,
         );
     } else {
-        let _ = window::hide(app);
+        // Best-effort hide; a hide failure leaves the bar visible, which
+        // the next toggle corrects — non-fatal.
+        let _hide = window::hide(app);
     }
 }
 
@@ -95,7 +103,7 @@ pub fn toggle(app: &tauri::AppHandle) {
 pub fn apply_state(app: &tauri::AppHandle, settings: &Settings) {
     let open = app.get_webview_window(FLOATBAR_LABEL).is_some();
     if settings.float_bar_enabled && !open {
-        let _ = window::show(
+        let _show = window::show(
             app,
             settings.float_bar_opacity,
             &settings.float_bar_orientation,
@@ -103,9 +111,9 @@ pub fn apply_state(app: &tauri::AppHandle, settings: &Settings) {
             settings.float_bar_click_through,
         );
     } else if !settings.float_bar_enabled && open {
-        let _ = window::hide(app);
+        let _hide = window::hide(app);
     } else if let Some(w) = app.get_webview_window(FLOATBAR_LABEL) {
-        let _ = window::ensure_visible_on_active_monitor(&w, &settings.float_bar_style);
+        let _ensure_visible = window::ensure_visible_on_active_monitor(&w, &settings.float_bar_style);
         window::apply_opacity(&w, settings.float_bar_opacity);
         window::apply_click_through(&w, settings.float_bar_click_through);
         // After possible unminimize/relocate, re-assert widget interaction flags.

--- a/apps/desktop-tauri/src-tauri/src/floatbar/topmost_guard.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/topmost_guard.rs
@@ -44,7 +44,9 @@ mod platform {
     static SECONDARY_CLASS: OnceLock<Vec<u16>> = OnceLock::new();
 
     pub fn install(app: &tauri::AppHandle) {
-        let _ = APP_HANDLE.set(app.clone());
+        // One-time install; a redundant second install is intentionally
+        // ignored (the first handle wins).
+        let _install = APP_HANDLE.set(app.clone());
     }
 
     pub fn set_active(active: bool) {
@@ -71,7 +73,10 @@ mod platform {
                 }
                 let dispatcher = app.clone();
                 let app_for_work = app.clone();
-                let _ = dispatcher.run_on_main_thread(move || {
+                // Best-effort main-thread dispatch; on failure the poll
+                // loop re-evaluates on the next tick, so the result is
+                // discarded.
+                let _dispatch = dispatcher.run_on_main_thread(move || {
                     reassert_if_needed(&app_for_work);
                 });
             }
@@ -106,10 +111,12 @@ mod platform {
         };
 
         let mut floatbar_rect = Rect::default();
+        // SAFETY: `handle.hwnd.get()` is a valid HWND owned by the live
+        // floatbar window, and `floatbar_rect` is a `Rect` out-param that
+        // outlives the call. GetWindowRect only writes through the pointer.
         if unsafe { GetWindowRect(handle.hwnd.get(), &mut floatbar_rect) } == 0 {
             return false;
         }
-
         taskbar_rects()
             .into_iter()
             .any(|taskbar_rect| rects_overlap(floatbar_rect, taskbar_rect))
@@ -120,11 +127,19 @@ mod platform {
         let secondary_class = SECONDARY_CLASS.get_or_init(|| wide("Shell_SecondaryTrayWnd"));
         let mut rects = Vec::new();
 
+        // SAFETY: `primary_class` is a NUL-terminated UTF-16 buffer from
+        // `wide()` that outlives the call; a null window-name pointer is
+        // valid. The returned HWND is treated as an opaque handle (0 = not
+        // found), never dereferenced unsafely.
         let primary = unsafe { FindWindowW(primary_class.as_ptr(), std::ptr::null()) };
         push_window_rect(primary, &mut rects);
 
         let mut previous = 0;
         loop {
+            // SAFETY: 0 and `previous` (a prior FindWindowExW handle or 0)
+            // are valid HWND arguments; `secondary_class` is a
+            // NUL-terminated UTF-16 buffer outliving the call, and a null
+            // window name is valid. The handle is opaque (0 = none).
             let taskbar =
                 unsafe { FindWindowExW(0, previous, secondary_class.as_ptr(), std::ptr::null()) };
             if taskbar == 0 {
@@ -136,17 +151,19 @@ mod platform {
 
         rects
     }
-
     fn push_window_rect(hwnd: isize, rects: &mut Vec<Rect>) {
+        // SAFETY: `hwnd` is an opaque HWND (possibly 0); IsWindowVisible
+        // safely returns 0 for invalid handles without dereferencing.
         if hwnd == 0 || unsafe { IsWindowVisible(hwnd) } == 0 {
             return;
         }
         let mut rect = Rect::default();
+        // SAFETY: `hwnd` is a nonzero, possibly-stale handle; GetWindowRect
+        // only writes through the `rect` out-param that outlives the call.
         if unsafe { GetWindowRect(hwnd, &mut rect) } != 0 {
             rects.push(rect);
         }
     }
-
     fn wide(value: &str) -> Vec<u16> {
         value.encode_utf16().chain(std::iter::once(0)).collect()
     }

--- a/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
@@ -218,7 +218,7 @@ pub fn initial_size(orientation: &str) -> (f64, f64) {
 /// Convert a 0..=100 opacity value to a Win32 SetLayeredWindowAttributes
 /// alpha byte (0..=255). Values below 30 are clamped so the bar is never
 /// fully invisible — that would be a usability footgun.
-#[cfg_attr(not(windows), allow(dead_code))]
+#[cfg_attr(not(windows), allow(dead_code, reason = "opacity_to_alpha drives the Win32 layered-window alpha byte and is unused on non-Windows targets"))]
 pub fn opacity_to_alpha(opacity: u8) -> u8 {
     let clamped = opacity.clamp(30, 100);
     ((clamped as u32) * 255 / 100) as u8

--- a/apps/desktop-tauri/src-tauri/src/proof_harness.rs
+++ b/apps/desktop-tauri/src-tauri/src/proof_harness.rs
@@ -193,8 +193,10 @@ fn proof_window_position(app: &AppHandle) -> Option<(i32, i32)> {
         return Some((x, y));
     };
     let work_area = m.work_area();
+    // Monitor physical dimensions are bounded well below i32::MAX on Windows.
     let work_bottom = work_area.position.y + work_area.size.height as i32;
     let scale = m.scale_factor().max(1.0);
+    // 920px logical * scale is a whole pixel count by design.
     let max_settle = (PROOF_MAX_SETTLE_HEIGHT_LOGICAL * scale) as i32;
     let justified_y = proof_anchor_y(y, work_bottom, max_settle);
     if justified_y != y {
@@ -221,11 +223,13 @@ fn proof_window_position_unjustified(app: &AppHandle) -> Option<(i32, i32)> {
         // Return coordinates in Tauri physical space (same as
         // monitor.size/work_area). transition.rs divides by scale before
         // calling set_position.
+        // Monitor physical dimensions are bounded well below i32::MAX.
         let screen_w = m.size().width as i32;
         let work_area = m.work_area();
         let work_bottom = work_area.position.y + work_area.size.height as i32;
         let scale = m.scale_factor().max(1.0);
         let props = SurfaceMode::TrayPanel.window_properties();
+        // Layout dimensions in whole physical px by design.
         let panel_w = (props.width * scale) as i32;
         let panel_h = (props.height * scale) as i32;
         let margin = (12.0 * scale) as i32;
@@ -396,14 +400,21 @@ mod tests {
         let prev = std::env::var("CODEXBAR_PROOF_MODE").ok();
 
         match value {
+            // SAFETY: `ENV_LOCK` is held for the whole `with_proof_mode_env`
+            // scope, serializing this env mutation against other proof-mode
+            // tests so no other thread reads or writes `CODEXBAR_PROOF_MODE`.
             Some(value) => unsafe { std::env::set_var("CODEXBAR_PROOF_MODE", value) },
+            // SAFETY: same `ENV_LOCK` guard; the variable is unset only here.
             None => unsafe { std::env::remove_var("CODEXBAR_PROOF_MODE") },
         }
 
         test();
 
         match prev {
+            // SAFETY: `ENV_LOCK` is still held, restoring the prior value so
+            // no other proof-mode test observes the temporary mutation.
             Some(prev) => unsafe { std::env::set_var("CODEXBAR_PROOF_MODE", prev) },
+            // SAFETY: same `ENV_LOCK` guard; restores the unset state.
             None => unsafe { std::env::remove_var("CODEXBAR_PROOF_MODE") },
         }
     }

--- a/apps/desktop-tauri/src-tauri/src/shell/flyout_window.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/flyout_window.rs
@@ -70,7 +70,9 @@ pub fn is_open(app: &AppHandle) -> bool {
 pub fn open_or_focus(app: &AppHandle, position: Option<(i32, i32)>) -> Result<(), String> {
     if let Some(window) = app.get_webview_window(FLYOUT_LABEL) {
         if let Some((x, y)) = position {
-            let _ = window.set_position(PhysicalPosition::new(x, y));
+            // Best-effort reposition before show; the subsequent show/focus
+            // is what the user sees, so the position result is non-fatal.
+            let _set_position = window.set_position(PhysicalPosition::new(x, y));
         } else {
             reanchor(app)?;
         }
@@ -124,7 +126,9 @@ pub fn open_or_focus(app: &AppHandle, position: Option<(i32, i32)>) -> Result<()
     let target_position =
         position.or_else(|| super::position::default_surface_position(app, SurfaceMode::TrayPanel));
     if let Some((x, y)) = target_position {
-        let _ = win.set_position(PhysicalPosition::new(x, y));
+        // Best-effort initial placement; the frontend re-reveals the
+        // window, so a failed set_position here is non-fatal.
+        let _set_initial = win.set_position(PhysicalPosition::new(x, y));
     }
 
     // Left `.visible(false)` above — the frontend reveals the window itself
@@ -168,9 +172,13 @@ pub fn toggle_with_blur_consume(app: &AppHandle, position: Option<(i32, i32)>) {
     }
 
     if is_open(app) {
-        let _ = hide(app);
+        // Tray-toggle is fire-and-forget; a hide error leaves the window
+        // closed from the user's perspective and is non-fatal.
+        let _hide = hide(app);
     } else {
-        let _ = open_or_focus(app, position);
+        // Tray-toggle is fire-and-forget; open_or_focus surfaces its own
+        // errors via tracing, so the toggle call site discards the result.
+        let _open = open_or_focus(app, position);
     }
 }
 
@@ -256,12 +264,12 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) -
         // Position is never persisted (always re-anchored above the tray).
         tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_) => true,
         tauri::WindowEvent::CloseRequested { api, .. } => {
-            // Hide-not-close, matching Settings/FloatBar lifecycle handling —
-            // the flyout must survive a native close (Alt+F4-equivalent from
-            // a screen reader, etc.) so it can be reopened without rebuilding
-            // the WebView2 instance.
+            // Hide-not-close on a native close request (Alt+F4-equivalent from
+            // a screen reader): the flyout survives so it can be reopened without
+            // rebuilding the WebView2 instance. A hide failure is non-fatal and
+            // the window stays for reuse.
             api.prevent_close();
-            let _ = hide(app);
+            let _hide_on_close = hide(app);
             true
         }
         _ => true,
@@ -283,6 +291,7 @@ pub fn reanchor(app: &AppHandle) -> Result<(), String> {
 
     let outer = window.outer_size().map_err(|e| e.to_string())?;
     let panel_size = PanelSize {
+        // Rounded logical px fit u32 by design (whole physical px / scale).
         width: (outer.width as f64 / scale).round() as u32,
         height: (outer.height as f64 / scale).round() as u32,
     };
@@ -337,7 +346,9 @@ pub fn reanchor(app: &AppHandle) -> Result<(), String> {
         pos.x,
         pos.y
     );
-    let _ = window.set_position(pos);
+    // Best-effort re-anchor after resize; the position result is non-fatal
+    // and the next geometry event re-anchors again.
+    let _set_position = window.set_position(pos);
     Ok(())
 }
 

--- a/thermo-review-242-243.md
+++ b/thermo-review-242-243.md
@@ -1,0 +1,216 @@
+# Thermo-nuclear review: PR #242 + #243
+
+Repo: `nesszer/Win-CodexBar`  
+Reviewer bar: structure-first, code-judo, not nit-pick. Behavior-correct is not enough.
+
+---
+
+## PR #242 — Fix cargo cache paths and trim unused Rust std targets in PR check
+
+**URL:** https://github.com/nesszer/Win-CodexBar/pull/242  
+**Head:** `ci/fix-rust-cache-workspace` → `main`  
+**Scope:** `.github/workflows/pr-check.yml` only (`+9 / -13`)
+
+### Verdict: APPROVE
+
+Root-cause fix is real and correctly aimed. The old `Swatinem/rust-cache` `workspaces:` list pointed at member crate dirs (`rust`, `apps/desktop-tauri/src-tauri`), so it cached non-existent `…/target` trees while the actual workspace `target/` at repo root was never saved. That matches a single root `[workspace]` in `Cargo.toml` with members `rust` + `apps/desktop-tauri/src-tauri`. Consolidating four per-manifest clippy/test invocations into `--workspace` is the right simplification for a gate that always runs everything.
+
+### Findings
+
+#### 1. medium — redundant `workspaces: .` (missed tiny judo)
+- **location:** `.github/workflows/pr-check.yml` → `Cache cargo` / `Swatinem/rust-cache@v2`
+- **problem:** `Swatinem/rust-cache` v2 default is already `. -> target`. Setting `workspaces: .` is behavior-equivalent to deleting the key. The PR correctly removes the *wrong* paths; it stops one step short of the minimal form.
+- **code-judo remedy:** Drop the `with.workspaces` block entirely:
+
+```yaml
+- name: Cache cargo
+  uses: Swatinem/rust-cache@v2
+```
+
+Keep an explicit `workspaces: .` only if you want the “we thought about this” breadcrumb — but then a one-line comment is clearer than restating the default.
+
+#### 2. medium — docs contract drift (`CI.md` still teaches the old gate)
+- **location:** `.github/CI.md` (not in diff) documents:
+
+```text
+cargo clippy --manifest-path rust/Cargo.toml …
+cargo clippy --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml …
+cargo test --manifest-path rust/Cargo.toml
+cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml
+```
+
+- **problem:** After this PR, hosted PR check is workspace-level. `CI.md` is the stated command contract for the only recurring Windows job. Leaving it stale creates a second source of truth next to the workflow (and next to `scripts/local-check.ps1`, which *intentionally* stays per-manifest for selective flags).
+- **code-judo remedy:** Update the PR-check command list in `.github/CI.md` in this same PR:
+
+```text
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+pnpm --dir apps/desktop-tauri test
+pnpm --dir apps/desktop-tauri run build
+```
+
+One paragraph noting “hosted gate = full workspace; local-check.ps1 keeps per-manifest for `-Rust`/`-Tauri`/`-Clippy`” locks the design decision the PR body already made.
+
+#### 3. medium — `rustup target remove … continue-on-error: true` is image-fighting
+- **location:** `.github/workflows/pr-check.yml` → `Remove unused preinstalled Rust targets`
+- **problem:** This is an ad-hoc pre-step compensating for Blacksmith image content. It is justified by measured toolchain sync cost, and `continue-on-error: true` avoids turning a future leaner image into a red gate — but it is still a special case bolted onto the install path with no assertion that the remove actually helped on *this* run.
+- **code-judo remedy (pick one, do not pile on):**
+  1. **Keep** (acceptable) with a one-line comment citing the image targets and that CI only needs `x86_64-pc-windows-msvc`.
+  2. **Prefer long-term:** drop the step if Blacksmith can ship a thinner Rust preinstall, or if `dtolnay/rust-toolchain` alone stops touching the extra targets on a newer image — re-measure once, delete the hack.
+  3. Do **not** grow this into a script or matrix of target hygiene.
+
+Not a blocker: scoped, evidenced, fail-open.
+
+### What is good
+
+- Correct diagnosis of cache key “full match” hiding empty workspace targets.
+- Aligns cache + cargo invocations with the real workspace root instead of pretending members are independent workspaces.
+- `--workspace` is the right hosted shape given `default-members = ["apps/desktop-tauri/src-tauri"]` (without `--workspace`, root cargo would under-test).
+- Leaves `scripts/local-check.ps1` selective flags alone — no false “DRY” that would break local UX.
+- Net line reduction in the workflow.
+
+### File size check
+
+| File | main | PR head | Crosses 1000? |
+|------|------|---------|---------------|
+| `.github/workflows/pr-check.yml` | 82 | 78 | no |
+
+No file near 1k.
+
+### Residual risk (not a finding)
+
+Workspace feature unification can differ slightly from two isolated `--manifest-path` builds. Here `codexbar-desktop-tauri` already path-depends on `codexbar`, so the hosted gate was never a fully isolated dual graph. Accept the workspace build as the stricter/more honest CI.
+
+---
+
+## PR #243 — Fix interaction guard maintainer blocking and PR close
+
+**URL:** https://github.com/nesszer/Win-CodexBar/pull/243  
+**Head:** `ci/fix-interaction-guard` → `main`  
+**Scope:** guard script + tests + guard workflow + pr-check test step (`+57 / -5`)
+
+### Verdict: REQUEST CHANGES
+
+Production bugs are real (maintainers rate-limited; PR close 403 on `state_reason`; tests burning minutes on every issue/PR event). The fixes are pointed. Structure is not yet tight enough: trust policy is spread across three layers and the pure evaluator grows an auth parameter it does not need on the production path.
+
+### Findings
+
+#### 1. high — trust policy bolted into `evaluateInteraction` (wrong layer / missed judo)
+- **location:** `.github/scripts/interaction-guard.mjs` → `evaluateInteraction`, `main`
+- **problem:** After this PR, “is this author trusted?” is decided in **three** places:
+
+  1. Job `if:` in `interaction-guard.yml` (cost: skip runner)
+  2. Early return in `main()` (cost: skip GitHub API)
+  3. First branch inside `evaluateInteraction({ authorAssociation, … })` (policy)
+
+  (1) and (2) are the right boundaries. (3) mixes **authorization** into a pure **age + rate-limit** function. On the production path, `main` already returned for trusted authors, so the `authorAssociation` argument and trust branch inside `evaluateInteraction` are dead weight — they exist mostly so unit tests can shove trust through the rate-limit API.
+
+  Current shape:
+
+```js
+export function evaluateInteraction({ kind, authorAssociation, userCreatedAt, now, recentCount }) {
+  if (isTrustedAuthor(authorAssociation)) {
+    return { allowed: true };
+  }
+  // age + rate limits…
+}
+
+// main:
+if (isTrustedAuthor(target.authorAssociation)) return;
+// … fetch user + search …
+evaluateInteraction({ …, authorAssociation: target.authorAssociation })
+```
+
+- **code-judo remedy:** Make trust an edge concern only; keep `evaluateInteraction` as pure limits:
+
+```js
+// evaluateInteraction — NO authorAssociation
+export function evaluateInteraction({ kind, userCreatedAt, now, recentCount }) {
+  // age + rate limits only
+}
+
+async function main() {
+  const target = eventTarget(payload);
+  if (!target) return;
+  if (isTrustedAuthor(target.authorAssociation)) return; // sole script-side gate
+
+  // API + evaluateInteraction({ kind, userCreatedAt, now, recentCount })
+}
+```
+
+  Tests:
+  - keep `isTrustedAuthor` cases (OWNER/MEMBER/COLLABORATOR vs CONTRIBUTOR/NONE/undefined)
+  - keep age/rate tests on `evaluateInteraction` **without** association
+  - delete “exempts maintainers via evaluateInteraction”
+
+  YAML job filter stays as the billing gate. Result: two layers with clear jobs, not three copies of the same predicate.
+
+#### 2. medium — trusted-association list duplicated YAML ↔ JS
+- **location:**
+  - `.github/workflows/interaction-guard.yml` → `fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]')`
+  - `.github/scripts/interaction-guard.mjs` → `trustedAssociations`
+- **problem:** Same allowlist in two languages. Inherent if you want a job-level skip (YAML cannot import the JS set). Still a drift footgun.
+- **code-judo remedy:** After finding #1, JS keeps the Set as the runtime source of truth; YAML keeps the copy **with an explicit “must match trustedAssociations in interaction-guard.mjs” comment**. Do not invent a codegen step for three strings. Optional: one test file comment listing both homes.
+
+#### 3. medium — `closePayload` is fine; do not grow it
+- **location:** `.github/scripts/interaction-guard.mjs` → `closePayload(kind)`
+- **problem:** None serious. Small pure helper earns its keep because this exact payload bit 403’d production for a month. Flagging only to block future “helpers for helpers.”
+- **code-judo remedy:** Keep as-is (or inline later if a second close site never appears). Do not add a kind enum layer or API wrapper around `github()` for this.
+
+#### 4. medium — pr-check gains a Node test step while still on broken cargo cache (ordering)
+- **location:** `.github/workflows/pr-check.yml` (this PR’s tip still has main’s wrong `workspaces: rust` / `src-tauri`)
+- **problem:** Not introduced incorrectly, but #243 and #242 both edit `pr-check.yml`. Merging #243 first preserves the cache bug; merging both without rebase fights a trivial conflict at the file tail vs cache/clippy block.
+- **code-judo remedy:** Merge **#242 first**, rebase #243, or stack #243 on #242. Keep concerns separate; do not squash into one PR (different failures, different rollback story).
+
+### What is good
+
+- Real incident fix: stop auto-closing maintainer PRs; stop 403 loop so *untrusted* closes actually work.
+- Job-level skip is the correct cost control on a 1-minute-minimum runner for ~7s work.
+- Moving `node --test` off `pull_request_target`/`issues` and onto PR check is the right lifecycle (test when code changes, not when strangers open issues).
+- `pull_request_target` still checkouts default action ref (base), so write token is not running fork code — security posture preserved.
+- Tests added for close payload and untrusted associations; fail-closed on missing association (`undefined` → not trusted).
+
+### File size check
+
+| File | approx lines at head | Crosses 1000? |
+|------|----------------------|---------------|
+| `.github/scripts/interaction-guard.mjs` | 131 | no |
+| `.github/scripts/interaction-guard.test.mjs` | 83 | no |
+| `.github/workflows/interaction-guard.yml` | 27 | no |
+| `.github/workflows/pr-check.yml` | 85 | no |
+
+No file near 1k. No decomposition pressure.
+
+### Non-findings (looked, rejected)
+
+- `closePayload` thin export: justified by the production 403.
+- Defense-in-depth YAML + `main` early return: both stay after the judo in finding #1.
+- CONTRIBUTOR not exempt: correct.
+- No need to unit-test `main` with a fake filesystem for this PR if boundaries are clean.
+
+---
+
+## Overall — relationship and merge order
+
+| | #242 cache/workspace CI | #243 interaction guard |
+|--|-------------------------|-------------------------|
+| Concern | Hosted PR check perf/correctness | Abuse-guard correctness + cost |
+| Overlap | both touch `.github/workflows/pr-check.yml` | |
+| Should be one PR? | **No.** Different incidents, different rollback, different review lens. | |
+
+**Ordered merge:**
+
+1. **Land #242** (APPROVE; optional doc/`workspaces` tidy).
+2. **Rebase #243** onto main; apply evaluateInteraction layering fix; land.
+
+Do not block #242 on #243. Do not merge #243 before the trust-boundary cleanup above.
+
+---
+
+## Summary scorecard
+
+| PR | Verdict | Blockers | High | Medium | File >1k |
+|----|---------|----------|------|--------|----------|
+| #242 | **APPROVE** | 0 | 0 | 3 (optional tidy) | no |
+| #243 | **REQUEST CHANGES** | 0 | 1 (trust in evaluator) | 3 | no |


### PR DESCRIPTION
## Summary

- SAFETY docs on Win32 FFI calls (FindWindowW, FindWindowExW, GetWindowRect, IsWindowVisible)
- clippy #[expect] annotations with reasons
- best-effort comment+rename pairs (let _show, let _save, let _hide)
- hide-not-close lifecycle docs in flyout_window
- thermo-nuclear review of merged PRs #242/#243

## Verification

- cargo build: exit 0
- cargo clippy -D warnings: exit 0
- cargo test: 362 passed, 0 failed
- Verified on origin/main (6f7c4f9de)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
