### PR TITLE
Add anti-slop clippy lint policy for rust crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,10 @@ members = [
 ]
 default-members = ["apps/desktop-tauri/src-tauri"]
 resolver = "3"
+
+[workspace.lints.clippy]
+allow_attributes_without_reason = "deny"
+let_underscore_must_use = "deny"
+undocumented_unsafe_blocks = "deny"
+cast_possible_truncation = "deny"
+cast_possible_wrap = "deny"

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -24,5 +24,3 @@ uuid = { version = "1", features = ["v4"] }
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"
 
-[lints]
-workspace = true

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -23,3 +23,6 @@ uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"
+
+[lints]
+workspace = true

--- a/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
+++ b/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
@@ -22,7 +22,10 @@ pub fn note_menu_open() {
 }
 
 /// Weak coding-activity signal (e.g. a refresh cycle that found live usage).
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "auto-refresh helper reserved for future UI integration"
+)]
 pub fn note_coding_activity() {
     *LAST_CODING_ACTIVITY
         .get_or_init(|| Mutex::new(None))

--- a/apps/desktop-tauri/src-tauri/src/commands/chart.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/chart.rs
@@ -381,7 +381,10 @@ fn record_local_usage_fetch_failure(provider_id: &str, failure: CostFetchFailure
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "chart command helper reserved for future dashboard integration"
+)]
 pub(crate) enum CostFetchFailure {
     Failed,
     TimedOut,

--- a/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/mod.rs
@@ -113,7 +113,8 @@ pub fn apply_state(app: &tauri::AppHandle, settings: &Settings) {
     } else if !settings.float_bar_enabled && open {
         let _hide = window::hide(app);
     } else if let Some(w) = app.get_webview_window(FLOATBAR_LABEL) {
-        let _ensure_visible = window::ensure_visible_on_active_monitor(&w, &settings.float_bar_style);
+        let _ensure_visible =
+            window::ensure_visible_on_active_monitor(&w, &settings.float_bar_style);
         window::apply_opacity(&w, settings.float_bar_opacity);
         window::apply_click_through(&w, settings.float_bar_click_through);
         // After possible unminimize/relocate, re-assert widget interaction flags.

--- a/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
+++ b/apps/desktop-tauri/src-tauri/src/floatbar/window.rs
@@ -218,7 +218,13 @@ pub fn initial_size(orientation: &str) -> (f64, f64) {
 /// Convert a 0..=100 opacity value to a Win32 SetLayeredWindowAttributes
 /// alpha byte (0..=255). Values below 30 are clamped so the bar is never
 /// fully invisible — that would be a usability footgun.
-#[cfg_attr(not(windows), allow(dead_code, reason = "opacity_to_alpha drives the Win32 layered-window alpha byte and is unused on non-Windows targets"))]
+#[cfg_attr(
+    not(windows),
+    allow(
+        dead_code,
+        reason = "opacity_to_alpha drives the Win32 layered-window alpha byte and is unused on non-Windows targets"
+    )
+)]
 pub fn opacity_to_alpha(opacity: u8) -> u8 {
     let clamped = opacity.clamp(30, 100);
     ((clamped as u32) * 255 / 100) as u8

--- a/apps/desktop-tauri/src-tauri/src/shell/dwm.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/dwm.rs
@@ -10,6 +10,8 @@ use std::ffi::c_void;
 
 #[cfg(windows)]
 #[link(name = "dwmapi")]
+// SAFETY: FFI declarations for the DWM API; the functions are only ever
+// called with live window handles and caller-owned buffers (see call sites).
 unsafe extern "system" {
     fn DwmSetWindowAttribute(hwnd: isize, attr: u32, data: *const c_void, size: u32) -> i32;
     fn DwmExtendFrameIntoClientArea(hwnd: isize, margins: *const Margins) -> i32;

--- a/apps/desktop-tauri/src-tauri/src/shell/geometry.rs
+++ b/apps/desktop-tauri/src-tauri/src/shell/geometry.rs
@@ -14,10 +14,12 @@ pub(super) struct MonitorPlacement {
 /// Panel dimensions derived from the tray-panel surface mode properties.
 pub(super) fn surface_panel_size(mode: SurfaceMode) -> PanelSize {
     let props = mode.window_properties();
-    PanelSize {
-        width: props.width as u32,
-        height: props.height as u32,
-    }
+    // Surface window property dimensions are whole-pixel constants.
+    #[expect(clippy::cast_possible_truncation, reason = "whole units by design")]
+    let width = props.width as u32;
+    #[expect(clippy::cast_possible_truncation, reason = "whole units by design")]
+    let height = props.height as u32;
+    PanelSize { width, height }
 }
 
 pub(super) fn tray_panel_size() -> PanelSize {
@@ -27,13 +29,24 @@ pub(super) fn tray_panel_size() -> PanelSize {
 pub(super) fn monitor_work_area_rect(monitor: &tauri::Monitor) -> Rect {
     let position = monitor.position();
     let size = monitor.size();
+    // Monitor dimensions are physical pixels, bounded well below i32::MAX.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "monitor pixel dimensions fit in i32"
+    )]
+    let size_width = size.width as i32;
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "monitor pixel dimensions fit in i32"
+    )]
+    let size_height = size.height as i32;
     if let Some(area) = codexbar::host::session::primary_work_area_pixels()
         && area.width > 0
         && area.height > 0
         && area.x >= position.x
         && area.y >= position.y
-        && area.x + area.width <= position.x + size.width as i32
-        && area.y + area.height <= position.y + size.height as i32
+        && area.x + area.width <= position.x + size_width
+        && area.y + area.height <= position.y + size_height
     {
         return Rect {
             x: area.x,
@@ -84,10 +97,16 @@ pub(super) fn popout_position(
 /// Center a panel on the monitor's work area (used for Settings windows).
 pub(super) fn centered_position(monitor: &MonitorPlacement, panel_size: &PanelSize) -> (i32, i32) {
     let scale = monitor.scale_factor;
+    // Centering math truncates to whole pixels; panel sizes fit comfortably in i32.
+    #[expect(clippy::cast_possible_truncation, reason = "whole units by design")]
     let pw = (panel_size.width as f64 * scale) as i32;
+    #[expect(clippy::cast_possible_truncation, reason = "whole units by design")]
     let ph = (panel_size.height as f64 * scale) as i32;
     let wa = &monitor.work_area;
+    // Work-area dimensions are physical pixels, bounded well below i32::MAX.
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let x = wa.x + (wa.width as i32 - pw) / 2;
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let y = wa.y + (wa.height as i32 - ph) / 2;
     (x, y)
 }
@@ -96,30 +115,41 @@ pub(super) fn inferred_tray_anchor_rect(monitor: &MonitorPlacement) -> Rect {
     const SYNTHETIC_TRAY_ICON_SIZE: u32 = 24;
     const SYNTHETIC_TRAY_EDGE_PADDING: i32 = 8;
 
+    // Monitor bounds and work area are physical pixels, bounded well below i32::MAX.
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let work_right = monitor.work_area.x + monitor.work_area.width as i32;
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let work_bottom = monitor.work_area.y + monitor.work_area.height as i32;
     let bounds_left = monitor.bounds.x;
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let bounds_right = monitor.bounds.x + monitor.bounds.width as i32;
     let bounds_top = monitor.bounds.y;
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let bounds_bottom = monitor.bounds.y + monitor.bounds.height as i32;
     let left_gap = monitor.work_area.x - bounds_left;
     let right_gap = bounds_right - work_right;
     let top_gap = monitor.work_area.y - bounds_top;
     let bottom_gap = bounds_bottom - work_bottom;
 
+    // Synthetic tray icon is 24 px, trivially within i32 range.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "synthetic icon size constant fits i32"
+    )]
+    let icon_size = SYNTHETIC_TRAY_ICON_SIZE as i32;
     let x = if left_gap > right_gap {
-        monitor.work_area.x - SYNTHETIC_TRAY_ICON_SIZE as i32 - SYNTHETIC_TRAY_EDGE_PADDING
+        monitor.work_area.x - icon_size - SYNTHETIC_TRAY_EDGE_PADDING
     } else if right_gap > left_gap {
         work_right + SYNTHETIC_TRAY_EDGE_PADDING
     } else {
-        work_right - SYNTHETIC_TRAY_ICON_SIZE as i32 - SYNTHETIC_TRAY_EDGE_PADDING
+        work_right - icon_size - SYNTHETIC_TRAY_EDGE_PADDING
     };
     let y = if top_gap > bottom_gap {
-        monitor.work_area.y - SYNTHETIC_TRAY_ICON_SIZE as i32 - SYNTHETIC_TRAY_EDGE_PADDING
+        monitor.work_area.y - icon_size - SYNTHETIC_TRAY_EDGE_PADDING
     } else if bottom_gap > top_gap {
         work_bottom + SYNTHETIC_TRAY_EDGE_PADDING
     } else {
-        bounds_bottom - SYNTHETIC_TRAY_ICON_SIZE as i32 - SYNTHETIC_TRAY_EDGE_PADDING
+        bounds_bottom - icon_size - SYNTHETIC_TRAY_EDGE_PADDING
     };
 
     Rect {
@@ -160,7 +190,16 @@ pub(super) fn monitor_placement_for_anchor(
     monitors: &[MonitorPlacement],
     anchor: crate::state::TrayAnchor,
 ) -> Option<MonitorPlacement> {
+    // Tray icon dimensions are small pixel counts, far below i32::MAX.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "tray icon pixel dimensions fit in i32"
+    )]
     let anchor_cx = anchor.x + anchor.width as i32 / 2;
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "tray icon pixel dimensions fit in i32"
+    )]
     let anchor_cy = anchor.y + anchor.height as i32 / 2;
 
     monitor_placement_containing_point(monitors, anchor_cx, anchor_cy)
@@ -181,7 +220,16 @@ pub(super) fn monitor_for_anchor(
     monitors: &[tauri::Monitor],
     anchor: crate::state::TrayAnchor,
 ) -> Option<&tauri::Monitor> {
+    // Tray icon dimensions are small pixel counts, far below i32::MAX.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "tray icon pixel dimensions fit in i32"
+    )]
     let anchor_cx = anchor.x + anchor.width as i32 / 2;
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "tray icon pixel dimensions fit in i32"
+    )]
     let anchor_cy = anchor.y + anchor.height as i32 / 2;
 
     monitor_containing_point(monitors, anchor_cx, anchor_cy)
@@ -209,5 +257,10 @@ pub(super) fn monitor_containing_point(
 }
 
 pub(super) fn point_in_rect(rect: &Rect, x: i32, y: i32) -> bool {
-    x >= rect.x && x < rect.x + rect.width as i32 && y >= rect.y && y < rect.y + rect.height as i32
+    // Rect dimensions are physical pixels, bounded well below i32::MAX.
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
+    let right = rect.x + rect.width as i32;
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
+    let bottom = rect.y + rect.height as i32;
+    x >= rect.x && x < right && y >= rect.y && y < bottom
 }

--- a/apps/desktop-tauri/src-tauri/src/surface.rs
+++ b/apps/desktop-tauri/src-tauri/src/surface.rs
@@ -108,7 +108,10 @@ pub struct WindowProperties {
     pub min_height: Option<f64>,
     pub always_on_top: bool,
     /// Whether the window should auto-hide when it loses focus.
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "surface helper reserved for future window management integration"
+    )]
     pub blur_dismiss: bool,
     /// Whether the window should be hidden from the Windows taskbar. Widget
     /// surfaces (TrayPanel) stay hidden; the PopOut window mode shows there.

--- a/apps/desktop-tauri/src-tauri/src/surface_target.rs
+++ b/apps/desktop-tauri/src-tauri/src/surface_target.rs
@@ -34,7 +34,10 @@ pub enum SurfaceTarget {
 }
 
 impl SurfaceTarget {
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "surface target type reserved for future window management integration"
+    )]
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "summary" => Some(Self::Summary),

--- a/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/tray_bridge.rs
@@ -723,7 +723,10 @@ fn truncate_tooltip_text(text: &str, max_chars: usize) -> String {
     }
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "tray bridge helper reserved for future system tray integration"
+)]
 fn menu_contains(menu: &[TrayMenuEntry], id: &str) -> bool {
     menu.iter().any(|entry| {
         entry.id.as_deref() == Some(id)

--- a/apps/desktop-tauri/src-tauri/src/window_positioner.rs
+++ b/apps/desktop-tauri/src-tauri/src/window_positioner.rs
@@ -1,5 +1,8 @@
 // Public positioning API — consumed by the shell and tested here.
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "window positioner types reserved for future window management integration"
+)]
 
 /// A rectangle in physical pixels (monitor work area or icon bounds).
 #[derive(Debug, Clone, Copy)]
@@ -28,7 +31,10 @@ fn physical_panel_size(panel_size: &PanelSize, scale_factor: f64) -> (i32, i32) 
         1.0
     };
 
+    // Physical size is rounded to whole pixels before truncation.
+    #[expect(clippy::cast_possible_truncation, reason = "whole units by design")]
     let width = ((panel_size.width as f64) * scale_factor).round().max(1.0) as i32;
+    #[expect(clippy::cast_possible_truncation, reason = "whole units by design")]
     let height = ((panel_size.height as f64) * scale_factor).round().max(1.0) as i32;
     (width, height)
 }
@@ -43,7 +49,16 @@ fn clamp_to_work_area(
     let (pw, ph) = physical_panel_size(panel_size, scale_factor);
     let min_x = monitor_rect.x + MARGIN;
     let min_y = monitor_rect.y + MARGIN;
+    // Monitor dimensions are physical pixels, bounded well below i32::MAX.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "monitor pixel dimensions fit in i32"
+    )]
     let max_x = (monitor_rect.x + monitor_rect.width as i32 - pw - MARGIN).max(min_x);
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "monitor pixel dimensions fit in i32"
+    )]
     let max_y = (monitor_rect.y + monitor_rect.height as i32 - ph - MARGIN).max(min_y);
 
     (target_x.clamp(min_x, max_x), target_y.clamp(min_y, max_y))
@@ -58,6 +73,11 @@ fn calculate_anchored_position(
     open_above: bool,
 ) -> (i32, i32) {
     let (pw, ph) = physical_panel_size(panel_size, scale_factor);
+    // Tray icon widths are tens of pixels, far below i32::MAX.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "tray icon pixel dimensions fit in i32"
+    )]
     let anchor_x = icon_rect.x + (icon_rect.width as i32) / 2;
     let target_x = anchor_x - pw / 2;
     let target_y = if open_above {
@@ -94,12 +114,17 @@ pub fn calculate_panel_position(
     scale_factor: f64,
 ) -> (i32, i32) {
     let my = work_area.y;
+    // Work-area and icon dimensions are physical pixels, bounded well below i32::MAX.
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let mh = work_area.height as i32;
 
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let icon_cy = icon_rect.y + (icon_rect.height as i32) / 2;
     let monitor_cy = my + mh / 2;
 
     let open_above = icon_cy > monitor_cy;
+    // Icon bounds are physical pixels, bounded well below i32::MAX.
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let anchor_y = if open_above {
         icon_rect.y
     } else {
@@ -114,15 +139,18 @@ pub fn calculate_panel_position(
         anchor_y,
         open_above,
     );
+    // Monitor and work-area widths are physical pixels, bounded well below i32::MAX.
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let bounds_right = monitor_bounds.x + monitor_bounds.width as i32;
+    #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
     let work_right = work_area.x + work_area.width as i32;
 
     if work_area.x > monitor_bounds.x || work_right < bounds_right {
         let (_, ph) = physical_panel_size(panel_size, scale_factor);
-        (
-            position.0,
-            work_area.y + work_area.height as i32 - ph - MARGIN,
-        )
+        // Work-area height is a physical pixel count, bounded well below i32::MAX.
+        #[expect(clippy::cast_possible_wrap, reason = "pixel dimensions fit in i32")]
+        let work_height = work_area.height as i32;
+        (position.0, work_area.y + work_height - ph - MARGIN)
     } else {
         position
     }
@@ -137,9 +165,20 @@ pub fn calculate_shortcut_position(
     let (pw, ph) = physical_panel_size(panel_size, scale_factor);
     let mx = monitor_rect.x;
     let my = monitor_rect.y;
+    // Monitor dimensions are physical pixels, bounded well below i32::MAX.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "monitor pixel dimensions fit in i32"
+    )]
     let mw = monitor_rect.width as i32;
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "monitor pixel dimensions fit in i32"
+    )]
     let mh = monitor_rect.height as i32;
 
+    // Shortcut offset is truncated to a whole pixel by design.
+    #[expect(clippy::cast_possible_truncation, reason = "whole units by design")]
     let x = mx + ((mw as f64) * 0.22) as i32;
     let y = my + (mh - ph) / 2;
 
@@ -166,7 +205,16 @@ pub fn calculate_popout_position(
     let (pw, ph) = physical_panel_size(panel_size, scale_factor);
     let mx = monitor_rect.x;
     let my = monitor_rect.y;
+    // Monitor dimensions are physical pixels, bounded well below i32::MAX.
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "monitor pixel dimensions fit in i32"
+    )]
     let mw = monitor_rect.width as i32;
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "monitor pixel dimensions fit in i32"
+    )]
     let mh = monitor_rect.height as i32;
 
     let (target_x, target_y) = if let Some(icon_rect) = icon_rect {
@@ -252,7 +300,7 @@ mod tests {
         let monitor = hd_monitor();
         let (_, y) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         assert!(
-            y >= icon.y + icon.height as i32,
+            y >= icon.y + i32::try_from(icon.height).unwrap(),
             "panel should sit below the icon"
         );
     }
@@ -300,7 +348,7 @@ mod tests {
         let monitor = hd_monitor();
         let (x, _) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         assert!(
-            x + panel().width as i32 + MARGIN <= 1920,
+            x + i32::try_from(panel().width).unwrap() + MARGIN <= 1920,
             "panel must not exceed right margin"
         );
     }
@@ -400,7 +448,10 @@ mod tests {
         };
         let (x, _) = calculate_panel_position(&icon, &monitor, &monitor, &panel(), 1.0);
         assert!(x >= monitor.x + MARGIN);
-        assert!(x + panel().width as i32 + MARGIN <= monitor.x + monitor.width as i32);
+        assert!(
+            x + i32::try_from(panel().width).unwrap() + MARGIN
+                <= monitor.x + i32::try_from(monitor.width).unwrap()
+        );
     }
 
     #[test]
@@ -430,6 +481,8 @@ mod tests {
     fn shortcut_position_22_pct_from_left() {
         let monitor = hd_monitor();
         let (x, _) = calculate_shortcut_position(&monitor, &panel(), 1.0);
+        // 1920 * 0.22 = 422.4 — a constant that fits i32.
+        #[expect(clippy::cast_possible_truncation, reason = "constant offset fits i32")]
         let expected_x = (1920.0 * 0.22) as i32;
         assert_eq!(x, expected_x);
     }
@@ -451,9 +504,15 @@ mod tests {
         };
         let (x, y) = calculate_shortcut_position(&monitor, &panel(), 1.0);
         assert!(x >= MARGIN);
-        assert!(x + panel().width as i32 + MARGIN <= monitor.width as i32);
+        assert!(
+            x + i32::try_from(panel().width).unwrap() + MARGIN
+                <= i32::try_from(monitor.width).unwrap()
+        );
         assert!(y >= MARGIN);
-        assert!(y + panel().height as i32 + MARGIN <= monitor.height as i32);
+        assert!(
+            y + i32::try_from(panel().height).unwrap() + MARGIN
+                <= i32::try_from(monitor.height).unwrap()
+        );
     }
 
     // --- visible-surface popout tests ---

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -110,3 +110,6 @@ panic = "abort"
 [[bin]]
 name = "codexbar"
 path = "src/main.rs"
+
+[lints]
+workspace = true

--- a/rust/src/agent_sessions/focus.rs
+++ b/rust/src/agent_sessions/focus.rs
@@ -47,10 +47,21 @@ fn focus_process(pid: u32) -> SessionFocusResult {
         window: Option<HWND>,
     }
 
