### PR TITLE
Bump pnpm to 11.24.0

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -70,7 +70,7 @@ Both jobs use CircleCI's hosted Windows executor (`circleci/windows@5.0`).
 2. The credential-free build validates the canonical remote, full tag SHA,
    tag-to-SHA identity, protected `main` ancestry, and every project version
    file. It provisions/asserts Node 24.x via the `OpenJS.NodeJS.LTS` winget
-   package, pnpm 10.18.1, the Rust MSVC target, Git, and Inno Setup 6.
+   package, pnpm 11.24.0, the Rust MSVC target, Git, and Inno Setup 6.
 3. It uses a new temporary `WorkRoot`, runs `release-doctor.ps1`, then runs
    `windows-release-build.ps1` with the immutable SHA and `-SmokeInstall`.
    It never uploads. Four assets, `release-manifest.json`, and build logs are

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -50,12 +50,12 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           cache-dependency-path: apps/desktop-tauri/pnpm-lock.yaml
 

--- a/apps/desktop-tauri/.npmrc
+++ b/apps/desktop-tauri/.npmrc
@@ -1,2 +1,1 @@
 registry=https://registry.npmjs.org/
-minimum-release-age=1440

--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -2,7 +2,7 @@
   "name": "desktop-tauri",
   "private": true,
   "version": "0.55.0",
-  "packageManager": "pnpm@10.18.1",
+  "packageManager": "pnpm@11.24.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop-tauri/pnpm-workspace.yaml
+++ b/apps/desktop-tauri/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 allowBuilds:
   esbuild: true
+minimumReleaseAge: 1440

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -4,7 +4,7 @@
 
 - **Rust** stable with the `x86_64-pc-windows-msvc` target
 - **Microsoft Visual Studio Build Tools** with the **Desktop development with C++** workload
-- **Node.js** 20+ and pnpm
+- **Node.js** 22.13+ (24 recommended) and pnpm 11
 
 Install the tools manually with rustup/winget/corepack, or use a tool manager
 such as mise. There is no automatic Windows bootstrap script in this port.

--- a/docs/release/ci-cd.md
+++ b/docs/release/ci-cd.md
@@ -19,7 +19,7 @@ gets the restricted `GH_TOKEN` context.
    branches, PRs, non-semver tags, non-canonical remotes, tag/SHA mismatch,
    and commits whose tag is not reachable from protected `origin/main`.
 2. The build job provisions/asserts Node 24.x via the `OpenJS.NodeJS.LTS`
-   winget package, pnpm 10.18.1, the Windows MSVC Rust target, Git, and Inno
+   winget package, pnpm 11.24.0, the Windows MSVC Rust target, Git, and Inno
    Setup 6. It validates every committed project version against the tag.
 3. The build invokes `scripts/release-doctor.ps1 -SkipGitHub`, then
    `scripts/windows-release-build.ps1 -Ref <full-SHA> -SmokeInstall` with a

--- a/scripts/install-release-prerequisites.ps1
+++ b/scripts/install-release-prerequisites.ps1
@@ -471,8 +471,8 @@ if (-not (Test-Path -LiteralPath $packageJsonPath -PathType Leaf)) {
 }
 $packageJson = Get-Content -Raw -LiteralPath $packageJsonPath | ConvertFrom-Json
 $expectedPnpm = [string]$packageJson.packageManager -replace '^pnpm@', ''
-if ($expectedPnpm -notmatch '^10\.18\.1$') {
-    throw "Unexpected packageManager '$($packageJson.packageManager)'; release pipeline pins pnpm 10.18.1."
+if ($expectedPnpm -notmatch '^11\.24\.0$') {
+    throw "Unexpected packageManager '$($packageJson.packageManager)'; release pipeline pins pnpm 11.24.0."
 }
 
 Require-PrerequisiteCommand 'git' 'Git.Git' 'git' | Out-Null
@@ -586,4 +586,4 @@ if ($innoVersion -notmatch '^6\.') {
 Write-Host "[ok] Inno Setup $innoVersion ($iscc)"
 
 Write-Host ''
-Write-Host "Release prerequisites passed (Git, Node $requiredNodeMajor, pnpm 10.18.1, Rust MSVC target, Inno Setup 6)."
+Write-Host "Release prerequisites passed (Git, Node $requiredNodeMajor, pnpm 11.24.0, Rust MSVC target, Inno Setup 6)."

--- a/scripts/release-pipeline.tests.ps1
+++ b/scripts/release-pipeline.tests.ps1
@@ -34,7 +34,7 @@ Assert-Throws { Assert-NodeMajor 'v23.11.0' 24 } 'non-24 Node major rejected by 
 
 $prerequisiteText = Get-Content -Raw -LiteralPath (Join-Path $scriptRoot 'install-release-prerequisites.ps1')
 Assert-True ($prerequisiteText -match '\$requiredNodeMajor\s*=\s*24') 'release prerequisite pins Node major 24'
-Assert-True ($prerequisiteText -match '10\\.18\\.1') 'release prerequisite keeps pnpm 10.18.1 pinned'
+Assert-True ($prerequisiteText -match '11\\.24\\.0') 'release prerequisite keeps pnpm 11.24.0 pinned'
 
 Assert-Equal (Normalize-GitHubRepository 'https://github.com/nesszer/Win-CodexBar.git') 'nesszer/win-codexbar' 'HTTPS canonical URL'
 Assert-Equal (Normalize-GitHubRepository 'git@github.com:nesszer/Win-CodexBar.git') 'nesszer/win-codexbar' 'SSH canonical URL'


### PR DESCRIPTION
## Summary

Bumps `packageManager` from `pnpm@10.18.1` to `pnpm@11.24.0` across the repo (cherry-picked from the port branch onto current `main`, `6f7c4f9de`).

- **Lockfile stays byte-identical** — `pnpm-lock.yaml` unchanged, still `lockfileVersion 9.0` (pnpm 11 writes the same 9.0 format; no dependency resolution changes).
- **Node floor ≥22.13** — pnpm 11 requires Node ≥22.13; the repo's Node usage is already compliant.
- **`allowBuilds` now honored** — pnpm 11 respects the `allowBuilds` policy that 10.18.1 silently ignored, so postinstall build scripts are gated properly.
- **CI Node 20→24** — `.github/workflows/pr-check.yml` bumped, since pnpm 11's floor rules out Node 20.
- **`minimumReleaseAge` migrated** — moved from `.npmrc` to `pnpm-workspace.yaml` (`minimumReleaseAge: 1440`, i.e. 24h); pnpm 11 reads this setting from the workspace manifest.

### Conflict resolution note

The cherry-pick of the original port-branch commit (`f1249f41b`) conflicted in `apps/desktop-tauri/package.json`: main had advanced `version` to `0.55.0` while the source commit predated it (`0.53.1`). Resolved by keeping main's `version: 0.55.0` and applying the bump's `packageManager: pnpm@11.24.0` — the version was not regressed. The other 8 files in the commit cherry-picked cleanly.

### Files touched (9)

`apps/desktop-tauri/package.json`, `apps/desktop-tauri/pnpm-workspace.yaml`, `apps/desktop-tauri/.npmrc`, `.github/workflows/pr-check.yml`, `.github/CI.md`, `docs/BUILDING.md`, `docs/release/ci-cd.md`, `scripts/install-release-prerequisites.ps1`, `scripts/release-pipeline.tests.ps1`
