### PR TITLE
Add oxalpha spend-contract tests and malformed-input rejection

### DIFF
--- a/rust/src/spend_contract.rs
+++ b/rust/src/spend_contract.rs
@@ -690,4 +690,120 @@ mod tests {
         assert_eq!(free.cost(&counts), Some(0.0));
         assert_eq!(missing.cost(&counts), None);
     }
+
+    #[test]
+    fn sum_optional_cost_propagates_unknown_and_rejects_non_finite() {
+        assert_eq!(sum_optional_cost(Some(1.5), Some(2.25)), Some(3.75));
+        assert_eq!(sum_optional_cost(Some(1.5), None), Some(1.5));
+        assert_eq!(sum_optional_cost(None, Some(2.0)), Some(2.0));
+        assert_eq!(sum_optional_cost(None, None), None);
+        assert_eq!(sum_optional_cost(Some(f64::INFINITY), Some(1.0)), None);
+    }
+
+    #[test]
+    fn add_optional_token_counts_guard_against_overflow() {
+        assert_eq!(add_optional(Some(2), Some(3)), Some(5));
+        assert_eq!(add_optional(Some(2), None), Some(2));
+        assert_eq!(add_optional(None, None), None);
+        assert_eq!(add_optional(Some(u64::MAX), Some(1)), None);
+    }
+
+    #[test]
+    fn merge_models_combines_duplicate_models_and_sorts_priced_first() {
+        let make_row = |model: &str, cost: Option<f64>, input: u64, custom: bool| SpendModelRow {
+            model: model.to_string(),
+            cost_usd: cost,
+            input_tokens: input,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            total_tokens: input,
+            custom_pricing: custom,
+        };
+        let merged = merge_models(
+            vec![
+                make_row("beta", Some(1.0), 10, false),
+                make_row("alpha", None, 5, false),
+                make_row("zzz", Some(1.0), 1, false),
+                make_row("aaa", Some(1.0), 1, false),
+            ],
+            &[make_row("beta", Some(2.0), 7, true)],
+        );
+        let names: Vec<&str> = merged.iter().map(|row| row.model.as_str()).collect();
+        assert_eq!(
+            names,
+            ["beta", "aaa", "zzz", "alpha"],
+            "cost desc, then name asc for ties, unknown cost last"
+        );
+        let beta = &merged[0];
+        assert_eq!(beta.cost_usd, Some(3.0));
+        assert_eq!(beta.input_tokens, 17);
+        assert_eq!(beta.total_tokens, 17);
+        assert!(beta.custom_pricing, "custom pricing flags are OR-ed");
+    }
+
+    #[test]
+    fn merge_daily_sums_matching_days_and_keeps_iso_day_ordering() {
+        let make_point = |day: &str, cost: Option<f64>, tokens: Option<u64>| SpendDailyPoint {
+            day: day.to_string(),
+            cost_usd: cost,
+            total_tokens: tokens,
+        };
+        let merged = merge_daily(
+            vec![
+                make_point("2026-08-02", Some(1.0), Some(10)),
+                make_point("2026-08-01", None, None),
+            ],
+            &[
+                make_point("2026-08-02", Some(2.5), Some(15)),
+                make_point("2026-08-03", Some(4.0), None),
+            ],
+        );
+        let days: Vec<&str> = merged.iter().map(|point| point.day.as_str()).collect();
+        assert_eq!(days, ["2026-08-01", "2026-08-02", "2026-08-03"]);
+        assert_eq!(merged[1].cost_usd, Some(3.5));
+        assert_eq!(merged[1].total_tokens, Some(25));
+        assert_eq!(merged[0].cost_usd, None, "unknown stays unknown");
+        assert_eq!(merged[0].total_tokens, None);
+        assert_eq!(merged[2].total_tokens, None);
+    }
+
+    #[test]
+    fn known_subtotal_sums_known_costs_only_and_needs_known_zero_for_empty() {
+        let make_row = |cost: Option<f64>| SpendModelRow {
+            model: String::new(),
+            cost_usd: cost,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            total_tokens: 0,
+            custom_pricing: false,
+        };
+        let mut summary = CostSummary::default();
+        assert_eq!(known_subtotal(&[], &summary), None);
+        summary.known_zero = true;
+        assert_eq!(known_subtotal(&[], &summary), Some(0.0));
+        summary.known_zero = false;
+        let mixed = [make_row(Some(1.5)), make_row(None), make_row(Some(2.25))];
+        assert_eq!(known_subtotal(&mixed, &summary), Some(3.75));
+        let all_unknown = [make_row(None)];
+        assert_eq!(known_subtotal(&all_unknown, &summary), None);
+    }
+
+    #[test]
+    fn coverage_for_models_counts_priced_rows_as_estimated() {
+        let make_row = |cost: Option<f64>| SpendModelRow {
+            model: String::new(),
+            cost_usd: cost,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            total_tokens: 0,
+            custom_pricing: false,
+        };
+        let coverage =
+            coverage_for_models(&[make_row(Some(0.0)), make_row(None), make_row(Some(3.0))]);
+        assert_eq!(coverage.estimated, 2);
+        assert_eq!(coverage.unpriced, 1);
+        assert_eq!(coverage.total(), 3);
+    }
 }