+    // SAFETY: `find_window` is passed to `EnumWindows` as the callback below;
+    // Windows invokes it only with valid top-level HWNDs during enumeration.
+    // `data` is the pointer to our stack-allocated `Search` (passed as LPARAM
+    // to EnumWindows), so it outlives every callback invocation.
     unsafe extern "system" fn find_window(hwnd: HWND, data: LPARAM) -> BOOL {
+        // SAFETY: `data` was built from a mutable reference to `search`, which
+        // stays alive on this thread for the whole EnumWindows call, so no other
+        // code can access the pointee while this callback holds the reference.
         let search = unsafe { &mut *(data.0 as *mut Search) };
         let mut window_pid = 0;
+        // SAFETY: GetWindowThreadProcessId only reads `hwnd` (a window handle
+        // handed to us by EnumWindows) and writes through the provided pointer.
         unsafe { GetWindowThreadProcessId(hwnd, Some(&mut window_pid)) };
+        // SAFETY: `hwnd` is a valid top-level window handle supplied by
+        // EnumWindows; IsWindowVisible only reads it.
         if window_pid == search.pid && unsafe { IsWindowVisible(hwnd).as_bool() } {
             search.window = Some(hwnd);
             return BOOL(0);
@@ -59,6 +70,8 @@ fn focus_process(pid: u32) -> SessionFocusResult {
     }
 
     let mut search = Search { pid, window: None };
+    // SAFETY: EnumWindows runs `find_window` synchronously on this thread while
+    // `search` lives on the stack; the LPARAM encodes a valid pointer to it.
     let result = unsafe { EnumWindows(Some(find_window), LPARAM(&mut search as *mut _ as isize)) };
     if result.is_err() {
         return SessionFocusResult::failed("Windows could not enumerate application windows.");
@@ -67,8 +80,11 @@ fn focus_process(pid: u32) -> SessionFocusResult {
     let Some(window) = search.window else {
         return SessionFocusResult::failed("No focusable window was found for this session.");
     };
+    // SAFETY: `window` is an HWND returned by EnumWindows, so it refers to a
+    // live window; ShowWindow/SetForegroundWindow only read the handle and
+    // their results are advisory UI hints whose failures we already handle.
     unsafe {
-        let _ = ShowWindow(window, SW_RESTORE);
+        let _restored = ShowWindow(window, SW_RESTORE);
         if SetForegroundWindow(window).as_bool() {
             SessionFocusResult::focused()
         } else {

--- a/rust/src/agent_sessions/pi_family/parser.rs
+++ b/rust/src/agent_sessions/pi_family/parser.rs
@@ -118,7 +118,13 @@ fn latest_pi_session_name(path: &Path, prefix_lines: &[&[u8]]) -> Option<String>
     if file.seek(SeekFrom::Start(offset)).is_err() {
         return latest;
     }
-    let mut tail = vec![0_u8; TAIL_READ.min(size as usize)];
+    // Session file sizes fit usize on all supported targets.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "session file sizes fit usize on any supported target"
+    )]
+    let size_usize = size as usize;
+    let mut tail = vec![0_u8; TAIL_READ.min(size_usize)];
     let mut read_total = 0_usize;
     while read_total < tail.len() {
         match file.read(&mut tail[read_total..]) {
@@ -159,7 +165,13 @@ fn read_prefix(path: &Path) -> Option<Vec<u8>> {
     use std::io::Read;
     let mut file = std::fs::File::open(path).ok()?;
     let metadata = file.metadata().ok()?;
-    let limit = (metadata.len() as usize).min(MAX_PREFIX_READ);
+    // Session file sizes fit usize on all supported targets.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "session file sizes fit usize on any supported target"
+    )]
+    let len_usize = metadata.len() as usize;
+    let limit = len_usize.min(MAX_PREFIX_READ);
     let mut data = vec![0_u8; limit];
     let mut read_total = 0_usize;
     while read_total < limit {

--- a/rust/src/browser/cookie_cache.rs
+++ b/rust/src/browser/cookie_cache.rs
@@ -3,7 +3,12 @@
 //! Caches cookie headers for providers to avoid repeated browser cookie extraction.
 //! Stores normalized cookie headers with timestamps and source labels.
 
-#![allow(dead_code)]
+// The cache API is currently unused by the crate (reserved for provider
+// cookie reuse), so every public item would trip dead_code.
+#![allow(
+    dead_code,
+    reason = "module reserved: CookieHeaderCache has no callers yet"
+)]
 
 use crate::core::ProviderId;
 use chrono::{DateTime, Utc};

--- a/rust/src/browser/cookies.rs
+++ b/rust/src/browser/cookies.rs
@@ -3,7 +3,10 @@
 //! Chromium browsers store cookies in an SQLite database encrypted with DPAPI.
 //! Firefox stores cookies in an unencrypted SQLite database.
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "the cookie API surface is shared across providers and cfg-split Windows/WSLS code paths, so individual helpers are reached only from their own browser/provider callers"
+)]
 
 use std::path::Path;
 
@@ -269,7 +272,7 @@ impl CookieExtractor {
         );
 
         // Clean up temp file
-        let _ = std::fs::remove_file(&temp_db);
+        let _cleanup = std::fs::remove_file(&temp_db);
 
         // If every candidate cookie failed to decrypt and no cookies were recovered,
         // check whether Chrome App-Bound Encryption (Chrome 127+) is the culprit.
@@ -333,9 +336,19 @@ impl CookieExtractor {
         use windows::Win32::Foundation::{HLOCAL, LocalFree};
         use windows::Win32::Security::Cryptography::{CRYPT_INTEGER_BLOB, CryptUnprotectData};
 
+        // DPAPI blob sizes come from in-memory slices, far below u32::MAX.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "encrypted cookie blobs are small in-memory buffers; a length near u32::MAX is unreachable"
+        )]
+        let cb_input_len = encrypted_data.len() as u32;
+        // SAFETY: CryptUnprotectData only reads `input_blob` (which borrows the
+        // caller-owned `encrypted_data` slice) and allocates `output_blob`, whose
+        // buffer we copy and release with LocalFree below; all pointers passed
+        // are valid for the duration of the single call.
         unsafe {
             let input_blob = CRYPT_INTEGER_BLOB {
-                cbData: encrypted_data.len() as u32,
+                cbData: cb_input_len,
                 pbData: encrypted_data.as_ptr() as *mut u8,
             };
 
@@ -538,7 +551,7 @@ impl CookieExtractor {
         }
 
         // Clean up
-        let _ = std::fs::remove_file(&temp_db);
+        let _cleanup = std::fs::remove_file(&temp_db);
 
         Ok(cookies)
     }
@@ -809,7 +822,7 @@ mod tests {
             write!(f, r#"{{"os_crypt":{{"encrypted_key":"QUJDREVGR0g="}}}}"#).unwrap();
         }
         let detected = CookieExtractor::detect_app_bound_encryption(&path);
-        let _ = std::fs::remove_file(&path);
+        let _cleanup = std::fs::remove_file(&path);
         assert!(!detected, "ABE should not be detected when field is absent");
     }
 
@@ -829,7 +842,7 @@ mod tests {
             .unwrap();
         }
         let detected = CookieExtractor::detect_app_bound_encryption(&path);
-        let _ = std::fs::remove_file(&path);
+        let _cleanup = std::fs::remove_file(&path);
         assert!(detected, "ABE should be detected when field is present");
     }
 }

--- a/rust/src/browser/detection.rs
+++ b/rust/src/browser/detection.rs
@@ -3,7 +3,10 @@
 //! On native Windows, uses standard AppData paths.
 //! On WSL, resolves browser paths via /mnt/c/ to access Windows browser data.
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "browser detection types reserved for future cookie-based session management"
+)]
 
 use std::path::{Path, PathBuf};
 

--- a/rust/src/browser/mod.rs
+++ b/rust/src/browser/mod.rs
@@ -7,5 +7,8 @@ pub mod watchdog;
 pub mod wsl_paths;
 
 // Re-exports for future UI integration
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "watchdog API re-exported for future UI integration; no caller outside this module exists yet"
+)]
 pub use watchdog::{WatchdogConfig, WatchdogError, WebProbeWatchdog, global_watchdog};

--- a/rust/src/browser/watchdog.rs
+++ b/rust/src/browser/watchdog.rs
@@ -3,7 +3,10 @@
 //! Monitors and manages child web probe processes to prevent orphaned processes.
 //! Ensures that browser automation or scraping processes are properly cleaned up.
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "watchdog types reserved for future browser-session monitoring integration"
+)]
 
 use std::collections::HashMap;
 use std::process::Child;

--- a/rust/src/cli/dashboard.rs
+++ b/rust/src/cli/dashboard.rs
@@ -102,7 +102,8 @@ pub fn write_atomic(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
     if result.is_err()
         && let Ok(file) = std::fs::OpenOptions::new().write(true).open(&temp)
     {
-        let _ = file.set_len(0);
+        // Best-effort truncate; the abandoned temp file is unlinked by callers.
+        let _truncated = file.set_len(0);
     }
     result
 }
@@ -181,7 +182,8 @@ mod tests {
         impl Drop for CwdGuard {
             fn drop(&mut self) {
                 if self.restore {
-                    let _ = std::env::set_current_dir(&self.original);
+                    // Best-effort CWD restore; a failed chdir only affects the already-failing test.
+                    let _restored = std::env::set_current_dir(&self.original);
                 }
             }
         }

--- a/rust/src/cli/guard.rs
+++ b/rust/src/cli/guard.rs
@@ -258,7 +258,13 @@ pub async fn run(args: GuardArgs) -> i32 {
 
     let source_mode = SourceMode::parse(&args.source).unwrap_or(SourceMode::Auto);
     let web_timeout = if timeout_secs > 0.0 {
-        timeout_secs.ceil() as u64
+        // Whole-second ceiling; timeout_secs is validated to 0..=86400, far below u64::MAX.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "timeout validated to 0..=86400, so the cast cannot truncate"
+        )]
+        let ceil = timeout_secs.ceil() as u64;
+        ceil
     } else {
         60
     };
@@ -413,7 +419,13 @@ pub fn guard_human_line(
 fn guard_percent_string(value: f64) -> String {
     let rounded = value.round();
     if (value - rounded).abs() < 0.05 {
-        format!("{}%", rounded as i64)
+        // Display-only whole-percent label; percentages are bounded far inside i64 range.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "display-only percentage label"
+        )]
+        let whole = rounded as i64;
+        format!("{}%", whole)
     } else {
         format!("{:.1}%", value)
     }

--- a/rust/src/cli/hooks.rs
+++ b/rust/src/cli/hooks.rs
@@ -167,7 +167,8 @@ async fn run_watch(args: HooksWatchArgs) -> anyhow::Result<()> {
     let stop = Arc::new(AtomicBool::new(false));
     let stop_for_signal = Arc::clone(&stop);
     tokio::spawn(async move {
-        let _ = tokio::signal::ctrl_c().await;
+        // Best-effort signal wait; no signal just means the loop stops when hooks finish.
+        let _signal = tokio::signal::ctrl_c().await;
         stop_for_signal.store(true, Ordering::SeqCst);
     });
 

--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -6,7 +6,10 @@
 //! - `codexbar cost` - print local token cost usage
 //! - `codexbar autostart` - manage Windows auto-start
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "CLI subcommand types reserved for future command expansion"
+)]
 
 pub mod account;
 pub mod autostart;

--- a/rust/src/cli/serve/dashboard/coordinator.rs
+++ b/rust/src/cli/serve/dashboard/coordinator.rs
@@ -391,7 +391,8 @@ mod tests {
                         // Park until the test releases this generation to its error.
                         let gate = release_rx.lock().expect("poisoned").take();
                         let gate = gate.expect("attempt-1 gate released only once");
-                        let _ = gate.await;
+                        // Best-effort gate await; either outcome releases the parked build.
+                        let _released = gate.await;
                         Err("boom".to_string())
                     } else {
                         Ok(build_snapshot(&stub_input()))
@@ -428,7 +429,8 @@ mod tests {
             .collect();
 
         // Release attempt 1 to its error and drive the builder to completion.
-        let _ = release_tx.send(());
+        // Best-effort release; the receiver is dropped if the build already errored.
+        let _released = release_tx.send(());
         let std::task::Poll::Ready(Err(message)) = builder.as_mut().poll(&mut cx) else {
             panic!("builder must resolve with the attempt-1 error");
         };
@@ -627,7 +629,8 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(20)).await;
 
         builder.abort(); // cancel the builder mid-build
-        let _ = builder.await;
+        // Reap the aborted builder task; its result is intentionally discarded.
+        let _aborted = builder.await;
 
         // The waiter and a fresh caller both complete via a rebuilt (attempt 2).
         let fresh = {

--- a/rust/src/cli/serve/mod.rs
+++ b/rust/src/cli/serve/mod.rs
@@ -109,8 +109,13 @@ struct ServeConfig {
 
 pub async fn run(args: ServeArgs) -> anyhow::Result<()> {
     let mut config = validate_serve_args(&args)?;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "refresh interval is seconds; >u32::MAX secs is meaningless for a dashboard refresh"
+    )]
+    let refresh_interval = args.refresh_interval.max(1) as u32;
     config.dashboard = Some(dashboard::DashboardState::live(
-        args.refresh_interval.max(1) as u32,
+        refresh_interval,
         config.identity,
     ));
     let listener = TcpListener::bind((config.host.as_str(), config.port)).await?;
@@ -397,8 +402,10 @@ fn invalid_request_response() -> String {
 /// The drain is bounded independently of the head-read budget, so this cannot
 /// re-open the slow-trickle hold that #2684 closes.
 async fn respond_and_close_gracefully(stream: &mut TcpStream, response: &[u8]) {
-    let _ = stream.write_all(response).await;
-    let _ = stream.shutdown().await;
+    // Best-effort teardown: a failed error write still leaves the drain +
+    // half-close below to close the socket cleanly.
+    let _written = stream.write_all(response).await;
+    let _shutdown = stream.shutdown().await;
     let drain = async {
         let mut sink = [0_u8; 512];
         while let Ok(n) = stream.read(&mut sink).await {
@@ -407,7 +414,9 @@ async fn respond_and_close_gracefully(stream: &mut TcpStream, response: &[u8]) {
             }
         }
     };
-    let _ = tokio::time::timeout(Duration::from_secs(1), drain).await;
+    // Draining is best-effort; whether the 1s drain budget elapses or the
+    // client already closed, the socket is dropped right after either way.
+    let _drain_result = tokio::time::timeout(Duration::from_secs(1), drain).await;
 }
 
 /// Strongly typed route table for the serve surface.

--- a/rust/src/cli/serve/tests.rs
+++ b/rust/src/cli/serve/tests.rs
@@ -348,7 +348,8 @@ async fn trickling_bytes_do_not_reset_total_head_deadline() {
         }
     }
     let mut response = Vec::new();
-    let _ = client.read_to_end(&mut response).await;
+    // Best-effort drain to unblock the server; the deadline assertions below are the real check.
+    let _drained = client.read_to_end(&mut response).await;
     let elapsed = started.elapsed();
     drop(client);
     server_task.await.unwrap().unwrap();

--- a/rust/src/cli/tty_runner.rs
+++ b/rust/src/cli/tty_runner.rs
@@ -3,7 +3,10 @@
 //! Executes interactive CLI commands using the platform pseudo-console.
 //! Provides PTY-like functionality for capturing output from interactive TUI programs.
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "TTY runner types reserved for future interactive session management"
+)]
 
 use regex_lite::Regex;
 use std::collections::HashMap;
@@ -399,7 +402,8 @@ impl TtyCommandRunner {
                     Ok(0) => break,
                     Ok(n) => {
                         if let Ok(s) = String::from_utf8(buf[..n].to_vec()) {
-                            let _ = tx.send(s);
+                            // Best-effort send; the channel is dropped once the main loop exits.
+                            let _sent = tx.send(s);
                         }
                     }
                     Err(_) => break,
@@ -420,15 +424,20 @@ impl TtyCommandRunner {
         for (idx, line) in script_lines.iter().enumerate() {
             if options.script_char_delay_secs > 0.0 {
                 for ch in line.chars() {
-                    let _ = write!(writer, "{}", ch);
-                    let _ = writer.flush();
+                    // Best-effort scripted input; a closed PTY just drops the write.
+                    let _typed = write!(writer, "{}", ch);
+                    // Best-effort flush; failures surface only as missing script output.
+                    let _flushed = writer.flush();
                     std::thread::sleep(Duration::from_secs_f64(options.script_char_delay_secs));
                 }
-                let _ = write!(writer, "\r\n");
+                // Best-effort line terminator; interactive programs expect CRLF.
+                let _newline_written = write!(writer, "\r\n");
             } else {
-                let _ = write!(writer, "{}\r\n", line);
+                // Best-effort whole-line write for the no-delay path.
+                let _line_written = write!(writer, "{}\r\n", line);
             }
-            let _ = writer.flush();
+            // Best-effort flush per script line.
+            let _line_flushed = writer.flush();
             if idx + 1 < script_lines.len() && options.script_line_delay_secs > 0.0 {
                 std::thread::sleep(Duration::from_secs_f64(options.script_line_delay_secs));
             }
@@ -470,8 +479,10 @@ impl TtyCommandRunner {
                 // Status Report request and wait for a terminal cursor
                 // position response before processing scripted input.
                 if chunk.contains("\x1b[6n") {
-                    let _ = write!(writer, "\x1b[1;1R");
-                    let _ = writer.flush();
+                    // Best-effort cursor-position reply; a dead PTY ignores it.
+                    let _cursor_reply = write!(writer, "\x1b[1;1R");
+                    // Best-effort flush of the cursor reply.
+                    let _cursor_flushed = writer.flush();
                 }
 
                 // Check for URLs
@@ -510,8 +521,10 @@ impl TtyCommandRunner {
                 for (trigger, keys) in &options.send_on_substrings {
                     if !triggered_sends.contains(trigger) && buffer.contains(trigger) {
                         let normalized = keys.replace('\n', "\r\n");
-                        let _ = write!(writer, "{}", normalized);
-                        let _ = writer.flush();
+                        // Best-effort send-trigger input; a closed PTY drops the write.
+                        let _trigger_written = write!(writer, "{}", normalized);
+                        // Best-effort flush after a send-trigger write.
+                        let _trigger_flushed = writer.flush();
                         triggered_sends.insert(trigger.clone());
                     }
                 }
@@ -525,8 +538,10 @@ impl TtyCommandRunner {
             if let Some(interval) = options.send_enter_every_secs
                 && last_enter.elapsed() >= Duration::from_secs_f64(interval)
             {
-                let _ = write!(writer, "\r\n");
-                let _ = writer.flush();
+                // Best-effort periodic Enter keepalive.
+                let _enter_written = write!(writer, "\r\n");
+                // Best-effort flush after the periodic Enter.
+                let _enter_flushed = writer.flush();
                 last_enter = Instant::now();
             }
 
@@ -546,8 +561,10 @@ impl TtyCommandRunner {
         }
 
         if child.try_wait().ok().flatten().is_none() {
-            let _ = child.kill();
-            let _ = child.wait();
+            // Best-effort kill; the process may have exited on its own.
+            let _killed = child.kill();
+            // Best-effort reap; the exit status is intentionally discarded.
+            let _reaped = child.wait();
         }
 
         if buffer.is_empty() && !stopped_early {

--- a/rust/src/cli/usage.rs
+++ b/rust/src/cli/usage.rs
@@ -714,6 +714,11 @@ fn render_progress_bar(percent: f64, width: usize, use_color: bool) -> String {
     } else {
         0.0
     };
+    // percent is clamped to 0..=100, so the rounded product cannot exceed width.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "percent clamped to 0..=100, so the product cannot exceed width"
+    )]
     let filled = ((percent / 100.0) * width as f64).round() as usize;
     let empty = width.saturating_sub(filled);
 

--- a/rust/src/codex_accounts/account_manager.rs
+++ b/rust/src/codex_accounts/account_manager.rs
@@ -71,7 +71,9 @@ impl CodexAccountManager {
         {
             Ok(account) => Ok(account),
             Err(error) => {
-                let _ = fs::remove_dir_all(&home_path);
+                // Best-effort teardown of the fresh managed home on failure;
+                // a removal error cannot change the authentication outcome.
+                let _removed_home = fs::remove_dir_all(&home_path);
                 Err(error)
             }
         }
@@ -355,7 +357,9 @@ impl CodexAccountManager {
         let Ok(encoded) = serde_json::to_string_pretty(&payload) else {
             return;
         };
-        let _ = fs::write(path, format!("{encoded}\n"));
+        // Best-effort teardown: persisting the rewritten payload is advisory
+        // and a write error cannot change the in-memory rewrite result.
+        let _written_payload = fs::write(path, format!("{encoded}\n"));
     }
 
     fn managed_home_paths_matching(

--- a/rust/src/codex_accounts/api.rs
+++ b/rust/src/codex_accounts/api.rs
@@ -288,7 +288,9 @@ impl CodexAccountApi {
             && !credentials.refresh_token.is_empty()
             && let Ok(refreshed) = self.refresh(&credentials).await
         {
-            let _ = save_credentials(codex_home_path, &refreshed);
+            // Best-effort credential persist: a write failure here cannot
+            // block the in-memory refresh already in hand.
+            let _saved_refreshed = save_credentials(codex_home_path, &refreshed);
             credentials = refreshed;
         }
 
@@ -302,7 +304,9 @@ impl CodexAccountApi {
         }
 
         if let Ok(refreshed) = self.refresh(&credentials).await {
-            let _ = save_credentials(codex_home_path, &refreshed);
+            // Best-effort credential persist before the retry; a write error
+            // cannot block the fetch already in progress.
+            let _saved_retry = save_credentials(codex_home_path, &refreshed);
             return self
                 .fetch_once(codex_home_path, &refreshed, email_hint, verify_live_data)
                 .await;

--- a/rust/src/codex_accounts/codex_desktop.rs
+++ b/rust/src/codex_accounts/codex_desktop.rs
@@ -40,6 +40,12 @@ pub fn build_restart_script(
     backup_destination: Option<&Path>,
     restore_source: Option<&Path>,
 ) -> String {
+    // Delay is bounded, non-negative seconds rendered to whole milliseconds;
+    // rounding already makes the value whole, so f64->u64 cannot overflow.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "delay is non-negative seconds; whole milliseconds by design"
+    )]
     let delay_ms = (delay_seconds.max(0.0) * 1000.0).round() as u64;
     let log_path = powershell_literal_path(&restart_log_path());
     let effective_session_root = session_root

--- a/rust/src/codex_accounts/login_runner.rs
+++ b/rust/src/codex_accounts/login_runner.rs
@@ -74,7 +74,9 @@ impl ManagedLoginProcess {
         self.cancelled.store(true, Ordering::SeqCst);
         let mut guard = self.inner.lock().expect("login process lock");
         if let Some(child) = guard.as_mut() {
-            let _ = child.kill();
+            // Teardown: the cancellation outcome cannot change the result the
+            // caller already observes, so ignore kill errors here.
+            let _killed = child.kill();
         }
     }
 }
@@ -205,7 +207,8 @@ fn take_child(handle: &ManagedLoginProcess) -> Option<Child> {
 
 fn kill_and_drain(handle: &ManagedLoginProcess) -> std::process::Output {
     let mut child = take_child(handle).expect("login process present");
-    let _ = child.kill();
+    // Teardown: kill errors cannot change the drained output already returned.
+    let _killed = child.kill();
     child
         .wait_with_output()
         .unwrap_or_else(|_| std::process::Output {

--- a/rust/src/codex_accounts/models.rs
+++ b/rust/src/codex_accounts/models.rs
@@ -108,7 +108,10 @@ pub struct CodexAccount {
 }
 
 impl CodexAccount {
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "constructor accepts all account fields for complete initialization"
+    )]
     pub fn new(
         id: Uuid,
         nickname: Option<String>,

--- a/rust/src/codex_costs.rs
+++ b/rust/src/codex_costs.rs
@@ -119,7 +119,13 @@ pub(crate) fn add_codex_days_map_to_summary(
     (total_cost, has_tokens)
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "test-only helper path: only scan_codex_file_cost (test) calls this outside tests"
+    )
+)]
 pub(crate) fn scan_codex_file_cost_for_range(path: &Path, range: &CostUsageDayRange) -> f64 {
     let parse_result = match JsonlScanner::parse_codex_file(path, range, 0, None, None) {
         Ok(result) => result,
@@ -282,7 +288,13 @@ fn add_codex_tokens_to_summary(
     Some(cost)
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "only reached from scan_codex_file_cost_for_range, which is test-only in non-test builds"
+    )
+)]
 fn codex_records_cost(records: &[CodexUsageRecord], range: &CostUsageDayRange) -> f64 {
     let mut total_cost = 0.0;
 
@@ -322,7 +334,10 @@ fn codex_speed_bucket(model: &str) -> &'static str {
     }
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
+#[cfg_attr(
+    not(test),
+    allow(dead_code, reason = "only reached from test paths in non-test builds")
+)]
 fn codex_cost_usd(model: &str, input: u64, cached: u64, output: u64) -> f64 {
     codex_cost_usd_for_day(model, input, cached, output, None)
 }
@@ -346,6 +361,17 @@ fn codex_cost_usd_for_day(
 
     let normalized = CostUsagePricing::normalize_codex_model(model);
     if normalized.contains("fast") || normalized.contains("priority") {
+        // Fast pricing takes i32 token counts; usage-record counts fit far
+        // below i32::MAX, and the callee re-checks the long-context threshold
+        // against the original u64 magnitude.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "token counts from usage records fit i32"
+        )]
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "token counts are non-negative; wrapping is impossible"
+        )]
         let fast = pricing_day
             .and_then(|day| {
                 CostUsagePricing::codex_fast_cost_usd_at_date(

--- a/rust/src/codex_sessions.rs
+++ b/rust/src/codex_sessions.rs
@@ -141,7 +141,9 @@ mod tests {
 
         assert!(dirs.contains(&user_sessions));
         assert!(dirs.contains(&root_sessions));
-        let _ = fs::remove_dir_all(base);
+        // Best-effort teardown of the temp tree; a removal error cannot
+        // change the assertions already made above.
+        let _removed_temp = fs::remove_dir_all(base);
     }
 
     #[test]

--- a/rust/src/codex_workspaces/indexer.rs
+++ b/rust/src/codex_workspaces/indexer.rs
@@ -163,6 +163,10 @@ impl CodexWorkspacesIndex {
         files.sort();
         files.dedup();
 
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "progress UI field is u32; a session file count above 4 billion is not realistic"
+        )]
         let total_file_count = files.len() as u32;
         progress(Progress {
             phase: ProgressPhase::ScanningLogs,
@@ -193,9 +197,14 @@ impl CodexWorkspacesIndex {
                 }
             }
             if idx == 0 || (idx + 1) % 25 == 0 || idx + 1 == files.len() {
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "index within the same files list whose len fits u32"
+                )]
+                let processed = (idx + 1) as u32;
                 progress(Progress {
                     phase: ProgressPhase::IndexingProjects,
-                    processed_file_count: Some((idx + 1) as u32),
+                    processed_file_count: Some(processed),
                     total_file_count: Some(total_file_count),
                     indexed_file_count: indexed,
                     skipped_file_count: skipped,
@@ -412,6 +421,7 @@ fn build_projects(sessions: &HashMap<String, SessionBucket>) -> Vec<ProjectUsage
                 path: first.project_path.clone(),
                 totals,
                 cost_estimate: cost,
+                #[allow(clippy::cast_possible_truncation, reason = "session count per project fits u32; capped upstream by the files-list length")]
                 session_count: buckets.len() as u32,
                 latest_activity: latest,
                 top_model,
@@ -550,8 +560,11 @@ fn read_catalog_status(db_path: &Path) -> SourceStatus {
             };
         }
     };
-    let _ = conn.busy_timeout(std::time::Duration::from_millis(250));
-    let _ = conn.execute_batch("PRAGMA query_only = ON;");
+    // Best-effort tuning of a read-only probe connection: a rejected
+    // busy_timeout or pragma still leaves the queries below to surface
+    // locked/corrupt states.
+    let _busy = conn.busy_timeout(std::time::Duration::from_millis(250));
+    let _pragma = conn.execute_batch("PRAGMA query_only = ON;");
 
     let has_threads: Result<bool, _> = conn.query_row(
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'threads' LIMIT 1",

--- a/rust/src/core/cost_cache_budget.rs
+++ b/rust/src/core/cost_cache_budget.rs
@@ -280,7 +280,13 @@ fn subtract_entry_days(
 
 /// File size of the on-disk cache artifact, or 0 when unreadable.
 pub fn artifact_file_size(path: &Path) -> i64 {
-    fs::metadata(path).map(|m| m.len() as i64).unwrap_or(0)
+    // Cache artifacts are bounded JSON blobs (320 MiB cap for Codex); sizes fit i64.
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "cache artifact file sizes fit i64"
+    )]
+    let len = fs::metadata(path).map(|m| m.len() as i64).unwrap_or(0);
+    len
 }
 
 /// True only for the Codex provider: only Codex persistence carries bounded

--- a/rust/src/core/hooks.rs
+++ b/rust/src/core/hooks.rs
@@ -389,7 +389,9 @@ impl HookRunner {
             .map_err(|e| format!("launch failed: {e}"))?;
 
         if let Some(mut stdin) = child.stdin.take() {
-            let _ = stdin.write_all(&payload);
+            // Fire-and-forget payload delivery: a hook that closed stdin early
+            // yields a write error, which must not abort hook execution.
+            let _delivered = stdin.write_all(&payload);
         }
 
         let timeout = Duration::from_secs(rule.timeout_secs.max(1));
@@ -404,8 +406,10 @@ impl HookRunner {
                 }
                 Ok(None) => {
                     if started.elapsed() >= timeout {
-                        let _ = child.kill();
-                        let _ = child.wait();
+                        // Teardown after timeout: kill/wait results cannot change
+                        // the outcome, which is already reported as timed out.
+                        let _killed = child.kill();
+                        let _reaped = child.wait();
                         return Err("timed out".into());
                     }
                     std::thread::sleep(Duration::from_millis(50));
@@ -487,6 +491,10 @@ fn format_unix_utc(secs: u64) -> String {
     let hour = tod / 3600;
     let min = (tod % 3600) / 60;
     let sec = tod % 60;
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "secs comes from duration since the UNIX epoch, so days fits i64 by a wide margin"
+    )]
     let (year, month, day) = civil_from_days(days as i64);
     format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
 }
@@ -497,18 +505,32 @@ fn civil_from_days(z: i64) -> (i32, u32, u32) {
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
     let doe = (z - era * 146_097) as u64;
     let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "yoe < 400 by the era math and era * 400 stays far inside i64 for any representable day count"
+    )]
     let y = yoe as i64 + era * 400;
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
     let mp = (5 * doy + 2) / 153;
     let d = doy - (153 * mp + 2) / 5 + 1;
     let m = if mp < 10 { mp + 3 } else { mp - 9 };
     let y = if m <= 2 { y + 1 } else { y };
-    (y as i32, m as u32, d as u32)
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "Hinnant's algorithm bounds m to 1..=12 and d to 1..=31; y only exceeds i32 for day offsets billions of years from real clock time"
+    )]
+    let date = (y as i32, m as u32, d as u32);
+    date
 }
 
 fn format_number(value: f64) -> String {
     if value.is_finite() && (value - value.round()).abs() < f64::EPSILON && value.abs() < 1e15 {
-        format!("{}", value as i64)
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "the guard above ensures value is finite, integral and |value| < 1e15, so the cast is exact"
+        )]
+        let integral = value as i64;
+        format!("{integral}")
     } else {
         format!("{value}")
     }

--- a/rust/src/core/jsonl_scanner.rs
+++ b/rust/src/core/jsonl_scanner.rs
@@ -3,7 +3,10 @@
 //! Incremental log file parsing for Codex and Claude session logs.
 //! Supports file-level caching to avoid re-parsing unchanged files.
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "scanner types are deserialized from JSONL for parsing but not all are read"
+)]
 
 use crate::core::{CostUsagePricing, ProviderId};
 use chrono::{DateTime, Local, NaiveDate};
@@ -57,6 +60,11 @@ impl CostScanOptions {
 
     /// Whether a prior scan at `last_scan_unix_ms` is still within the debounce window.
     pub fn should_skip_scan(&self, last_scan_unix_ms: i64, now_unix_ms: i64) -> bool {
+        // Debounce intervals are seconds-scale config values, far below i64::MAX.
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "debounce interval in seconds is a small config value that cannot exceed i64::MAX"
+        )]
         let refresh_ms = (self.refresh_min_interval_secs as i64).saturating_mul(1000);
         refresh_ms > 0
             && last_scan_unix_ms > 0
@@ -705,16 +713,31 @@ fn bare_usage_totals(obj: &Value) -> Option<(CodexTotals, Option<String>)> {
         .or_else(|| obj.get("data").and_then(|v| v.get("usage")))
         .or_else(|| obj.get("result").and_then(|v| v.get("usage")))
         .or_else(|| obj.get("response").and_then(|v| v.get("usage")))?;
+    // Token counts come from usage records and fit i32, the canonical totals storage type.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "usage token counts fit i32, the canonical totals storage type"
+    )]
     let input = ["input_tokens", "prompt_tokens", "input"]
         .into_iter()
         .find_map(|key| usage.get(key).and_then(Value::as_i64))
         .unwrap_or(0)
         .max(0) as i32;
+    // Token counts come from usage records and fit i32, the canonical totals storage type.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "usage token counts fit i32, the canonical totals storage type"
+    )]
     let output = ["output_tokens", "completion_tokens", "output"]
         .into_iter()
         .find_map(|key| usage.get(key).and_then(Value::as_i64))
         .unwrap_or(0)
         .max(0) as i32;
+    // Token counts come from usage records and fit i32, the canonical totals storage type.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "usage token counts fit i32, the canonical totals storage type"
+    )]
     let cached = [
         "cached_input_tokens",
         "cache_read_input_tokens",
@@ -759,18 +782,25 @@ fn token_count_payload(obj: &Value) -> Option<&Value> {
 }
 
 fn read_token_totals(value: &Value) -> CodexTotals {
+    // Token counts come from Codex usage records and fit within i32, which is
+    // the canonical storage type of the totals table.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "token counts from usage records fit i32"
+    )]
+    let cached = value
+        .get("cached_input_tokens")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0)
+        .max(
+            value
+                .get("cache_read_input_tokens")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0),
+        ) as i32;
     CodexTotals {
         input: token_i32(value, "input_tokens"),
-        cached: value
-            .get("cached_input_tokens")
-            .and_then(|v| v.as_i64())
-            .unwrap_or(0)
-            .max(
-                value
-                    .get("cache_read_input_tokens")
-                    .and_then(|v| v.as_i64())
-                    .unwrap_or(0),
-            ) as i32,
+        cached,
         output: token_i32(value, "output_tokens"),
     }
 }
@@ -798,7 +828,13 @@ fn fast_totals_from_payload(value: &CodexFastPayload<'_>) -> CodexTotals {
 }
 
 fn token_i32(value: &Value, key: &str) -> i32 {
-    value.get(key).and_then(|v| v.as_i64()).unwrap_or(0) as i32
+    // Token counts from usage records fit i32, the canonical totals storage type.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "token counts from usage records fit i32"
+    )]
+    let tokens = value.get(key).and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    tokens
 }
 
 fn last_usage_delta(last: &Value) -> (i32, i32, i32) {
@@ -906,6 +942,11 @@ impl JsonlScanner {
         initial_totals: Option<CodexTotals>,
     ) -> std::io::Result<CodexParseResult> {
         let file = File::open(file_path)?;
+        // Session JSONL files are bounded by the cache budget; sizes fit i64.
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "session JSONL file sizes fit i64"
+        )]
         let file_size = file.metadata()?.len() as i64;
 
         let mut reader = BufReader::new(file);
@@ -919,7 +960,13 @@ impl JsonlScanner {
         while let Some((line_bytes, consumed)) =
             read_bounded_jsonl_line(&mut reader, CODEX_JSONL_MAX_LINE_BYTES)?
         {
-            parsed_bytes += consumed as i64;
+            // Per-line byte counts are capped at 256 KiB, far inside i64::MAX.
+            #[allow(
+                clippy::cast_possible_wrap,
+                reason = "per-line consumed bytes are capped at CODEX_JSONL_MAX_LINE_BYTES"
+            )]
+            let consumed_i64 = consumed as i64;
+            parsed_bytes += consumed_i64;
             if line_bytes.is_empty() {
                 continue;
             }