--- a/rust/src/spend_contract/opencodex.rs
+++ b/rust/src/spend_contract/opencodex.rs
@@ -693,4 +693,71 @@ mod tests {
         assert_eq!(entry.cache_read_tokens, Some(3));
         assert_eq!(entry.reasoning_tokens, Some(2));
     }
+
+    #[test]
+    fn parser_normalizes_defaults_and_rejects_malformed_lines() {
+        let minimal = serde_json::json!({
+            "requestId": "  r1  ", "model": "gpt-test", "timestamp": "2026-08-18T10:00:00Z",
+            "usageStatus": "  REPORTED ", "usage": {"cacheCreationInputTokens": 7}
+        });
+        let entry = parse_line(&minimal.to_string()).expect("entry");
+        assert_eq!(entry.request_id, "r1", "ids are trimmed");
+        assert_eq!(
+            entry.provider, "openai",
+            "missing provider defaults to openai"
+        );
+        assert_eq!(
+            entry.usage_status, "reported",
+            "status is lowercased and trimmed"
+        );
+        assert_eq!(entry.conversation_id, None);
+        assert_eq!(entry.cache_creation_tokens, Some(7));
+
+        for malformed in [
+            "{}",
+            r#"{"requestId": "", "model": "m", "timestamp": "2026-08-18T10:00:00Z"}"#,
+            r#"{"requestId": "r1", "model": "   ", "timestamp": "2026-08-18T10:00:00Z"}"#,
+            r#"{"requestId": "r1", "model": "m"}"#,
+            "not json at all",
+        ] {
+            assert!(parse_line(malformed).is_none(), "rejected: {malformed}");
+        }
+    }
+
+    #[test]
+    fn timestamps_parse_rfc3339_epoch_seconds_and_millis() {
+        let expected = Utc.with_ymd_and_hms(2026, 8, 18, 10, 0, 0).unwrap();
+        let rfc3339 = serde_json::json!("2026-08-18T10:00:00Z");
+        assert_eq!(parse_timestamp(&rfc3339), Some(expected));
+        let epoch_seconds = serde_json::json!(1_787_047_200i64);
+        assert_eq!(parse_timestamp(&epoch_seconds), Some(expected));
+        let epoch_millis = serde_json::json!(1_787_047_200_000f64);
+        assert_eq!(parse_timestamp(&epoch_millis), Some(expected));
+        let numeric_string = serde_json::json!("1787047200.0");
+        assert_eq!(parse_timestamp(&numeric_string), Some(expected));
+        for invalid in [
+            serde_json::json!("not a date"),
+            serde_json::json!(0),
+            serde_json::json!(-5.0),
+            serde_json::Value::Null,
+            serde_json::json!(true),
+        ] {
+            assert!(parse_timestamp(&invalid).is_none(), "rejected: {invalid}");
+        }
+    }
+
+    #[test]
+    fn nonnegative_u64_accepts_json_numbers_and_bounded_floats() {
+        assert_eq!(nonnegative_u64(Some(&serde_json::json!(42))), Some(42));
+        assert_eq!(nonnegative_u64(Some(&serde_json::json!(12.0))), Some(12));
+        // Fractional floats are accepted via `as u64` truncation.
+        assert_eq!(nonnegative_u64(Some(&serde_json::json!(1.5))), Some(1));
+        // `u64::MAX as f64` rounds up to 2^64; f64 spacing there is 4096, so
+        // +2048.0 rounds back into range. First out-of-range step is +4096.0.
+        assert_eq!(
+            nonnegative_u64(Some(&serde_json::json!(u64::MAX as f64 + 4096.0))),
+            None
+        );
+        assert_eq!(nonnegative_u64(None), None);
+    }
 }


### PR DESCRIPTION
Adds +179 lines in spend_contract.rs and opencodex.rs: trim/default normalization, malformed-line rejection with malformed-input matrix test. Main has parse_line but not these contract tests. Applies cleanly from stash@{2}.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for spend aggregation, token-count handling, model merging, daily spend reporting, and coverage classification.
  * Added validation for parser defaults, malformed inputs, timestamp formats, and numeric token limits.
  * Improved confidence in spend calculations, input validation, timestamp interpretation, and handling of edge cases such as overflow, fractional values, and out-of-range data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->