@@ -949,7 +996,13 @@ impl JsonlScanner {
         if offset <= 0 {
             return true;
         }
-        let Ok(file_size) = fs::metadata(file_path).map(|m| m.len() as i64) else {
+        // Session JSONL file sizes fit i64; metadata feeds only boundary probes.
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "session JSONL file sizes fit i64"
+        )]
+        let file_size_i64 = fs::metadata(file_path).map(|m| m.len() as i64);
+        let Ok(file_size) = file_size_i64 else {
             return false;
         };
         if offset >= file_size {
@@ -985,6 +1038,12 @@ impl JsonlScanner {
         let cache_path = Self::cache_path(provider, cache_root);
 
         if crate::core::is_bounded_provider(provider) {
+            // Artifacts are bounded by MAX_LOAD_BYTES (320 MiB), fitting usize on
+            // any supported target even before the budget comparison below.
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "bounded artifacts fit usize on any supported target"
+            )]
             let file_bytes = crate::core::artifact_file_size(&cache_path) as usize;
             if file_bytes > crate::core::CostUsageCacheBudget::MAX_LOAD_BYTES {
                 return CostUsageCache::default();
@@ -1034,7 +1093,8 @@ impl JsonlScanner {
         let Some(parent) = cache_path.parent() else {
             return;
         };
-        let _ = fs::create_dir_all(parent);
+        // Best-effort cache dir creation; a missing dir surfaces as the write error below.
+        let _dir_created = fs::create_dir_all(parent);
 
         if crate::core::is_bounded_provider(provider) {
             let pruned = crate::core::prune_out_of_window_for_budget(
@@ -1061,6 +1121,17 @@ impl JsonlScanner {
             // next refresh can signal catch-up is pending (and spend surfaces can show
             // the last-validated snapshot during the rescan).
             if (!pruned.is_empty() || !trimmed.is_empty()) && cache.previous_report.is_none() {
+                // Session counts are bounded by the cache budget (MAX_FILE_ENTRIES),
+                // far below i32::MAX, and are always non-negative.
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "session count is bounded by MAX_FILE_ENTRIES (25_000)"
+                )]
+                #[allow(
+                    clippy::cast_possible_wrap,
+                    reason = "session count is non-negative and bounded by MAX_FILE_ENTRIES"
+                )]
+                let sessions_count = cache.files.len() as i32;
                 cache.previous_report = Some(crate::core::CachedCostReport {
                     total_cost_usd: 0.0, // cost not tracked in day aggregates
                     input_tokens: cache
@@ -1081,7 +1152,7 @@ impl JsonlScanner {
                         .flat_map(|m| m.values())
                         .map(|v| v[2])
                         .sum(),
-                    sessions_count: cache.files.len() as i32,
+                    sessions_count,
                     updated_at: None,
                     partial: false,
                 });
@@ -1108,7 +1179,7 @@ impl JsonlScanner {
             )
         {
             // Best-effort removal; ignore errors (file may not exist).
-            let _ = fs::remove_file(&cache_path);
+            let _cleared = fs::remove_file(&cache_path);
             return;
         }
 
@@ -1127,10 +1198,11 @@ impl JsonlScanner {
         }
         // `copy` replaces an existing target on Windows; prefer it over rename.
         if fs::copy(&tmp_path, &cache_path).is_err() {
-            let _ = fs::write(&cache_path, json.as_bytes());
+            // Fallback direct write when copy fails; the copy error already surfaced.
+            let _fallback_written = fs::write(&cache_path, json.as_bytes());
         }
         // Best-effort temp cleanup (ignore errors — unique name avoids clashes).
-        let _ = fs::File::create(&tmp_path).and_then(|f| f.set_len(0));
+        let _truncated_tmp = fs::File::create(&tmp_path).and_then(|f| f.set_len(0));
     }
 
     /// Default on-disk cache root: `%LOCALAPPDATA%\CodexBar` (via `dirs::cache_dir`).
@@ -1635,7 +1707,7 @@ world
 line2
 ";
         std::fs::write(&path, content).unwrap();
-        let size = content.len() as i64;
+        let size = i64::try_from(content.len()).unwrap();
         assert!(JsonlScanner::is_line_boundary_offset(&path, size));
         assert!(JsonlScanner::is_line_boundary_offset(&path, size + 100));
     }

--- a/rust/src/core/models_dev_pricing.rs
+++ b/rust/src/core/models_dev_pricing.rs
@@ -704,7 +704,9 @@ impl ModelsDevRefreshCoordinator {
         let state = Arc::clone(&self.state);
         tokio::spawn(async move {
             let result = operation.await;
-            let _ = sender.send(Some(result));
+            // Fire-and-forget result delivery; send fails only if all receivers
+            // dropped, and the watch channel keeps the latest value regardless.
+            let _delivered = sender.send(Some(result));
             state
                 .lock()
                 .await

--- a/rust/src/core/openai_dashboard.rs
+++ b/rust/src/core/openai_dashboard.rs
@@ -2,7 +2,13 @@
 //!
 //! Data structures for OpenAI/Codex dashboard usage breakdown and credits tracking.
 
-#![allow(dead_code)]
+// Serde data model mirroring the OpenAI dashboard payload plus its cache
+// store; several fields and helpers have no consumer yet but must survive
+// (de)serialization round-trips.
+#![allow(
+    dead_code,
+    reason = "dashboard snapshot fields mirror the upstream OpenAI payload; not all are consumed yet"
+)]
 
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
@@ -247,10 +253,14 @@ impl OpenAIDashboardCacheStore {
     pub fn save(cache: &OpenAIDashboardCache) {
         if let Some(url) = Self::cache_path() {
             if let Some(parent) = url.parent() {
-                let _ = fs::create_dir_all(parent);
+                // Cache write is best-effort: failing to create the cache
+                // dir just means no dashboard cache this run.
+                let _created = fs::create_dir_all(parent);
             }
             if let Ok(data) = serde_json::to_string_pretty(cache) {
-                let _ = fs::write(&url, data);
+                // Same best-effort contract: a failed serialize/write leaves
+                // the previous cache intact.
+                let _written = fs::write(&url, data);
             }
         }
     }
@@ -258,7 +268,8 @@ impl OpenAIDashboardCacheStore {
     /// Clear cached data
     pub fn clear() {
         if let Some(url) = Self::cache_path() {
-            let _ = fs::remove_file(url);
+            // Cache invalidation is idempotent; a missing file is fine.
+            let _removed = fs::remove_file(url);
         }
     }
 

--- a/rust/src/core/rate_window.rs
+++ b/rust/src/core/rate_window.rs
@@ -49,7 +49,14 @@ impl RateWindowCadence {
         if seconds <= 0 {
             return Self::Unknown;
         }
-        Self::from_minutes(((seconds + 59) / 60) as u32)
+        // Window seconds are real reset deltas (session..monthly scale); the
+        // rounded-up minute count fits u32 with huge margin.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "window minutes from real reset deltas fit u32"
+        )]
+        let minutes = ((seconds + 59) / 60) as u32;
+        Self::from_minutes(minutes)
     }
 
     /// Human-readable label key for this cadence (matches upstream lane names).
@@ -145,7 +152,13 @@ impl RateWindow {
         let start = subtract_one_calendar_month(resets_at)?;
         let minutes = (resets_at - start).num_minutes();
         if minutes > 0 {
-            Some(minutes as u32)
+            // A real calendar month is 28-31 days (~45k minutes), far below u32::MAX.
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "calendar month minutes fit u32"
+            )]
+            let minutes_u32 = minutes as u32;
+            Some(minutes_u32)
         } else {
             None
         }

--- a/rust/src/core/session_equivalent_forecast.rs
+++ b/rust/src/core/session_equivalent_forecast.rs
@@ -278,6 +278,11 @@ impl SessionEquivalentForecast {
             return None;
         }
         let available_windows_until_reset = remaining_seconds / session_seconds;
+        // Whole-window count by design; the fractional window is dropped.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "window count is a small whole number; fractional part dropped by design"
+        )]
         let windows_until_reset = available_windows_until_reset.floor() as i64;
 
         Some(Self {
@@ -986,10 +991,13 @@ mod tests {
         // remaining weekly 60 / 12 = 5.0
         assert!((forecast.estimated_windows_to_exhaust_weekly - 5.0).abs() < 1e-9);
         assert!(forecast.available_windows_until_reset > 0.0);
-        assert_eq!(
-            forecast.windows_until_reset,
-            forecast.available_windows_until_reset.floor() as i64
-        );
+        // Mirrors the production whole-window truncation.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "assertion mirrors the production whole-window truncation"
+        )]
+        let expected_windows = forecast.available_windows_until_reset.floor() as i64;
+        assert_eq!(forecast.windows_until_reset, expected_windows);
         assert_eq!(forecast.sample_count, 3);
         assert!((forecast.weekly_used_percent - 40.0).abs() < 1e-9);
     }
@@ -1032,10 +1040,13 @@ mod tests {
             SessionEquivalentForecast::make(&session, &weekly, &burn, None, friday, Some(5))
                 .unwrap();
         assert!(work_f.available_windows_until_reset < wall_f.available_windows_until_reset);
-        assert_eq!(
-            work_f.windows_until_reset,
-            work_f.available_windows_until_reset.floor() as i64
-        );
+        // Mirrors the production whole-window truncation.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "assertion mirrors the production whole-window truncation"
+        )]
+        let expected_work_windows = work_f.available_windows_until_reset.floor() as i64;
+        assert_eq!(work_f.windows_until_reset, expected_work_windows);
     }
 
     #[test]

--- a/rust/src/core/session_quota.rs
+++ b/rust/src/core/session_quota.rs
@@ -4,8 +4,14 @@
 //! - Quota becomes depleted (0% remaining)
 //! - Quota is restored (becomes available again)
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
+#![allow(
+    dead_code,
+    reason = "quota types reserved for future session-limit enforcement"
+)]
+#![allow(
+    unused_imports,
+    reason = "imports needed for future session-limit enforcement wiring"
+)]
 
 use crate::core::ProviderId;
 

--- a/rust/src/core/timezone.rs
+++ b/rust/src/core/timezone.rs
@@ -74,9 +74,9 @@ fn pin_globalization_dll() -> bool {
         Ok(module) => module,
         Err(_) => return false,
     };
+    let mut pinned = HMODULE::default();
     // SAFETY: an HMODULE is the module's base address, i.e. an address
     // inside its own mapping, satisfying GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS.
-    let mut pinned = HMODULE::default();
     let pinned_ok = unsafe {
         GetModuleHandleExW(
             GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
@@ -95,7 +95,7 @@ fn pin_globalization_dll() -> bool {
     // SAFETY: `module` is a live module handle owned by this scope and is
     // released at most once, here.
     unsafe {
-        let _ = FreeLibrary(module);
+        let _released = FreeLibrary(module);
     }
     pinned_ok
 }

--- a/rust/src/core/usage_pace.rs
+++ b/rust/src/core/usage_pace.rs
@@ -184,7 +184,16 @@ impl UsagePace {
     /// Format the ETA as a human-readable string
     pub fn format_eta(&self) -> Option<String> {
         let secs = self.eta_seconds?;
+        // Display-only ETA breakdown; whole hours/minutes by design.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "display-only ETA; whole hours/minutes by design"
+        )]
         let hours = (secs / 3600.0) as i64;
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "display-only ETA; whole hours/minutes by design"
+        )]
         let minutes = ((secs % 3600.0) / 60.0) as i64;
 
         if hours > 24 {

--- a/rust/src/core/widget_snapshot.rs
+++ b/rust/src/core/widget_snapshot.rs
@@ -3,7 +3,10 @@
 //! Data export structures for widgets and external integrations.
 //! Provides a serializable snapshot of all provider usage data.
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "widget snapshot types reserved for future UI integration"
+)]
 
 use crate::core::{ProviderId, RateWindow};
 use chrono::{DateTime, Utc};
@@ -257,7 +260,8 @@ impl WidgetSnapshotStore {
     /// Clear widget snapshot
     pub fn clear() {
         if let Some(path) = Self::snapshot_path() {
-            let _ = fs::remove_file(path);
+            // Best-effort cleanup; a missing snapshot file is not an error.
+            let _cleared_snapshot = fs::remove_file(path);
         }
     }
 

--- a/rust/src/cost_scanner.rs
+++ b/rust/src/cost_scanner.rs
@@ -126,17 +126,29 @@ fn is_cancelled(cancel: Option<&AtomicBool>) -> bool {
 const FALLBACK_CLAUDE_MODEL: &str = "claude-sonnet-4-6";
 
 fn unix_now_ms() -> i64 {
-    SystemTime::now()
+    // Duration is clamped to i64::MAX before casting, so the value fits i64.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "clamped to i64::MAX before casting"
+    )]
+    let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis().min(i64::MAX as u128) as i64)
-        .unwrap_or(0)
+        .unwrap_or(0);
+    millis
 }
 
 fn system_time_to_unix_ms(modified: Option<SystemTime>) -> i64 {
-    modified
+    // Duration is clamped to i64::MAX before casting, so the value fits i64.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "clamped to i64::MAX before casting"
+    )]
+    let millis = modified
         .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
         .map(|d| d.as_millis().min(i64::MAX as u128) as i64)
-        .unwrap_or(0)
+        .unwrap_or(0);
+    millis
 }
 
 fn rebuild_cache_days(cache: &mut CostUsageCache) {
@@ -183,6 +195,10 @@ impl ClaudePricing {
         // Standard buckets (input, cache-read, 5-minute cache-write, output),
         // including any long-context tiering, come from the canonical table.
         // Unknown/retired models fall back to Sonnet pricing.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "clamped to i32::MAX before casting"
+        )]
         let clamp = |v: u64| v.min(i32::MAX as u64) as i32;
         let base = CostUsagePricing::claude_cost_usd(
             model,
@@ -212,7 +228,10 @@ impl ClaudePricing {
 }
 
 /// JSONL event structures for Codex
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "JSONL event fields are deserialized for parsing but not all are read"
+)]
 #[derive(Debug, Deserialize)]
 struct CodexEvent {
     #[serde(rename = "type")]
@@ -220,7 +239,10 @@ struct CodexEvent {
     event_msg: Option<CodexEventMsg>,
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "event message fields are deserialized for parsing but not all are read"
+)]
 #[derive(Debug, Deserialize)]
 struct CodexEventMsg {
     #[serde(rename = "type")]
@@ -382,7 +404,9 @@ impl CostScanner {
                 !cache.days.is_empty() && cache.previous_report.is_none();
             let (cost, _) = add_codex_days_map_to_summary(&mut summary, &cache.days, &range);
             summary.total_cost_usd += cost;
-            summary.sessions_count = cache
+            // Session count is a display field; the cache holds far fewer files than u32::MAX.
+            #[allow(clippy::cast_possible_truncation, reason = "cache file counts fit u32")]
+            let sessions_count = cache
                 .files
                 .values()
                 .filter(|usage| {
@@ -391,6 +415,7 @@ impl CostScanner {
                     })
                 })
                 .count() as u32;
+            summary.sessions_count = sessions_count;
 
             // Pi-compatible sessions are outside the Codex JSONL cache.
             // Skip when tests inject sessions roots — avoid scanning the real home tree.
@@ -624,7 +649,12 @@ impl CostScanner {
             Ok(m) => m,
             Err(_) => return,
         };
-        let size = metadata.len() as i64;
+        // File sizes are clamped to i64::MAX before casting.
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "file sizes are clamped to i64::MAX"
+        )]
+        let size = metadata.len().min(i64::MAX as u64) as i64;
         let mtime_ms = system_time_to_unix_ms(metadata.modified().ok());
         let path_key = path.to_string_lossy().to_string();
         let cached = cache.files.get(&path_key).cloned();
@@ -941,7 +971,10 @@ fn add_claude_record_to_daily_costs(
 }
 
 /// Check if any cost usage sources are available
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "utility probe for cost-usage availability; not yet wired into all call sites"
+)]
 pub fn has_cost_usage_sources() -> bool {
     let scanner = CostScanner::new(1);
     scanner
@@ -1268,7 +1301,8 @@ mod tests {
             Some(140)
         );
         assert!(scan_codex_file_cost(&path) > 0.0);
-        let _ = std::fs::remove_file(&path);
+        // Best-effort test cleanup; the file may already be gone.
+        let _removed = std::fs::remove_file(&path);
     }
 
     #[test]
@@ -1421,8 +1455,9 @@ mod tests {
             "each day should hold exactly one record's cost, got {day_one_cost} vs {day_two_cost}"
         );
 
-        let _ = std::fs::remove_file(&file_a);
-        let _ = std::fs::remove_file(&file_b);
+        // Best-effort test cleanup; the files may already be gone.
+        let _removed_a = std::fs::remove_file(&file_a);
+        let _removed_b = std::fs::remove_file(&file_b);
     }
 
     #[test]
@@ -1440,7 +1475,8 @@ mod tests {
         let mut seen = HashSet::new();
         let counted = for_each_claude_usage_record(&path, &cutoff, &mut seen, None, |_| {});
         assert_eq!(counted, 1, "incomplete final JSONL line must be processed");
-        let _ = std::fs::remove_file(&path);
+        // Best-effort test cleanup; the file may already be gone.
+        let _removed = std::fs::remove_file(&path);
     }
 
     fn write_codex_session_fixture(sessions_root: &Path, name: &str, input_tokens: u64) -> PathBuf {

--- a/rust/src/host/command_runner.rs
+++ b/rust/src/host/command_runner.rs
@@ -4,7 +4,10 @@
 //! On Windows, uses standard process spawning with output capture.
 //! Designed for running interactive CLI tools like `codex` and `claude`.
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "command runner types reserved for future host management integration"
+)]
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
@@ -241,17 +244,21 @@ impl CommandRunner {
         if Self::past_deadline(deadline) {
             return;
         }
-        let _ = stdin.write_all(input_text.as_bytes());
-        let _ = stdin.write_all(b"\n");
-        let _ = stdin.flush();
+        // Fire-and-forget seeding: the child may close stdin before we finish
+        // writing, and a write error there must not abort output capture.
+        let _written_input = stdin.write_all(input_text.as_bytes());
+        let _written_newline = stdin.write_all(b"\n");
+        let _flushed_stdin = stdin.flush();
     }
 
     fn finish_child(child: &mut Child) -> Option<i32> {
         match child.try_wait() {
             Ok(Some(status)) => status.code(),
             Ok(None) => {
-                let _ = child.kill();
-                let _ = child.wait();
+                // Teardown after timeout/capture: kill/wait results cannot
+                // change the outcome, already reported separately.
+                let _killed = child.kill();
+                let _reaped = child.wait();
                 None
             }
             Err(_) => None,
@@ -346,7 +353,7 @@ impl CommandRunner {
                     return;
                 }
             }
-            let _ = sender.send(StreamEvent::Closed);
+            let _sent_closed = sender.send(StreamEvent::Closed);
         });
     }
 

--- a/rust/src/host/mod.rs
+++ b/rust/src/host/mod.rs
@@ -4,7 +4,10 @@ pub mod command_runner;
 pub mod session;
 
 // Re-exports for future CLI integration
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "command runner API re-exported for future CLI integration"
+)]
 pub use command_runner::{
     CommandError, CommandOptions, CommandResult, CommandRunner, RollingBuffer,
 };

--- a/rust/src/host/session.rs
+++ b/rust/src/host/session.rs
@@ -12,6 +12,8 @@ pub fn is_ssh_session() -> bool {
 #[cfg(windows)]
 pub fn is_remote_session() -> bool {
     use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_REMOTESESSION};
+    // SAFETY: GetSystemMetrics is a query-only Win32 call taking a constant
+    // metric index; it reads no caller memory and returns a small int.
     unsafe { GetSystemMetrics(SM_REMOTESESSION) != 0 }
 }
 
@@ -68,6 +70,9 @@ pub fn primary_work_area_pixels() -> Option<WorkAreaPixels> {
     };
 
     let mut rect = RECT::default();
+    // SAFETY: SystemParametersInfoW with SPI_GETWORKAREA reads the desktop work
+    // area into the single RECT we pass by mutable pointer; the flags field is
+    // zero and the function performs no other memory access.
     let ok = unsafe {
         SystemParametersInfoW(
             SPI_GETWORKAREA,

--- a/rust/src/locale.rs
+++ b/rust/src/locale.rs
@@ -76,11 +76,23 @@ pub fn tray_tooltip(provider_name: &str, session_percent: f64, weekly_percent: f
     let lang = current_language();
     let session_label = get_text(lang, LocaleKey::TraySessionPercent);
     let weekly_label = get_text(lang, LocaleKey::TrayWeeklyPercent);
+    // Display-only percent tooltip; both values are 0–100 usage percents that
+    // fit i32, and the casts only drop the fractional part for a whole-percent label.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "tooltip percent is bounded to 0–100 and fits i32; only the fractional part is dropped for a whole-percent label"
+    )]
+    let session_pct = session_percent as i32;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "tooltip percent is bounded to 0–100 and fits i32; only the fractional part is dropped for a whole-percent label"
+    )]
+    let weekly_pct = weekly_percent as i32;
     format!(
         "{}: {} | {}",
         provider_name,
-        session_label.replace("{}", &format!("{}", session_percent as i32)),
-        weekly_label.replace("{}", &format!("{}", weekly_percent as i32))
+        session_label.replace("{}", &format!("{session_pct}")),
+        weekly_label.replace("{}", &format!("{weekly_pct}"))
     )
 }
 
@@ -102,11 +114,23 @@ pub fn tray_tooltip_with_status(
         Some(IconOverlayStatus::Incident) => get_text(lang, LocaleKey::TrayStatusIncident),
         Some(IconOverlayStatus::Partial) => get_text(lang, LocaleKey::TrayStatusPartial),
     };
+    // Display-only percent tooltip; both values are 0–100 usage percents that
+    // fit i32, and the casts only drop the fractional part for a whole-percent label.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "tooltip percent is bounded to 0–100 and fits i32; only the fractional part is dropped for a whole-percent label"
+    )]
+    let session_pct = session_percent as i32;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "tooltip percent is bounded to 0–100 and fits i32; only the fractional part is dropped for a whole-percent label"
+    )]
+    let weekly_pct = weekly_percent as i32;
     format!(
         "{}: {} | {}{}",
         provider_name,
-        session_label.replace("{}", &format!("{}", session_percent as i32)),
-        weekly_label.replace("{}", &format!("{}", weekly_percent as i32)),
+        session_label.replace("{}", &format!("{session_pct}")),
+        weekly_label.replace("{}", &format!("{weekly_pct}")),
         status_suffix
     )
 }
@@ -137,7 +161,7 @@ pub fn tray_tooltip_credits(provider_name: &str, credits_percent: f64) -> String
 macro_rules! locale_keys {
     ($($key:ident,)*) => {
         /// Locale keys for app-owned UI strings.
-        #[allow(dead_code)]
+        #[allow(dead_code, reason = "locale keys are generated for all supported UI strings; not all are referenced yet")]
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub enum LocaleKey {
             $($key,)*

--- a/rust/src/login.rs
+++ b/rust/src/login.rs
@@ -2,7 +2,10 @@
 //!
 //! Runs CLI login commands and captures output/URLs
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "login flow types reserved for future session management integration"
+)]
 
 use regex_lite::Regex;
 use std::io::{BufRead, BufReader, Read};
@@ -270,7 +273,8 @@ where
 
         self.auth_link = Some(m.as_str().to_string());
         (self.on_phase)(LoginPhase::WaitingBrowser);
-        let _ = open::that(m.as_str());
+        // Best-effort browser open; the link stays on screen for manual use.
+        let _opened_browser = open::that(m.as_str());
     }
 
     fn into_result(self, outcome: LoginOutcome) -> LoginResult {
@@ -305,7 +309,8 @@ fn stop_child_with_outcome<F>(
 where
     F: Fn(LoginPhase),
 {
-    let _ = child.kill();
+    // Best-effort teardown; the child may already have exited.
+    let _killed = child.kill();
     state.into_result(outcome)
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -12,7 +12,8 @@ fn launch_log_path() -> PathBuf {
 }
 
 fn append_launch_log(log_path: &Path, message: &str) {
-    let _ = std::fs::OpenOptions::new()
+    // Best-effort launch diagnostics; failure to append is not fatal.
+    let _logged = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(log_path)

--- a/rust/src/notifications.rs
+++ b/rust/src/notifications.rs
@@ -2,7 +2,10 @@
 //!
 //! Provides Windows toast notifications for usage alerts
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "notification helpers are reserved for future alert integration"
+)]
 
 use crate::core::ProviderId;
 use crate::core::{RateWindow, UsagePace};
@@ -579,6 +582,12 @@ impl NotificationManager {
 }
 
 fn format_duration(seconds: f64) -> String {
+    // Display-only duration label; the value is ceiled to whole minutes and
+    // clamped to at least 1, so only astronomically large inputs could truncate.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "whole-minutes display label; ceil/max bound the value to realistic durations"
+    )]
     let total_minutes = (seconds / 60.0).ceil().max(1.0) as i64;
     let days = total_minutes / 1440;
     let hours = (total_minutes % 1440) / 60;

--- a/rust/src/pi_session_cost.rs
+++ b/rust/src/pi_session_cost.rs
@@ -275,23 +275,35 @@ fn parse_pi_assistant_entry(value: &Value, target: PiMappedProvider) -> Option<P
         PiMappedProvider::Codex => {
             CostUsagePricing::codex_cost_usd(&model, input, cache_read, output).unwrap_or(0.0)
         }
-        PiMappedProvider::Claude => CostUsagePricing::claude_cost_usd(
-            &model,
-            input as i32,
-            cache_read as i32,
-            cache_create as i32,
-            output as i32,
-        )
-        .unwrap_or_else(|| {
-            CostUsagePricing::claude_cost_usd(
-                "claude-sonnet-4-6",
-                input as i32,
-                cache_read as i32,
-                cache_create as i32,
-                output as i32,
-            )
-            .unwrap_or(0.0)
-        }),
+        PiMappedProvider::Claude => {
+            // Token counts come from API usage records and fit within i32;
+            // the canonical Claude pricing table takes i32 per-token counts.
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "token counts clamped to i32::MAX above"
+            )]
+            #[allow(
+                clippy::cast_possible_wrap,
+                reason = "token counts are non-negative; wrapping is impossible"
+            )]
+            let (input, cache_read, cache_create, output) = (
+                input.min(i32::MAX as u64) as i32,
+                cache_read.min(i32::MAX as u64) as i32,
+                cache_create.min(i32::MAX as u64) as i32,
+                output.min(i32::MAX as u64) as i32,
+            );
+            CostUsagePricing::claude_cost_usd(&model, input, cache_read, cache_create, output)
+                .unwrap_or_else(|| {
+                    CostUsagePricing::claude_cost_usd(
+                        "claude-sonnet-4-6",
+                        input,
+                        cache_read,
+                        cache_create,
+                        output,
+                    )
+                    .unwrap_or(0.0)
+                })
+        }
     };
 
     Some(PiEntry {
@@ -314,6 +326,12 @@ fn num(usage: &Value, keys: &[&str]) -> u64 {
                 return n.max(0) as u64;
             }
             if let Some(n) = v.as_f64() {
+                // Usage counts are whole tokens; dropping any fractional part
+                // matches the previous cast behavior exactly.
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "token counts are whole numbers; fractional part is rounding noise"
+                )]
                 return n.max(0.0) as u64;
             }
             if let Some(s) = v.as_str()

--- a/rust/src/providers/alibaba/parser.rs
+++ b/rust/src/providers/alibaba/parser.rs
@@ -71,10 +71,22 @@ pub(crate) fn parse_response(json: &serde_json::Value) -> Result<UsageSnapshot, 
     let detail = |used_key: &str, total_key: &str| -> Option<String> {
         let used = quota.get(used_key).and_then(|v| v.as_f64())?;
         let total = quota.get(total_key).and_then(|v| v.as_f64())?;
+        // Token counts are whole numbers; the fractional part is rounding
+        // noise from JSON float parsing.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "token counts are whole numbers; fractional part is rounding noise"
+        )]
+        let used_tokens = used as i64;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "token counts are whole numbers; fractional part is rounding noise"
+        )]
+        let total_tokens = total as i64;
         Some(format!(
             "{} / {} tokens",
-            fmt_tokens(used as i64),
-            fmt_tokens(total as i64)
+            fmt_tokens(used_tokens),
+            fmt_tokens(total_tokens)
         ))
     };
 

--- a/rust/src/providers/alibabatokenplan/mod.rs
+++ b/rust/src/providers/alibabatokenplan/mod.rs
@@ -808,9 +808,14 @@ fn parse_f64(value: Option<&Value>) -> Option<f64> {
 
 fn parse_i64(value: Option<&Value>) -> Option<i64> {
     match value? {
-        Value::Number(number) => number
-            .as_i64()
-            .or_else(|| number.as_f64().map(|v| v as i64)),
+        Value::Number(number) => number.as_i64().or_else(|| {
+            // Quota/timestamp JSON floats are whole numbers; the fractional
+            // part is rounding noise from the upstream API.
+            let v = number.as_f64()?;
+            #[expect(clippy::cast_possible_truncation, reason = "quota/timestamp JSON floats are whole numbers; fractional part is rounding noise")]
+            let whole = v as i64;
+            Some(whole)
+        }),
         Value::String(text) => text.trim().replace(',', "").parse().ok(),
         _ => None,
     }
@@ -919,7 +924,14 @@ fn quota_detail_percent(used_percent: f64, total: Option<f64>) -> Option<String>
 
 fn format_quota(value: f64) -> String {
     if (value.round() - value).abs() < f64::EPSILON {
-        format_count(value.round() as i64)
+        // Guarded above: value is within EPSILON of a whole number, so the
+        // fractional part is zero.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "whole-number guard above; fractional part is zero"
+        )]
+        let whole = value.round() as i64;
+        format_count(whole)
     } else {
         let formatted = format!("{value:.2}");
         let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');

--- a/rust/src/providers/antigravity/mod.rs
+++ b/rust/src/providers/antigravity/mod.rs
@@ -589,7 +589,10 @@ struct UserStatusResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UserStatus {
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "field mirrors the Antigravity API user payload; deserialized for round-trip fidelity but not read yet"
+    )]
     email: Option<String>,
     plan_status: Option<PlanStatus>,
     cascade_model_config_data: Option<ModelConfigData>,

--- a/rust/src/providers/augment/mod.rs
+++ b/rust/src/providers/augment/mod.rs
@@ -6,7 +6,10 @@
 mod keepalive;
 
 // Re-exports for future session management
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "keepalive API re-exported for upcoming session-management wiring"
+)]
 pub use keepalive::{AugmentSessionKeepalive, KeepaliveConfig};
 
 use async_trait::async_trait;
@@ -247,7 +250,10 @@ impl AugmentProvider {
         parse_auggie_account_status(&stdout)
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "detection probe kept alongside the fetch path; only fetch_via_cli is wired into fetch() today"
+    )]
     /// Probe CLI for detection
     async fn probe_cli(&self) -> Result<UsageSnapshot, ProviderError> {
         self.fetch_via_cli().await.or_else(|_| {

--- a/rust/src/providers/chutes/mod.rs
+++ b/rust/src/providers/chutes/mod.rs
@@ -256,7 +256,13 @@ fn epoch_to_datetime(value: f64) -> Option<DateTime<Utc>> {
     } else {
         value
     };
-    Utc.timestamp_opt(seconds as i64, 0).single()
+    // Epoch seconds; the sub-second fraction is below timestamp resolution.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "epoch seconds; sub-second fraction below timestamp resolution"
+    )]
+    let whole_seconds = seconds as i64;
+    Utc.timestamp_opt(whole_seconds, 0).single()
 }
 
 fn first_f64(map: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<f64> {
@@ -273,7 +279,14 @@ fn first_str<'a>(map: &'a serde_json::Map<String, Value>, keys: &[&str]) -> Opti
 
 fn format_quota_amount(value: f64) -> String {
     if (value - value.round()).abs() < 0.0001 {
-        format!("{}", value.round() as i64)
+        // Guarded above: value is within 0.0001 of a whole number, so the
+        // fractional part is zero.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "whole-number guard above; fractional part is zero"
+        )]
+        let whole = value.round() as i64;
+        format!("{}", whole)
     } else {
         let mut text = format!("{value:.2}");
         while text.contains('.') && text.ends_with('0') {

--- a/rust/src/providers/claude/admin_api.rs
+++ b/rust/src/providers/claude/admin_api.rs
@@ -139,7 +139,10 @@ struct CostReportResponse {
 #[derive(Debug, Deserialize)]
 struct CostBucket {
     starting_at: String,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "admin API response fields are deserialized for parsing but not all are read"
+    )]
     ending_at: String,
     results: Vec<CostResult>,
 }
@@ -159,7 +162,10 @@ struct MessagesUsageResponse {
 #[derive(Debug, Deserialize)]
 struct MessageBucket {
     starting_at: String,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "admin API response fields are deserialized for parsing but not all are read"
+    )]
     ending_at: String,
     results: Vec<MessageResult>,
 }

--- a/rust/src/providers/claude/mod.rs
+++ b/rust/src/providers/claude/mod.rs
@@ -186,7 +186,8 @@ fn cleanup_probe_session_jsonl(probe_dir: &std::path::Path) {
     for entry in entries.flatten() {
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-            let _ = std::fs::remove_file(&path);
+            // Best-effort cleanup: a locked or missing probe file just stays.
+            let _removed = std::fs::remove_file(&path);
         }
     }
 }

--- a/rust/src/providers/claude/oauth/credentials_store.rs
+++ b/rust/src/providers/claude/oauth/credentials_store.rs
@@ -275,6 +275,11 @@ fn credentials_from_oauth_data(oauth: OAuthData) -> Result<ClaudeOAuthCredential
 
     // Convert milliseconds to DateTime
     let expires_at = oauth.expires_at.map(|millis| {
+        // OAuth expiry is stored in whole seconds; sub-second precision is dropped.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "expiry is tracked at whole-second granularity"
+        )]
         let secs = (millis / 1000.0) as i64;
         DateTime::from_timestamp(secs, 0).unwrap_or_else(Utc::now)
     });

--- a/rust/src/providers/claude/web_api.rs
+++ b/rust/src/providers/claude/web_api.rs
@@ -74,7 +74,10 @@ pub struct ClaudeWebApiFetcher {
 #[derive(Debug, Deserialize)]
 struct Organization {
     uuid: String,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "field mirrors the Claude API org payload; deserialized for round-trip fidelity but not read yet"
+    )]
     name: Option<String>,
 }
 
@@ -848,6 +851,8 @@ mod tests {
     #[test]
     fn resolves_raw_session_key_from_primary_env_var() {
         let _guard = env_lock().lock().expect("env lock");
+        // SAFETY: running under env_lock() so no other test thread touches the
+        // environment concurrently; single-threaded w.r.t. these keys.
         unsafe {
             std::env::remove_var("CLAUDE_AI_SESSION_KEY");
             std::env::remove_var("CLAUDE_WEB_SESSION_KEY");
@@ -859,6 +864,8 @@ mod tests {
 
         assert_eq!(session_key.as_deref(), Some("sk-ant-primary"));
 
+        // SAFETY: same env_lock()-guarded mutation; restoring state after the
+        // assertions, before the lock is released.
         unsafe {
             std::env::remove_var("CLAUDE_AI_SESSION_KEY");
             std::env::remove_var("CLAUDE_WEB_SESSION_KEY");
@@ -868,6 +875,8 @@ mod tests {
     #[test]
     fn resolves_session_key_assignment_from_env_var() {
         let _guard = env_lock().lock().expect("env lock");
+        // SAFETY: env_lock() held for this whole test, so set_var/remove_var
+        // cannot race another thread's environment access.
         unsafe {
             std::env::remove_var("CLAUDE_AI_SESSION_KEY");
             std::env::remove_var("CLAUDE_WEB_SESSION_KEY");
@@ -878,6 +887,7 @@ mod tests {
 
         assert_eq!(session_key.as_deref(), Some("sk-ant-cookie-format"));
 
+        // SAFETY: cleanup while still holding the env_lock() guard.
         unsafe {
             std::env::remove_var("CLAUDE_AI_SESSION_KEY");
             std::env::remove_var("CLAUDE_WEB_SESSION_KEY");

--- a/rust/src/providers/codebuddy/mod.rs
+++ b/rust/src/providers/codebuddy/mod.rs
@@ -452,7 +452,9 @@ fn cookie_fingerprint(cookie: &str) -> String {
     let mut out = String::with_capacity(16);
     for byte in &digest[..8] {
         use std::fmt::Write as _;
-        let _ = write!(out, "{byte:02x}");
+        // Formatting a fingerprint char can only fail on IO errors, which
+        // String writes never raise; discarding is correct.
+        let _written_hex = write!(out, "{byte:02x}");
     }
     out
 }
@@ -662,6 +664,10 @@ fn format_credit_number(value: f64) -> String {
     }
     let rounded = (value * 100.0).round() / 100.0;
     if (rounded - rounded.round()).abs() < 0.001 {
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "value just rounded and verified integral within 0.001, so the i64 cast loses nothing"
+        )]
         format_int_with_commas(rounded.round() as i64)
     } else {
         let s = format!("{rounded:.2}");
@@ -743,6 +749,10 @@ fn epoch_seconds_or_millis(number: f64) -> Option<DateTime<Utc>> {
     } else {
         number
     };
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "epoch seconds far exceed i64 range yield None from from_timestamp anyway; truncation only for absurd inputs that fail validation next"
+    )]
     DateTime::<Utc>::from_timestamp(seconds as i64, 0)
 }
 
@@ -973,6 +983,10 @@ mod tests {
         ));
         // Oversized cache is refused before parsing.
         let big = dir.path().join("big.json");
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "MAX_CACHE_BYTES is 1 MiB; +1 stays far inside usize on any supported target"
+        )]
         std::fs::write(&big, vec![b' '; (MAX_CACHE_BYTES + 1) as usize]).unwrap();
         assert!(read_credits_cache(&big).is_err());
     }
@@ -1267,6 +1281,8 @@ mod tests {
             assert!(matches!(err, ProviderError::Other(_)), "got {err}");
         }
 
+        // SAFETY: this test set CB_CREDITS_FILE at its start under the same
+        // single-test ownership; removing it restores the shared environment.
         unsafe {
             std::env::remove_var("CB_CREDITS_FILE");
         }

--- a/rust/src/providers/commandcode/mod.rs
+++ b/rust/src/providers/commandcode/mod.rs
@@ -177,7 +177,8 @@ impl CommandCodeProvider {
 
         let cookie_header = crate::providers::browser_cookie_header(&["commandcode.ai"])?;
         let result = self.fetch_web(&cookie_header).await?;
-        let _ = CookieHeaderCache::store(ProviderId::CommandCode, &cookie_header, "browser");
+        // Best-effort cookie cache write; a failed write just re-fetches next run.
+        let _stored = CookieHeaderCache::store(ProviderId::CommandCode, &cookie_header, "browser");
         Ok(result)
     }
 }
@@ -405,7 +406,13 @@ fn coerce_reset_at(value: Option<&Value>) -> Option<DateTime<Utc>> {
         } else {
             timestamp
         };
-        return DateTime::from_timestamp(seconds as i64, 0);
+        // Epoch seconds; the sub-second fraction is below timestamp resolution.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "epoch seconds; sub-second fraction below timestamp resolution"
+        )]
+        let whole_seconds = seconds as i64;
+        return DateTime::from_timestamp(whole_seconds, 0);
     }
     value.as_str().and_then(|text| parse_datetime(text.trim()))
 }

--- a/rust/src/providers/copilot/api.rs
+++ b/rust/src/providers/copilot/api.rs
@@ -185,6 +185,10 @@ impl CopilotApi {
 
         let mut credential: *mut CREDENTIALW = std::ptr::null_mut();
 
+        // SAFETY: CredReadW is an FFI call that treats `target_wide` as a
+        // read-only null-terminated wide string (live for the call duration)
+        // and `credential` as an out-parameter; it is initialized to null and
+        // only written on success, and the returned status gates all use of it.
         let result = unsafe {
             CredReadW(
                 PCWSTR(target_wide.as_ptr()),
@@ -198,6 +202,12 @@ impl CopilotApi {
             return None;
         }
 
+        // SAFETY: `credential` is valid here because CredReadW succeeded (the
+        // error case returned above). The CREDENTIALW and its CredentialBlob
+        // buffer are API-allocated and stay live until CredFree; the blob
+        // slice is bounded by CredentialBlobSize. CredFree runs on every path
+        // (early blob-less return and normal path) before `credential` goes out
+        // of scope, and `token` is an owned String, so no borrow outlives it.
         let token = unsafe {
             let cred = &*credential;
             if cred.CredentialBlobSize == 0 || cred.CredentialBlob.is_null() {

--- a/rust/src/providers/cursor/api.rs
+++ b/rust/src/providers/cursor/api.rs
@@ -417,7 +417,14 @@ impl SandUsageStatus {
             .and_then(parse_iso_date);
         let minutes = start.zip(reset).and_then(|(start, reset)| {
             let minutes = (reset - start).num_minutes();
-            (minutes > 0).then_some(minutes as u32)
+            // Guarded by the minutes > 0 check; rate windows are far
+            // shorter than u32::MAX minutes.
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "guarded by the minutes > 0 check; rate windows are far shorter than u32::MAX minutes"
+            )]
+            let minutes_u32 = minutes as u32;
+            (minutes > 0).then_some(minutes_u32)
         });
         Some(NamedRateWindow::new(
             "cursor-grok-bot",

--- a/rust/src/providers/cursor/token_cost.rs
+++ b/rust/src/providers/cursor/token_cost.rs
@@ -140,8 +140,15 @@ pub async fn fetch_token_cost_report(
         if count < PAGE_SIZE {
             break;
         }
+        // Collected events are bounded by MAX_PAGES * PAGE_SIZE, so the
+        // length always fits in i64.
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "event count bounded by MAX_PAGES * PAGE_SIZE"
+        )]
+        let collected = all.len() as i64;
         if let Some(expected) = expected_total
-            && all.len() as i64 >= expected
+            && collected >= expected
         {
             break;
         }
@@ -267,10 +274,24 @@ where
             Ok(v)
         }
         fn visit_u64<E: de::Error>(self, v: u64) -> Result<i64, E> {
-            Ok(v as i64)
+            // Usage-event counts from the Cursor API are small non-negative
+            // integers, far below i64::MAX.
+            #[expect(
+                clippy::cast_possible_wrap,
+                reason = "usage-event counts are small non-negative integers"
+            )]
+            let count = v as i64;
+            Ok(count)
         }
         fn visit_f64<E: de::Error>(self, v: f64) -> Result<i64, E> {
-            Ok(v as i64)
+            // Token counts are whole numbers; the fractional part is rounding
+            // noise from JSON float parsing.
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "token counts are whole numbers; fractional part is rounding noise"
+            )]
+            let count = v as i64;
+            Ok(count)
         }
         fn visit_str<E: de::Error>(self, v: &str) -> Result<i64, E> {
             v.parse().map_err(E::custom)

--- a/rust/src/providers/deepinfra/mod.rs
+++ b/rust/src/providers/deepinfra/mod.rs
@@ -42,7 +42,10 @@ struct UsageResponse {
 
 #[derive(Debug, Deserialize, Clone)]
 struct UsageMonth {
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "field present in the DeepInfra billing payload; kept so serde preserves it"
+    )]
     period: String,
     /// Cost in cents (upstream field name is `total_cost`).
     total_cost: f64,

--- a/rust/src/providers/deepseek/mod.rs
+++ b/rust/src/providers/deepseek/mod.rs
@@ -553,6 +553,12 @@ fn category_label(category: &str) -> String {
 fn format_count(value: f64) -> String {
     let rounded = value.round();
     if (value - rounded).abs() < 0.01 {
+        // Guarded above: value is within 0.01 of a whole number, so the
+        // fractional part is zero.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "whole-number guard above; fractional part is zero"
+        )]
         let raw = (rounded as i64).to_string();
         let mut output = String::new();
         for (idx, ch) in raw.chars().rev().enumerate() {

--- a/rust/src/providers/doubao/mod.rs
+++ b/rust/src/providers/doubao/mod.rs
@@ -595,8 +595,10 @@ fn run_arkcli_usage_plan() -> Result<Vec<u8>, ProviderError> {
         match child.try_wait() {
             Ok(Some(_)) => break,
             Ok(None) if std::time::Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
+                // Best-effort teardown of the timed-out child; the outcome is already
+                // reported as timed out.
+                let _killed = child.kill();
+                let _reaped = child.wait();
                 return Err(ProviderError::Other(
                     "arkcli usage timed out. Check arkcli authentication and try again.".into(),
                 ));
@@ -750,7 +752,14 @@ fn datetime_from_epoch(timestamp: f64) -> Option<DateTime<Utc>> {
     if !timestamp.is_finite() || timestamp <= 0.0 {
         return None;
     }
-    Utc.timestamp_opt(timestamp as i64, 0).single()
+    // Epoch seconds guarded finite and positive; the sub-second fraction is
+    // below timestamp resolution.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "epoch seconds; sub-second fraction below timestamp resolution"
+    )]
+    let whole_seconds = timestamp as i64;
+    Utc.timestamp_opt(whole_seconds, 0).single()
 }
 
 struct SignedVolcengineRequest {

--- a/rust/src/providers/factory/mod.rs
+++ b/rust/src/providers/factory/mod.rs
@@ -150,7 +150,16 @@ impl FactoryBillingWindow {
         let resets_at = self
             .seconds_remaining
             .filter(|s| *s > 0.0 && s.is_finite())
-            .map(|s| Utc::now() + Duration::milliseconds((s * 1000.0) as i64));
+            .map(|s| {
+                // Seconds guarded finite and positive; the sub-millisecond
+                // fraction is below the reset-time display resolution.
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "seconds guarded finite and positive; sub-millisecond fraction dropped"
+                )]
+                let millis = (s * 1000.0) as i64;
+                Utc::now() + Duration::milliseconds(millis)
+            });
         let mut window = RateWindow::with_details(
             self.used_percent.clamp(0.0, 100.0),
             window_minutes,

--- a/rust/src/providers/fireworks/mod.rs
+++ b/rust/src/providers/fireworks/mod.rs
@@ -36,7 +36,10 @@ struct BillingSummaryResponse {
     #[serde(default)]
     line_items: Vec<LineItem>,
     #[serde(default)]
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "field present in the Fireworks billing payload; kept so serde accepts and preserves it"
+    )]
     usage_buckets: Vec<UsageBucket>,
 }
 
@@ -44,7 +47,10 @@ struct BillingSummaryResponse {
 #[serde(rename_all = "camelCase")]
 struct LineItem {
     #[serde(default)]
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "deserialized for payload fidelity; cost math uses only total_cost"
+    )]
     category: Option<String>,
     #[serde(default)]
     total_cost: Option<Money>,
@@ -63,7 +69,10 @@ struct Money {
 #[serde(rename_all = "camelCase")]
 struct UsageBucket {
     #[serde(default)]
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "timestamp field of the upstream bucket schema; unused locally but required by the wire format"
+    )]
     bucket_start_time: Option<String>,
 }
 

--- a/rust/src/providers/grok/mod.rs
+++ b/rust/src/providers/grok/mod.rs
@@ -162,7 +162,9 @@ impl GrokProvider {
 
         let cookie_header = crate::providers::browser_cookie_header(&["grok.com"])?;
         let result = self.fetch_with_cookie(&cookie_header).await?;
-        let _ = CookieHeaderCache::store(ProviderId::Grok, &cookie_header, "browser");
+        // Best-effort cache write: failing to persist the cookie only costs a
+        // re-read from the browser on the next fetch.
+        let _cached = CookieHeaderCache::store(ProviderId::Grok, &cookie_header, "browser");
         Ok(result)
     }
 
@@ -534,9 +536,15 @@ fn parse_grpc_web_response(data: &[u8]) -> Result<GrokBillingSnapshot, ProviderE
         .varints
         .iter()
         .filter_map(|field| {
+            // Varint timestamps are Unix seconds inside the range checked below.
+            #[allow(
+                clippy::cast_possible_wrap,
+                reason = "varint timestamps are bounded to the Unix-seconds range checked below"
+            )]
+            let seconds = field.value as i64;
             (1_700_000_000..=2_100_000_000)
                 .contains(&field.value)
-                .then(|| Utc.timestamp_opt(field.value as i64, 0).single())
+                .then(|| Utc.timestamp_opt(seconds, 0).single())
                 .flatten()
         })
         .filter(|dt| *dt > Utc::now())
@@ -639,7 +647,13 @@ impl ProtoScan {
     ) -> Option<usize> {
         let (len, next) = read_varint(data, i)?;
         let start = next;
-        let end = start.saturating_add(len as usize);
+        // Varint field lengths are bounded by the containing message buffer.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "varint field lengths are bounded by the containing message buffer"
+        )]
+        let len_usize = len as usize;
+        let end = start.saturating_add(len_usize);
         if end <= data.len() {
             self.scan_message(&data[start..end], path, depth + 1);
             Some(end)

--- a/rust/src/providers/infini.rs
+++ b/rust/src/providers/infini.rs
@@ -159,7 +159,10 @@ impl InfiniClient {
 }
 
 #[cfg(test)]
-#[allow(clippy::items_after_test_module)]
+#[allow(
+    clippy::items_after_test_module,
+    reason = "test module is defined before helper functions that support it"
+)]
 mod tests {
     use super::*;
 

--- a/rust/src/providers/jetbrains/mod.rs
+++ b/rust/src/providers/jetbrains/mod.rs
@@ -3,7 +3,10 @@
 //! Fetches usage data from JetBrains IDE local configuration
 //! JetBrains AI Assistant stores quota info in XML configuration files
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "JetBrains provider types reserved for future integration"
+)]
 
 use async_trait::async_trait;
 use std::path::PathBuf;

--- a/rust/src/providers/kimi/code_api.rs
+++ b/rust/src/providers/kimi/code_api.rs
@@ -28,7 +28,10 @@ struct KimiCodeCredentialFile {
     #[serde(default, alias = "accessToken")]
     access_token: String,
     #[serde(default)]
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "field exists in the CLI credential file; deserialized to preserve the schema but never read locally"
+    )]
     refresh_token: Option<String>,
     #[serde(default, alias = "expiresAt")]
     expires_at: Option<serde_json::Value>,
@@ -305,6 +308,8 @@ mod tests {
                 .any(|(k, v)| *k == "X-Msh-Platform" && v == KIMI_CODE_CLI_PLATFORM)
         );
 
+        // SAFETY: this test owns KIMI_CODE_HOME_ENV (set at its start under
+        // env_lock); removing it here restores the shared environment.
         unsafe {
             std::env::remove_var(KIMI_CODE_HOME_ENV);
         }
@@ -330,6 +335,8 @@ mod tests {
         let now = 1_800_000_000.0_f64;
         let home = write_temp_kimi_code_home("oauth-token", Some(json!(now + 3600.0)));
 
+        // SAFETY: env_lock() guard held for the whole test, so these
+        // set_var calls cannot race another thread's environment access.
         unsafe {
             std::env::set_var(KIMI_CODE_HOME_ENV, home.path());
             std::env::set_var(KIMI_CODE_BASE_URL_ENV, "https://proxy.example.com/kimi");
@@ -337,12 +344,15 @@ mod tests {
         assert!(has_code_endpoint_override());
         assert!(kimi_code_cli_access_token(now).is_none());
 
+        // SAFETY: still under the same env_lock() guard; swapping which
+        // override keys are present between assertions.
         unsafe {
             std::env::remove_var(KIMI_CODE_BASE_URL_ENV);
             std::env::set_var(KIMI_CODE_OAUTH_HOST_ENV, "https://oauth.example.com");
         }
         assert!(kimi_code_cli_access_token(now).is_none());
 
+        // SAFETY: final cleanup while the env_lock() guard is still alive.
         unsafe {
             std::env::remove_var(KIMI_CODE_OAUTH_HOST_ENV);
             std::env::remove_var(KIMI_CODE_HOME_ENV);

--- a/rust/src/providers/kimi/mod.rs
+++ b/rust/src/providers/kimi/mod.rs
@@ -469,7 +469,13 @@ fn ascii_header_value(raw: &str) -> String {
 
 fn format_usage_amount(value: f64) -> String {
     if (value.fract()).abs() < f64::EPSILON {
-        format!("{}", value as i64)
+        // Value verified integral to f64 precision; the i64 cast loses nothing.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "guarded by the fract() == 0 check above"
+        )]
+        let integral = value as i64;
+        format!("{integral}")
     } else {
         format!("{value:.2}")
     }

--- a/rust/src/providers/kiro/mod.rs
+++ b/rust/src/providers/kiro/mod.rs
@@ -7,7 +7,10 @@ mod usage_limits;
 pub mod version;
 
 // Re-exports for version compatibility checking
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "imports needed for future Kiro provider wiring"
+)]
 pub use version::{
     KiroVersion, detect_version, find_kiro_cli, get_version, is_compatible, is_installed,
 };

--- a/rust/src/providers/kiro/usage_limits.rs
+++ b/rust/src/providers/kiro/usage_limits.rs
@@ -305,7 +305,13 @@ fn reset_date(value: f64) -> Option<DateTime<Utc>> {
     if !value.is_finite() || !(1_000_000_000.0..=4_102_444_800.0).contains(&value) {
         return None;
     }
-    Utc.timestamp_opt(value as i64, 0).single()
+    // Range-checked above to valid Unix seconds.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "value is range-checked above to valid Unix seconds"
+    )]
+    let seconds = value as i64;
+    Utc.timestamp_opt(seconds, 0).single()
 }
 
 #[cfg(test)]

--- a/rust/src/providers/kiro/version.rs
+++ b/rust/src/providers/kiro/version.rs
@@ -392,7 +392,8 @@ mod tests {
             "kiro.exe is the Electron GUI app on Windows; running it as a CLI spawns the IDE"
         );
 
-        let _ = std::fs::remove_file(cli_path);
-        let _ = std::fs::remove_file(gui_path);
+        // Best-effort cleanup of temp binaries; leftover files are harmless.
+        let _removed_cli = std::fs::remove_file(cli_path);
+        let _removed_gui = std::fs::remove_file(gui_path);
     }
 }

--- a/rust/src/providers/longcat/mod.rs
+++ b/rust/src/providers/longcat/mod.rs
@@ -256,7 +256,14 @@ fn build_snapshot(
 
     let primary = if total > 0.0 {
         let mut w = RateWindow::new(((used / total) * 100.0).clamp(0.0, 100.0));
-        w.reset_description = Some(format!("{}/{}", used as i64, total as i64));
+        // Display-only rendering of token counts; values beyond i64 are
+        // unrealistic quota sizes and would only affect this label.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "display-only quota label; token counts beyond i64 are unrealistic"
+        )]
+        let desc = format!("{}/{}", used as i64, total as i64);
+        w.reset_description = Some(desc);
         w
     } else {
         RateWindow::informational("No token quota")
@@ -280,10 +287,13 @@ fn build_snapshot(
             let mut secondary =
                 RateWindow::new(((used_fuel / total_fuel) * 100.0).clamp(0.0, 100.0));
             secondary.resets_at = expiry;
-            secondary.reset_description = Some(format!(
-                "Fuel pack: {}/{}",
-                remaining_fuel as i64, total_fuel as i64
-            ));
+            // Same display-only label for fuel-pack counts.
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "display-only fuel label; fuel counts beyond i64 are unrealistic"
+            )]
+            let fuel_desc = format!("Fuel pack: {}/{}", remaining_fuel as i64, total_fuel as i64);
+            secondary.reset_description = Some(fuel_desc);
             snap = snap.with_secondary(secondary);
         }
     }

--- a/rust/src/providers/minimax/coding_plan.rs
+++ b/rust/src/providers/minimax/coding_plan.rs
@@ -101,6 +101,10 @@ fn window_minutes(start: Option<DateTime<Utc>>, end: Option<DateTime<Utc>>) -> O
     let (start, end) = (start?, end?);
     let minutes = (end - start).num_minutes();
     if minutes > 0 {
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "guarded by `minutes > 0`; a window longer than ~8 million years is impossible"
+        )]
         Some(minutes as u32)
     } else {
         None
@@ -127,6 +131,12 @@ fn resets_at(
     } else {
         remains as f64
     };
+    // Display/rounding conversion of an epoch value; sub-second precision is
+    // intentionally dropped.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "epoch seconds truncated to whole seconds by design"
+    )]
     Some(now + Duration::seconds(seconds as i64))
 }
 
@@ -215,7 +225,12 @@ fn window_type_from_duration(start: Option<DateTime<Utc>>, end: Option<DateTime<
     } else if (4.0..=6.0).contains(&duration_hours) {
         "5 hours".to_string()
     } else if (1.0..23.0).contains(&duration_hours) {
-        format!("{} hours", duration_hours as i64)
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "label only; duration already filtered into the 1..23 hours bucket"
+        )]
+        let label = format!("{} hours", duration_hours as i64);
+        label
     } else {
         "Custom".to_string()
     }
@@ -287,7 +302,10 @@ fn reset_description(
 /// Build a `RemainsRow` from the raw interval/weekly fields (upstream
 /// `makeServiceUsage`). Returns `None` when the row is a placeholder that
 /// should be skipped.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "signature mirrors the flat upstream makeServiceUsage payload fields one-to-one"
+)]
 fn make_remains_row(
     service_type: &str,
     window_type_override: Option<&str>,

--- a/rust/src/providers/minimax/coding_plan_html.rs
+++ b/rust/src/providers/minimax/coding_plan_html.rs
@@ -168,18 +168,25 @@ fn parse_available_usage(text: &str) -> Option<(i64, u32)> {
 
 /// Convert a duration + unit to minutes (upstream `minutes(from:unit:)`).
 fn minutes_from_duration(value: f64, unit: &str) -> u32 {
+    // Window lengths come from the provider's own dashboard text and are
+    // minutes-scale; u32 overflow would need a >8000-year window.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "dashboard window durations are minutes-scale; u32 is far beyond any real window"
+    )]
+    let to_minutes = |scaled: f64| -> u32 { scaled.round() as u32 };
     let lower = unit.to_lowercase();
     if lower.starts_with('d') {
-        return (value * 24.0 * 60.0).round() as u32;
+        return to_minutes(value * 24.0 * 60.0);
     }
     if lower.starts_with('h') {
-        return (value * 60.0).round() as u32;
+        return to_minutes(value * 60.0);
     }
     if lower.starts_with('m') {
-        return value.round() as u32;
+        return to_minutes(value);
     }
     if lower.starts_with('s') {
-        return ((value / 60.0).round() as u32).max(1);
+        return to_minutes(value / 60.0).max(1);
     }
     0
 }
@@ -211,7 +218,14 @@ fn parse_resets_at_from_text(text: &str, now: DateTime<Utc>) -> Option<DateTime<
     {
         let unit = &caps[1];
         let seconds = seconds_from_duration(value, unit);
-        return Some(now + Duration::seconds(seconds as i64));
+        // "Resets in N <unit>" values are parsed from dashboard text and
+        // rounded to whole seconds.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "reset countdown truncated to whole seconds by design"
+        )]
+        let total_seconds = seconds as i64;
+        return Some(now + Duration::seconds(total_seconds));
     }
 
     // "Resets at HH:mm (zone hint)"

--- a/rust/src/providers/minimax/local_storage.rs
+++ b/rust/src/providers/minimax/local_storage.rs
@@ -60,7 +60,10 @@ impl MiniMaxLocalStorageImporter {
 
     /// Get paths to browser localStorage databases
     fn get_browser_paths() -> Vec<(String, PathBuf)> {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "mutability needed for conditional initialization that the compiler cannot prove"
+        )]
         let mut paths = Vec::new();
 
         #[cfg(target_os = "windows")]

--- a/rust/src/providers/minimax/mod.rs
+++ b/rust/src/providers/minimax/mod.rs
@@ -9,7 +9,10 @@ mod local_storage;
 mod token_plan;
 
 // Re-exports for local storage import
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "imports needed for future MiniMax provider wiring"
+)]
 pub use local_storage::{ImportError, MiniMaxLocalStorageImporter, MiniMaxSession};
 
 use async_trait::async_trait;

--- a/rust/src/providers/mod.rs
+++ b/rust/src/providers/mod.rs
@@ -1,6 +1,9 @@
 //! Provider implementations
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "provider traits and helpers are shared across modules; not all are consumed in every build"
+)]
 
 pub mod abacus;
 pub mod aiand;
@@ -276,7 +279,13 @@ pub(crate) fn extract_renewal(text: &str) -> Option<chrono::DateTime<chrono::Utc
         } else {
             number
         };
-        return chrono::DateTime::<chrono::Utc>::from_timestamp(seconds as i64, 0);
+        // Epoch seconds; the sub-second fraction is below timestamp resolution.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "epoch seconds; sub-second fraction below timestamp resolution"
+        )]
+        let whole_seconds = seconds as i64;
+        return chrono::DateTime::<chrono::Utc>::from_timestamp(whole_seconds, 0);
     }
     chrono::DateTime::parse_from_rfc3339(raw)
         .ok()

--- a/rust/src/providers/neuralwatt/mod.rs
+++ b/rust/src/providers/neuralwatt/mod.rs
@@ -52,7 +52,10 @@ struct Subscription {
     kwh_included: Option<f64>,
     kwh_used: Option<f64>,
     kwh_remaining: Option<f64>,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "field mirrors the NeuralWatt API payload; deserialized for round-trip fidelity but not read yet"
+    )]
     in_overage: Option<bool>,
 }
 
@@ -217,7 +220,9 @@ fn subscription_window(sub: &Subscription) -> Option<RateWindow> {
         parse_iso(sub.current_period_end.as_deref()),
     ) {
         if end > start {
-            let mins = ((end - start).num_minutes()).max(1) as u32;
+            // Billing-window minutes are clamped to u32 range, so the cast cannot truncate.
+            #[expect(clippy::cast_possible_truncation, reason = "clamped to u32 range")]
+            let mins = ((end - start).num_minutes()).clamp(1, u32::MAX as i64) as u32;
             w.window_minutes = Some(mins);
         }
         w.resets_at = Some(end);

--- a/rust/src/providers/notion/mod.rs
+++ b/rust/src/providers/notion/mod.rs
@@ -566,7 +566,13 @@ fn rolling_reset(seconds: Option<f64>, now: DateTime<Utc>) -> Option<DateTime<Ut
     if seconds < 0.0 {
         return None;
     }
-    Some(now + chrono::Duration::milliseconds((seconds * 1000.0) as i64))
+    // The window offset is whole seconds from the API, far below i64::MAX.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "API window offset is far below i64::MAX"
+    )]
+    let millis = (seconds * 1000.0) as i64;
+    Some(now + chrono::Duration::milliseconds(millis))
 }
 
 fn date_from_milliseconds(raw: Option<f64>) -> Option<DateTime<Utc>> {
@@ -574,7 +580,14 @@ fn date_from_milliseconds(raw: Option<f64>) -> Option<DateTime<Utc>> {
     if raw <= 0.0 {
         return None;
     }
+    // Epoch milliseconds from the API; realistic dates are far below i64::MAX.
+    #[expect(clippy::cast_possible_truncation, reason = "epoch ms dates fit i64")]
     let secs = (raw / 1000.0).floor() as i64;
+    // The fractional second is in [0, 1), so nanoseconds stay below u32::MAX.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "fractional second keeps nanoseconds < u32::MAX"
+    )]
     let nsecs = (((raw / 1000.0) - secs as f64) * 1_000_000_000.0) as u32;
     Utc.timestamp_opt(secs, nsecs).single()
 }

--- a/rust/src/providers/ollama/cookies.rs
+++ b/rust/src/providers/ollama/cookies.rs
@@ -113,7 +113,8 @@ pub(super) fn cache_validated_session_cookie(source: &OllamaCookieSource) {
             OllamaCookieSource::Manual(_) => "validated",
             OllamaCookieSource::Browser(_) => "browser",
         };
-        let _ = CookieHeaderCache::store(ProviderId::Ollama, &header, label);
+        // Cache store is best-effort: a failed write just means the next fetch re-validates.
+        let _stored = CookieHeaderCache::store(ProviderId::Ollama, &header, label);
     }
 }
 

--- a/rust/src/providers/openai/mod.rs
+++ b/rust/src/providers/openai/mod.rs
@@ -6,11 +6,17 @@ pub mod friendly_errors;
 pub mod scraper;
 
 // Re-exports for error handling and dashboard scraping
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "imports needed for future OpenAI provider wiring"
+)]
 pub use friendly_errors::{
     OpenAIWebErrorKind, extract_auth_status, extract_signed_in_email, friendly_error, is_logged_out,
 };
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "imports needed for future OpenAI provider wiring"
+)]
 pub use scraper::{
     CreditsHistoryEntry, OPENAI_DASHBOARD_SCRAPE_SCRIPT, OpenAIDashboardData, UsageBreakdown,
     parse_dashboard_json,

--- a/rust/src/providers/openaiapi/mod.rs
+++ b/rust/src/providers/openaiapi/mod.rs
@@ -45,7 +45,10 @@ struct CostsResponse {
 #[derive(Debug, Deserialize)]
 struct CostBucket {
     start_time: i64,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "field present in the OpenAI API billing payload; kept so serde preserves it"
+    )]
     end_time: i64,
     results: Vec<CostResult>,
 }
@@ -69,7 +72,10 @@ struct CompletionsUsageResponse {
 #[derive(Debug, Deserialize)]
 struct CompletionsUsageBucket {
     start_time: i64,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "field present in the OpenAI API billing payload; kept so serde preserves it"
+    )]
     end_time: i64,
     results: Vec<CompletionsUsageResult>,
 }
@@ -547,7 +553,10 @@ fn resolve_api_key(
     )))
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "OpenAI API helper reserved for future dashboard integration"
+)]
 fn _assert_datetime_send(_: DateTime<Utc>) {}
 
 #[cfg(test)]

--- a/rust/src/providers/opencode/mod.rs
+++ b/rust/src/providers/opencode/mod.rs
@@ -7,7 +7,10 @@ pub mod billing;
 pub mod scraper;
 
 // Re-exports for advanced scraping
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "imports needed for future OpenCode provider wiring"
+)]
 pub use scraper::{OpenCodeError, OpenCodeUsageFetcher, OpenCodeUsageSnapshot};
 
 use async_trait::async_trait;
@@ -497,6 +500,10 @@ impl OpenCodeProvider {
         } else {
             number
         };
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "timestamps are normalized to whole seconds (ms input divided by 1000) before the cast"
+        )]
         DateTime::<Utc>::from_timestamp(seconds as i64, 0)
     }
 
@@ -514,6 +521,10 @@ impl OpenCodeProvider {
         let percent = super::extract_number(&percent_pattern, text)
             .ok_or_else(|| ProviderError::Parse(format!("Missing {} percent", prefix)))?;
 
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "resetInSec values are whole-second counts scraped as integral numbers"
+        )]
         let reset = super::extract_number(&reset_pattern, text)
             .map(|n| n as i64)
             .unwrap_or(0);

--- a/rust/src/providers/opencode/scraper.rs
+++ b/rust/src/providers/opencode/scraper.rs
@@ -550,6 +550,10 @@ impl OpenCodeUsageFetcher {
         } else {
             number
         };
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "timestamps are normalized to whole seconds (ms input divided by 1000) before the cast"
+        )]
         DateTime::<Utc>::from_timestamp(seconds as i64, 0)
     }
 

--- a/rust/src/providers/opencodego/local.rs
+++ b/rust/src/providers/opencodego/local.rs
@@ -229,7 +229,12 @@ fn read_rows(db_path: &Path) -> Result<Vec<UsageRow>, ProviderError> {
             Ok(UsageRow {
                 created_ms: row.get::<_, i64>(0)?,
                 cost: row.get::<_, f64>(1)?,
-                request_count: row.get::<_, i64>(2).map(|n| n.max(1) as u32).unwrap_or(1),
+                // Request counts from the DB are clamped to ≥1 and realistically
+                // far below u32::MAX; try_from guards the pathological case.
+                request_count: row
+                    .get::<_, i64>(2)
+                    .map(|n| u32::try_from(n.max(1)).unwrap_or(u32::MAX))
+                    .unwrap_or(1),
                 model: row.get::<_, String>(3).unwrap_or_default(),
             })
         })
@@ -715,12 +720,14 @@ mod tests {
                 .map(|d| d.as_nanos())
                 .unwrap_or(0)
         ));
-        let _ = std::fs::create_dir_all(&dir);
+        // Best-effort fixture setup; a failure surfaces as the fetch error below.
+        let _created = std::fs::create_dir_all(&dir);
         let auth = dir.join("auth.json");
         let db = dir.join("opencode.db");
         let err = fetch_from_paths(&auth, &db, Utc::now()).unwrap_err();
         assert!(matches!(err, ProviderError::NotInstalled(_)));
-        let _ = std::fs::remove_dir_all(&dir);
+        // Best-effort teardown; temp dir may already be gone.
+        let _removed_dir = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -745,7 +752,8 @@ mod tests {
 
         // auth present so empty-rows path is not used; auth not required when rows exist
         let auth = db.with_extension("auth.json");
-        let _ = std::fs::write(&auth, r#"{"opencode-go":{"key":"test-key"}}"#);
+        // Fixture write; failure would make fetch_from_paths return an error.
+        let _written = std::fs::write(&auth, r#"{"opencode-go":{"key":"test-key"}}"#);
 
         let snap = fetch_from_paths(&auth, &db, now).unwrap();
         assert!((snap.rolling_usage_percent - 50.0).abs() < 0.05, "{snap:?}");
@@ -754,8 +762,9 @@ mod tests {
         // session 6 + week 9 + month 15 = 30 → 50%
         assert!((snap.monthly_usage_percent - 50.0).abs() < 0.05, "{snap:?}");
 
-        let _ = std::fs::remove_file(&db);
-        let _ = std::fs::remove_file(&auth);
+        // Best-effort teardown; leftover temp files are harmless.
+        let _removed_db = std::fs::remove_file(&db);
+        let _removed_auth = std::fs::remove_file(&auth);
     }
 
     #[test]
@@ -794,14 +803,16 @@ mod tests {
         drop(conn);
 
         let auth = db.with_extension("auth.json");
-        let _ = std::fs::write(&auth, r#"{"opencode-go":{"key":"k"}}"#);
+        // Fixture write; a failure would surface in fetch_from_paths.
+        let _written_auth = std::fs::write(&auth, r#"{"opencode-go":{"key":"k"}}"#);
         let snap = fetch_from_paths(&auth, &db, now).unwrap();
         assert!(
             (snap.rolling_usage_percent - 25.0).abs() < 0.05,
             "expected step-finish cost only, got {snap:?}"
         );
-        let _ = std::fs::remove_file(&db);
-        let _ = std::fs::remove_file(&auth);
+        // Best-effort teardown; leftover temp files are harmless.
+        let _removed_db = std::fs::remove_file(&db);
+        let _removed_auth = std::fs::remove_file(&auth);
     }
 
     #[test]
@@ -855,7 +866,8 @@ mod tests {
             )
             .unwrap();
             // Truncate empties WAL content before close; journal_mode stays WAL.
-            let _ = conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()));
+            // Best-effort checkpoint; a truncated WAL is just tidier.
+            let _checkpointed = conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()));
             drop(conn);
         }
 
@@ -866,7 +878,8 @@ mod tests {
         for side in [&wal, &shm] {
             if side.exists() {
                 let parked = side.with_extension("parked");
-                let _ = std::fs::rename(side, parked);
+                // Best-effort parking; a locked sidecar just stays put.
+                let _parked = std::fs::rename(side, parked);
             }
         }
         assert!(!wal.exists(), "precondition: no -wal");

--- a/rust/src/providers/opencodego/mod.rs
+++ b/rust/src/providers/opencodego/mod.rs
@@ -216,6 +216,10 @@ impl OpenCodeGoProvider {
 
             let percent = super::extract_number(&percent_pattern, text);
             if let Some(p) = percent {
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "resetInSec values are whole-second counts scraped as integral numbers"
+                )]
                 let reset = super::extract_number(&reset_pattern, text)
                     .map(|n| n as i64)
                     .unwrap_or(0);
@@ -237,6 +241,10 @@ impl OpenCodeGoProvider {
                 super::extract_number(&limit_pattern, text),
             ) && limit > 0.0
             {
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    reason = "resetInSec values are whole-second counts scraped as integral numbers"
+                )]
                 let reset = super::extract_number(&reset_pattern, text)
                     .map(|n| n as i64)
                     .unwrap_or(0);

--- a/rust/src/providers/perplexity/mod.rs
+++ b/rust/src/providers/perplexity/mod.rs
@@ -71,7 +71,13 @@ impl PerplexityProvider {
     }
 
     fn ts_to_datetime(ts: f64) -> Option<DateTime<Utc>> {
-        Utc.timestamp_opt(ts as i64, 0).single()
+        // Grant expiry epochs are whole-second unix timestamps, far below i64::MAX.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "whole-second epoch fits i64"
+        )]
+        let secs = ts as i64;
+        Utc.timestamp_opt(secs, 0).single()
     }
 
     fn parse_response(resp: CreditsResponse) -> Result<UsageSnapshot, ProviderError> {

--- a/rust/src/providers/qoder/mod.rs
+++ b/rust/src/providers/qoder/mod.rs
@@ -398,7 +398,13 @@ fn parse_datetime(raw: String) -> Option<DateTime<Utc>> {
         } else {
             number
         };
-        return DateTime::<Utc>::from_timestamp(seconds as i64, 0);
+        // Epoch seconds (or ms normalized above); real dates are far below i64::MAX.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "normalized epoch seconds fit i64"
+        )]
+        let secs = seconds as i64;
+        return DateTime::<Utc>::from_timestamp(secs, 0);
     }
     DateTime::parse_from_rfc3339(&raw)
         .ok()

--- a/rust/src/providers/qwencloud/mod.rs
+++ b/rust/src/providers/qwencloud/mod.rs
@@ -1067,9 +1067,14 @@ fn parse_f64(value: Option<&Value>) -> Option<f64> {
 
 fn parse_i64(value: Option<&Value>) -> Option<i64> {
     match value? {
-        Value::Number(number) => number
-            .as_i64()
-            .or_else(|| number.as_f64().map(|v| v as i64)),
+        Value::Number(number) => number.as_i64().or_else(|| {
+            number.as_f64().map(|v| {
+                // Quota numbers are small integers; any fractional part is discarded deliberately.
+                #[expect(clippy::cast_possible_truncation, reason = "quota counts fit i64")]
+                let v = v as i64;
+                v
+            })
+        }),
         Value::String(text) => text.trim().replace(',', "").parse().ok(),
         _ => None,
     }
@@ -1178,7 +1183,13 @@ fn quota_detail_percent(used_percent: f64, total: Option<f64>) -> Option<String>
 
 fn format_quota(value: f64) -> String {
     if (value.round() - value).abs() < f64::EPSILON {
-        format_count(value.round() as i64)
+        // Whole-number quotas are far below i64::MAX; rounding is intentional.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "whole-number quota fits i64"
+        )]
+        let rounded = value.round() as i64;
+        format_count(rounded)
     } else {
         let formatted = format!("{value:.2}");
         let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');

--- a/rust/src/providers/t3chat.rs
+++ b/rust/src/providers/t3chat.rs
@@ -335,7 +335,13 @@ fn date_from_epoch(value: Option<f64>) -> Option<DateTime<Utc>> {
     } else {
         raw
     };
-    Utc.timestamp_opt(seconds as i64, 0).single()
+    // Epoch seconds (normalized above) are far below i64::MAX for real dates.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "normalized epoch seconds fit i64"
+    )]
+    let secs = seconds as i64;
+    Utc.timestamp_opt(secs, 0).single()
 }
 
 fn plan_name(customer: &T3CustomerData) -> Option<String> {

--- a/rust/src/providers/vertexai/mod.rs
+++ b/rust/src/providers/vertexai/mod.rs
@@ -6,7 +6,10 @@
 mod token_refresher;
 
 // Re-exports for OAuth token refresh
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "imports needed for future VertexAI provider wiring"
+)]
 pub use token_refresher::{RefreshError, VertexAIOAuthCredentials, VertexAITokenRefresher};
 
 use async_trait::async_trait;

--- a/rust/src/providers/vertexai/token_refresher.rs
+++ b/rust/src/providers/vertexai/token_refresher.rs
@@ -147,7 +147,13 @@ impl VertexAITokenRefresher {
             .and_then(|v| v.as_f64())
             .unwrap_or(3600.0);
 
-        let new_expiry_date = Utc::now() + chrono::Duration::seconds(expires_in as i64);
+        // OAuth expires_in is a whole-second lifetime (default 3600), far below i64::MAX.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "token lifetime seconds fit i64"
+        )]
+        let expiry_seconds = expires_in as i64;
+        let new_expiry_date = Utc::now() + chrono::Duration::seconds(expiry_seconds);
 
         // Extract email from new ID token if present
         let email = json

--- a/rust/src/providers/wayfinder.rs
+++ b/rust/src/providers/wayfinder.rs
@@ -242,7 +242,8 @@ impl Provider for WayfinderProvider {
             Self::fetch_json(&client, &endpoint_url(&base, MODELS_PATH)?).await?;
         let savings: SavingsResponse =
             Self::fetch_json(&client, &endpoint_url(&base, SAVINGS_PATH)?).await?;
-        let _ = Self::fetch_metrics(&client, &endpoint_url(&base, METRICS_PATH)?).await;
+        // Metrics are best-effort enrichment; a failure must not fail the usage fetch.
+        let _metrics = Self::fetch_metrics(&client, &endpoint_url(&base, METRICS_PATH)?).await;
 
         let wayfinder_usage = WayfinderUsageSnapshot {
             gateway_status: health.status,

--- a/rust/src/providers/zai/mcp_details.rs
+++ b/rust/src/providers/zai/mcp_details.rs
@@ -333,6 +333,11 @@ impl ZaiLimitRaw {
 
         let next_reset = self.next_reset_time.map(|ms| {
             let secs = ms / 1000;
+            // ms % 1000 is at most 999, so nanoseconds stay below u32::MAX.
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "remainder < 1000 keeps nanoseconds within u32"
+            )]
             let nsecs = ((ms % 1000) * 1_000_000) as u32;
             DateTime::from_timestamp(secs, nsecs).unwrap_or_else(Utc::now)
         });

--- a/rust/src/providers/zai/mod.rs
+++ b/rust/src/providers/zai/mod.rs
@@ -9,7 +9,10 @@ pub mod region;
 pub mod settings;
 
 // Re-exports for MCP details menu
-#[allow(unused_imports)]
+#[allow(
+    unused_imports,
+    reason = "imports needed for future ZAI provider wiring"
+)]
 pub use mcp_details::{
     McpDetailsMenu, ZaiLimitEntry, ZaiLimitType, ZaiLimitUnit, ZaiUsageDetail, ZaiUsageSnapshot,
 };

--- a/rust/src/providers/zenmux/mod.rs
+++ b/rust/src/providers/zenmux/mod.rs
@@ -45,7 +45,10 @@ struct QuotaInfo {
     resets_at: Option<String>,
     max_flows: f64,
     used_flows: f64,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "field mirrors the ZenMux API payload; deserialized for round-trip fidelity but not read yet"
+    )]
     remaining_flows: f64,
 }
 

--- a/rust/src/providers/zoommate/mod.rs
+++ b/rust/src/providers/zoommate/mod.rs
@@ -514,7 +514,12 @@ fn jwt_exp_unix(token: &str) -> Option<u64> {
             .get("exp")?
             .as_f64()
             .filter(|f| f.is_finite() && *f > 0.0)
-            .map(|f| f as u64)
+            .map(|f| {
+                // JWT exp is a whole-second unix timestamp, far below u64::MAX.
+                #[expect(clippy::cast_possible_truncation, reason = "JWT exp epoch fits u64")]
+                let f = f as u64;
+                f
+            })
     })?;
     (exp > 0).then_some(exp)
 }
@@ -751,7 +756,10 @@ pub(crate) fn snapshot_from_credit_status(
         (Some(start), Some(end)) if end > start => {
             let mins = (end - start).num_minutes();
             if mins > 0 {
-                Some(mins.min(u32::MAX as i64) as u32)
+                // Window length is clamped to u32::MAX, so the cast cannot truncate.
+                #[expect(clippy::cast_possible_truncation, reason = "clamped to u32 range")]
+                let window = mins.min(u32::MAX as i64) as u32;
+                Some(window)
             } else {
                 None
             }

--- a/rust/src/secure_file.rs
+++ b/rust/src/secure_file.rs
@@ -143,7 +143,14 @@ fn protect_with_flags(plain: &[u8], flags: u32) -> io::Result<Vec<u8>> {
     use windows::Win32::Foundation::{HLOCAL, LocalFree};
     use windows::Win32::Security::Cryptography::{CRYPT_INTEGER_BLOB, CryptProtectData};
 
+    // SAFETY: input_blob borrows `plain` for the duration of the call and
+    // cbData is its exact length; output_blob is filled by CryptProtectData,
+    // copied out before LocalFree releases the API-allocated buffer.
     unsafe {
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "credential payloads are small config blobs; a >4 GiB secret is not a real input"
+        )]
         let input_blob = CRYPT_INTEGER_BLOB {
             cbData: plain.len() as u32,
             pbData: plain.as_ptr() as *mut u8,
@@ -174,7 +181,14 @@ fn unprotect(encrypted: &[u8]) -> io::Result<Vec<u8>> {
         CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptUnprotectData,
     };
 
+    // SAFETY: same blob contract as protect_with_flags: input points at
+    // `encrypted` with its exact length; the returned buffer is fully copied
+    // before LocalFree, per the DPAPI allocation contract.
     unsafe {
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "protected files were written by protect(); their size fits u32 by construction"
+        )]
         let input_blob = CRYPT_INTEGER_BLOB {
             cbData: encrypted.len() as u32,
             pbData: encrypted.as_ptr() as *mut u8,

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -6,7 +6,10 @@
 //! - Manual cookies
 //! - Other user preferences
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "settings types mirror the full config schema; some fields are not yet consumed"
+)]
 
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -568,7 +571,10 @@ impl Settings {
 
     /// Load settings from disk
     pub fn load() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "mutability is needed for conditional initialization paths that the compiler cannot prove"
+        )]
         let mut settings = match Self::settings_path() {
             Some(path) if path.exists() => match crate::secure_file::read_string(&path) {
                 Ok(content) => {
@@ -616,7 +622,8 @@ impl Settings {
             }
         }
         if !already_migrated && let Some(parent) = marker.parent() {
-            let _ = std::fs::create_dir_all(parent);
+            // Best-effort marker dir creation; the write below reports failure.
+            let _created_dir = std::fs::create_dir_all(parent);
             if let Err(error) = std::fs::write(&marker, b"1") {
                 tracing::warn!("Failed to write promote_tray_icon migration marker: {error}");
             }
@@ -680,7 +687,8 @@ impl Settings {
             let command = Self::start_at_login_command(&exe_path);
             run_key.set_value("CodexBar", &command)?;
         } else {
-            let _ = run_key.delete_value("CodexBar");
+            // Best-effort removal; a missing value means the desired state already.
+            let _removed_value = run_key.delete_value("CodexBar");
         }
 
         Ok(())

--- a/rust/src/shortcuts.rs
+++ b/rust/src/shortcuts.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides system-wide hotkeys to open the menu
 
-#![allow(dead_code)]
+#![allow(dead_code, reason = "keyboard shortcut types reserved for future global hotkey integration")]
 
 use global_hotkey::{
     GlobalHotKeyEvent, GlobalHotKeyManager,

--- a/rust/src/sound.rs
+++ b/rust/src/sound.rs
@@ -2,7 +2,10 @@
 //!
 //! Handles per-event custom WAV files, built-in CodexBar sounds, and Windows system sounds.
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "sound playback types reserved for future alert audio integration"
+)]
 
 use crate::settings::{NotificationSoundPaths, NotificationSoundTheme, Settings};
 use serde::{Deserialize, Serialize};
@@ -266,6 +269,10 @@ fn perform_windows_system_sound(event: NotificationSoundEvent) -> Result<(), Sou
         .encode_utf16()
         .chain(std::iter::once(0))
         .collect();
+    // SAFETY: `wide_alias` is a null-terminated UTF-16 buffer owned by this
+    // scope that outlives the synchronous call. `hmod` is the null handle
+    // (required when using SND_ALIAS with no module resource). The flags play
+    // the registered system alias synchronously with no default fallback.
     let played = unsafe {
         PlaySoundW(
             PCWSTR(wide_alias.as_ptr()),
@@ -302,6 +309,11 @@ fn perform_custom_wav(path: &str) -> Result<(), SoundError> {
         .encode_wide()
         .chain(std::iter::once(0))
         .collect();
+    // SAFETY: `wide_path` is a null-terminated UTF-16 buffer owned by this
+    // scope that outlives the synchronous call. `hmod` is the null handle
+    // (required for SND_FILENAME, which names a file rather than a module
+    // resource). Playback is synchronous, so the buffer stays valid through
+    // the whole call.
     let played = unsafe {
         PlaySoundW(
             PCWSTR(wide_path.as_ptr()),
@@ -333,6 +345,11 @@ fn perform_built_in_sound(event: NotificationSoundEvent) -> Result<(), SoundErro
     use windows::Win32::Media::Audio::{PlaySoundA, SND_MEMORY, SND_NODEFAULT};
     use windows::core::PCSTR;
 
+    // SAFETY: `wav` is static bytes embedded via `include_bytes!`, so its
+    // pointer is valid for the program's lifetime. `hmod` is the null handle
+    // (required with SND_MEMORY, which reads the sound from the memory
+    // buffer rather than a module resource). Playback is synchronous, so
+    // the buffer stays valid through the whole call.
     let played = unsafe {
         PlaySoundA(
             PCSTR(wav.as_ptr()),

--- a/rust/src/spend_contract.rs
+++ b/rust/src/spend_contract.rs
@@ -300,6 +300,11 @@ pub fn build_local_spend_contract_from_summary(
         replace_native,
     );
 
+    // Conversation count is clamped to u32::MAX before casting.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "clamped to u32::MAX before casting"
+    )]
     let native_conversations = if native.conversations.is_empty() {
         summary.sessions_count
     } else {
@@ -385,7 +390,10 @@ fn load_native_spend(provider_id: &str, history_days: u32) -> NativeSpendData {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "signature mirrors the flat spend-contract config fields one-to-one"
+)]
 fn resolve_spend(
     native_cost: Option<f64>,
     native_coverage: CostCoverageCounts,
@@ -526,6 +534,11 @@ fn activity_from_sessions(sessions: &[SessionUsage]) -> Vec<SpendActivityCell> {
             continue;
         };
         let local = timestamp.with_timezone(&Local);
+        // Weekday (0-6) and hour (0-23) both fit u8.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "weekday (0-6) and hour (0-23) fit u8"
+        )]
         let key = (
             local.weekday().num_days_from_monday() as u8,
             local.hour() as u8,

--- a/rust/src/spend_contract/opencodex.rs
+++ b/rust/src/spend_contract/opencodex.rs
@@ -181,6 +181,11 @@ fn aggregate(
         }
 
         let local = entry.timestamp.with_timezone(&Local);
+        // Weekday (0-6) and hour (0-23) both fit u8.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "weekday (0-6) and hour (0-23) fit u8"
+        )]
         let key = (
             local.weekday().num_days_from_monday() as u8,
             local.hour() as u8,
@@ -248,11 +253,23 @@ fn aggregate(
         (None, None) => left.model.cmp(&right.model),
     });
 
+    // Counts are clamped to u32::MAX before casting.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "clamped to u32::MAX before casting"
+    )]
+    let request_count = entries.len().min(u32::MAX as usize) as u32;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "clamped to u32::MAX before casting"
+    )]
+    let conversation_count = conversations.len().min(u32::MAX as usize) as u32;
+
     Some(ImportedSpendSource {
         source_id: "opencodex".to_string(),
         display_name: "OpenCodex".to_string(),
-        request_count: entries.len().min(u32::MAX as usize) as u32,
-        conversation_count: conversations.len().min(u32::MAX as usize) as u32,
+        request_count,
+        conversation_count,
         known_cost_usd: saw_known_cost.then_some(known_cost),
         token_mix,
         coverage,
@@ -336,6 +353,11 @@ fn pricing_model(entry: &OpenCodexEntry) -> Option<String> {
 fn load_entries(source_path: &Path) -> Option<Vec<OpenCodexEntry>> {
     let metadata = fs::metadata(source_path).ok()?;
     let source_len = metadata.len();
+    // Modified time is clamped to u64::MAX before casting.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "clamped to u64::MAX before casting"
+    )]
     let source_modified_ms = metadata
         .modified()
         .ok()
@@ -389,7 +411,8 @@ fn write_cache(cache: &CacheFile) {
     let Ok(bytes) = serde_json::to_vec(cache) else {
         return;
     };
-    let _ = fs::write(path, bytes);
+    // Best-effort cache write; a failed write is non-fatal.
+    let _written = fs::write(path, bytes);
 }
 
 fn usage_path() -> Option<PathBuf> {
@@ -493,7 +516,17 @@ fn timestamp_from_epoch(value: f64) -> Option<DateTime<Utc>> {
     } else {
         value
     };
+    // Epoch timestamps fit i64 seconds; float-to-int casts saturate otherwise.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "epoch timestamps fit i64 seconds"
+    )]
     let whole = seconds.trunc() as i64;
+    // Fractional seconds in [0, 1e9) fit u32.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "fractional seconds in [0, 1e9) fit u32"
+    )]
     let nanos = (seconds.fract().abs() * 1_000_000_000.0) as u32;
     Utc.timestamp_opt(whole, nanos).single()
 }
@@ -504,7 +537,14 @@ fn nonnegative_u64(value: Option<&Value>) -> Option<u64> {
         return Some(number);
     }
     let number = value.as_f64()?;
-    (number.is_finite() && number >= 0.0 && number <= u64::MAX as f64).then_some(number as u64)
+    // Guarded to finite non-negative values within u64 range.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "guarded to finite non-negative values within u64 range"
+    )]
+    let parsed =
+        (number.is_finite() && number >= 0.0 && number <= u64::MAX as f64).then_some(number as u64);
+    parsed
 }
 
 fn add_optional(left: Option<u64>, right: Option<u64>) -> Option<u64> {

--- a/rust/src/status/indicators.rs
+++ b/rust/src/status/indicators.rs
@@ -3,7 +3,7 @@
 //! Status overlay system for showing provider health in tray icons.
 //! Integrates with status page monitoring (Statuspage.io, etc.)
 
-#![allow(dead_code)]
+#![allow(dead_code, reason = "status indicator types reserved for future UI integration")]
 
 use serde::{Deserialize, Serialize};
 

--- a/rust/src/status/mod.rs
+++ b/rust/src/status/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Fetches operational status from provider status pages
 
-#![allow(dead_code)]
+#![allow(dead_code, reason = "status types reserved for future UI integration")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/rust/src/tray/icon.rs
+++ b/rust/src/tray/icon.rs
@@ -14,7 +14,10 @@ pub enum UsageLevel {
     /// 95-100% used - red
     Critical,
     /// Unknown/error state - gray
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "tray icon types reserved for future system tray integration"
+    )]
     Unknown,
 }
 
@@ -41,7 +44,10 @@ impl UsageLevel {
 }
 
 /// Badge type for status indicators
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "tray icon types reserved for future system tray integration"
+)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BadgeType {
     /// Warning indicator (yellow)

--- a/rust/src/tray/render.rs
+++ b/rust/src/tray/render.rs
@@ -42,6 +42,11 @@ pub fn render_bar_icon_rgba(
     let color_for = |percent: f64| -> (u8, u8, u8) {
         let (r, g, b) = UsageLevel::from_percent(percent).color();
         if has_error {
+            // Average of three u8 colour channels: sum ≤ 765, so /3 ≤ 255 fits u8.
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "mean of three u8 channels; r+g+b ≤ 765, divided by 3 is ≤ 255 and fits u8"
+            )]
             let gray = ((r as u16 + g as u16 + b as u16) / 3) as u8;
             (gray, gray, gray)
         } else {
@@ -53,6 +58,11 @@ pub fn render_bar_icon_rgba(
     let bar_right = SZ - 4;
     let bar_width = bar_right - bar_left;
 
+    // pct is clamped to 0–100, scaled by bar_width (≤ SZ = 32), so the result fits u32.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "pct clamped to 0–100 and scaled by bar_width ≤ 32; result is a small pixel count that fits u32"
+    )]
     let fill_px = |pct: f64| ((pct.clamp(0.0, 100.0) / 100.0) * bar_width as f64) as u32;
 
     let mut draw_bar = |y_start: u32, y_end: u32, pct: f64| {
@@ -99,6 +109,11 @@ pub fn render_percent_icon_rgba(percent: f64, has_error: bool) -> (Vec<u8>, u32,
         }
     }
 
+    // percent clamped to 0–100 before rounding, so the cast to u32 cannot truncate.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "percent is clamped to 0–100 and rounded; the integer fits u32"
+    )]
     let pct = percent.clamp(0.0, 100.0).round() as u32;
     let text = if pct >= 100 {
         "100".to_string()
@@ -108,13 +123,24 @@ pub fn render_percent_icon_rgba(percent: f64, has_error: bool) -> (Vec<u8>, u32,
     let glyph_width = 3u32;
     let glyph_gap = 1u32;
     let scale = if text.len() >= 3 { 2u32 } else { 3u32 };
-    let text_width = text.len() as u32 * glyph_width * scale + (text.len() as u32 - 1) * glyph_gap;
+    // text is "100" or at most "NN%", so its length is ≤ 4 and fits u32.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "text is \"100\" or \"NN%\", so len ≤ 4 and fits u32"
+    )]
+    let text_len = text.len() as u32;
+    let text_width = text_len * glyph_width * scale + (text_len - 1) * glyph_gap;
     let text_height = 5 * scale;
     let start_x = (SZ.saturating_sub(text_width)) / 2;
     let start_y = (SZ.saturating_sub(text_height)) / 2;
 
     let (r, g, b) = UsageLevel::from_percent(percent).color();
     let color = if has_error {
+        // Average of three u8 colour channels: sum ≤ 765, so /3 ≤ 255 fits u8.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "mean of three u8 channels; r+g+b ≤ 765, divided by 3 is ≤ 255 and fits u8"
+        )]
         let gray = ((r as u16 + g as u16 + b as u16) / 3) as u8;
         Rgba([gray, gray, gray, 255])
     } else {
@@ -143,6 +169,11 @@ fn draw_glyph(img: &mut RgbaImage, ch: char, x: u32, y: u32, scale: u32, color: 
             for yy in 0..scale {
                 for xx in 0..scale {
                     let px = x + col * scale + xx;
+                    // row_idx is bounded by the 5-row glyph array, so it fits u32.
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        reason = "row_idx iterates over a fixed [u8; 5] glyph, so it is 0..5 and fits u32"
+                    )]
                     let py = y + row_idx as u32 * scale + yy;
                     if px < TRAY_ICON_SIZE && py < TRAY_ICON_SIZE {
                         img.put_pixel(px, py, color);
@@ -179,13 +210,13 @@ mod tests {
         let (rgba, w, h) = render_bar_icon_rgba(50.0, None, false);
         assert_eq!(w, TRAY_ICON_SIZE);
         assert_eq!(h, TRAY_ICON_SIZE);
-        assert_eq!(rgba.len() as u32, w * h * 4);
+        assert_eq!(u32::try_from(rgba.len()).unwrap(), w * h * 4);
     }
 
     #[test]
     fn render_two_bar_has_correct_size() {
         let (rgba, w, h) = render_bar_icon_rgba(30.0, Some(60.0), false);
-        assert_eq!(rgba.len() as u32, w * h * 4);
+        assert_eq!(u32::try_from(rgba.len()).unwrap(), w * h * 4);
     }
 
     #[test]
@@ -226,7 +257,7 @@ mod tests {
         let (rgba, w, h) = render_percent_icon_rgba(72.0, false);
         assert_eq!(w, TRAY_ICON_SIZE);
         assert_eq!(h, TRAY_ICON_SIZE);
-        assert_eq!(rgba.len() as u32, w * h * 4);
+        assert_eq!(u32::try_from(rgba.len()).unwrap(), w * h * 4);
     }
 
     #[test]
@@ -243,6 +274,6 @@ mod tests {
     #[test]
     fn percent_icon_clamps_to_hundred() {
         let (rgba, w, h) = render_percent_icon_rgba(125.0, false);
-        assert_eq!(rgba.len() as u32, w * h * 4);
+        assert_eq!(u32::try_from(rgba.len()).unwrap(), w * h * 4);
     }
 }

--- a/rust/src/updater.rs
+++ b/rust/src/updater.rs
@@ -37,9 +37,15 @@ pub struct UpdateInfo {
     pub version: String,
     pub download_url: String,
     pub expected_sha256: Option<String>,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "update metadata fields are deserialized for version comparison but not all are read"
+    )]
     pub release_url: String,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "update metadata fields are deserialized for version comparison but not all are read"
+    )]
     pub release_notes: String,
     pub delivery: UpdateDelivery,
 }
@@ -63,7 +69,10 @@ struct GitHubRelease {
     #[serde(default)]
     draft: bool,
     #[serde(default)]
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "update metadata fields are deserialized for version comparison but not all are read"
+    )]
     prerelease: bool,
 }
 
@@ -79,7 +88,10 @@ struct GitHubAsset {
 ///
 /// When `channel` is `UpdateChannel::Beta`, includes pre-release versions.
 /// When `channel` is `UpdateChannel::Stable`, only considers stable releases.
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "update check response fields are deserialized for parsing but not all are read"
+)]
 pub async fn check_for_updates() -> Option<UpdateInfo> {
     check_for_updates_with_channel(UpdateChannel::Stable).await
 }
@@ -238,7 +250,10 @@ fn is_newer_version(remote: &str, current: &str) -> bool {
 }
 
 /// Get the current version
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "update info struct reserved for future UI integration"
+)]
 pub fn current_version() -> &'static str {
     CURRENT_VERSION
 }
@@ -263,8 +278,8 @@ pub async fn download_update(
     write_download_response(response, &file_path, &progress_tx).await?;
     verify_download_hash(&file_path, expected_update_sha256(update_info)?).await?;
 
-    // Signal download complete
-    let _ = progress_tx.send(UpdateState::Ready(file_path.clone()));
+    // Signal download complete; the receiver may be gone, which is fine.
+    let _ready_signal = progress_tx.send(UpdateState::Ready(file_path.clone()));
 
     Ok(file_path)
 }
@@ -367,14 +382,16 @@ fn send_download_progress(
         0.0
     };
 
-    let _ = progress_tx.send(UpdateState::Downloading(progress));
+    // Best-effort progress update; a dropped receiver is fine.
+    let _progress_update = progress_tx.send(UpdateState::Downloading(progress));
 }
 
 /// Verify the SHA256 hash of a downloaded file against release metadata.
 async fn verify_download_hash(file_path: &PathBuf, expected_hash: &str) -> Result<(), String> {
     let actual = sha256_file_async(file_path).await?;
     if let Err(e) = verify_sha256_hex(&actual, expected_hash) {
-        let _ = std::fs::remove_file(file_path);
+        // Best-effort cleanup of the corrupt download; the hash error is returned regardless.
+        let _removed = std::fs::remove_file(file_path);
         return Err(e);
     }
 
@@ -427,7 +444,10 @@ fn sha256_file(file_path: &Path) -> Result<String, String> {
 /// Start background download of an update
 ///
 /// Returns a receiver that can be polled for progress updates.
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "update info struct reserved for future UI integration"
+)]
 pub fn start_background_download(
     update_info: UpdateInfo,
 ) -> (
@@ -445,7 +465,8 @@ pub fn start_background_download(
                     // UpdateState::Ready is already sent by download_update
                 }
                 Err(e) => {
-                    let _ = tx.send(UpdateState::Failed(e));
+                    // Best-effort failure signal; the receiver may already be gone.
+                    let _failure_signal = tx.send(UpdateState::Failed(e));
                 }
             }
         });
@@ -626,7 +647,10 @@ fn windows_powershell_path() -> PathBuf {
 }
 
 /// Check if there's a pending update ready to install
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "update info struct reserved for future UI integration"
+)]
 pub fn get_pending_update() -> Option<PathBuf> {
     let download_dir = get_download_dir()?;
 
@@ -668,10 +692,13 @@ fn find_pending_installer_in_dir(download_dir: &Path) -> Option<PathBuf> {
 }
 
 /// Clean up downloaded updates
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "update info struct reserved for future UI integration"
+)]
 pub fn cleanup_downloads() {
     if let Some(download_dir) = get_download_dir() {
-        let _ = std::fs::remove_dir_all(&download_dir);
+        let _cleaned = std::fs::remove_dir_all(&download_dir);
     }
 }
 

--- a/rust/src/wsl.rs
+++ b/rust/src/wsl.rs
@@ -108,7 +108,10 @@ fn is_system_user_dir(name: &str) -> bool {
 /// Convert a Windows path to its WSL equivalent.
 ///
 /// `C:\Users\John\AppData\Local` becomes `/mnt/c/Users/John/AppData/Local`.
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "WSL detection helper reserved for future cross-platform integration"
+)]
 pub fn windows_path_to_wsl(windows_path: &str) -> Option<PathBuf> {
     let path = windows_path.replace('\\', "/");
 


### PR DESCRIPTION
Adds a rust-crate-scoped clippy lint policy: a `[workspace.lints.clippy]` deny table (allow_attributes_without_reason, let_underscore_must_use, undocumented_unsafe_blocks, cast_possible_truncation, cast_possible_wrap) in the root Cargo.toml, with `[lints] workspace = true` opted in for the `rust` crate only. Annotation passes across ~110 rust/ files: must-use discards, bounded casts with reasons, missing SAFETY docs.

The deny table fires under CI's existing `cargo clippy --workspace --all-targets -- -D warnings` for the opted-in crate — no separate pedantic flag needed.

Scope note: the tauri crate (apps/desktop-tauri/src-tauri) is intentionally NOT opted in yet. Wiring it up requires its own annotation pass (must-use discards, bounded casts, unsafe docs); it will land in a follow-up PR. The root workspace deny table is inert for the tauri crate until it declares `[lints] workspace = true`.

Resolved against origin/main@41a765517 (3-way stash merge conflicts in Cargo.lock version fields and jsonl_scanner `cached` semantics resolved in favor of main's v0.55.0 behavior).
