### PR TITLE
Publish codexbar-cli.exe as a release asset with checksum

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -73,7 +73,10 @@ Both jobs use CircleCI's hosted Windows executor (`circleci/windows@5.0`).
    package, pnpm 11.24.0, the Rust MSVC target, Git, and Inno Setup 6.
 3. It uses a new temporary `WorkRoot`, runs `release-doctor.ps1`, then runs
    `windows-release-build.ps1` with the immutable SHA and `-SmokeInstall`.
-   It never uploads. Four assets, `release-manifest.json`, and build logs are
+   It never uploads. Six assets — `CodexBar-<version>-Setup.exe` and its
+   `.sha256` sidecar, `CodexBar-<version>-portable.exe` and its `.sha256`
+   sidecar, `CodexBarCLI-v<version>-windows-x64.zip` and its `.sha256`
+   sidecar — plus `release-manifest.json` and build logs are
    persisted to the workspace and stored as CircleCI artifacts.
 4. `release-approval` is a required manual CircleCI approval job.
 5. `release-publish` attaches the workspace and is the only job with context

--- a/.github/workflows/signpath-test.yml
+++ b/.github/workflows/signpath-test.yml
@@ -136,7 +136,7 @@ jobs:
           $version = '${{ steps.version.outputs.version }}'
           $outputDir = 'release-output'
           $tag = '${{ inputs.tag }}'
-          $assets = Get-ChildItem "$outputDir\CodexBar-$version-*" |
+          $assets = Get-ChildItem "$outputDir\CodexBar-$version-*", "$outputDir\CodexBarCLI-v$version-*" |
             Where-Object { $_.Name -notmatch '\.log$' } |
             Select-Object -ExpandProperty FullName
           gh release create $tag --repo nesszer/Win-CodexBar --draft --title "Win-CodexBar $version" --notes "Release $version" @assets

--- a/docs/adr/0004-circleci-release-trust-boundary.md
+++ b/docs/adr/0004-circleci-release-trust-boundary.md
@@ -25,8 +25,11 @@ It provisions/asserts pinned-enough prerequisites, uses a fixed WorkRoot
 pnpm store), runs release-doctor, and invokes `windows-release-build.ps1` with
 the immutable SHA and `-SmokeInstall`. The WorkRoot's `cache/` subdirectory
 survives between runs while `source/` and `assets/` are cleaned fresh. It emits
-four expected assets, a manifest, and logs into a persisted workspace. The
-builder has no publication path.
+six expected assets — `CodexBar-<version>-Setup.exe` and its `.sha256`
+sidecar, `CodexBar-<version>-portable.exe` and its `.sha256` sidecar,
+`CodexBarCLI-v<version>-windows-x64.zip` and its `.sha256` sidecar — plus a
+manifest and logs into a persisted workspace. The builder has no publication
+path.
 
 A required CircleCI approval separates build from `release-publish`. Only that
 job receives the project-restricted `github-release-publisher` context with a

--- a/docs/release/ci-cd.md
+++ b/docs/release/ci-cd.md
@@ -24,10 +24,12 @@ gets the restricted `GH_TOKEN` context.
 3. The build invokes `scripts/release-doctor.ps1 -SkipGitHub`, then
    `scripts/windows-release-build.ps1 -Ref <full-SHA> -SmokeInstall` with a
    fresh temporary `WorkRoot`. It never receives `GH_TOKEN` and never uploads.
-4. The job emits exactly these four publishable assets:
+4. The job emits exactly these six publishable assets:
    `CodexBar-X.Y.Z-Setup.exe`, its `.sha256` sidecar,
-   `CodexBar-X.Y.Z-portable.exe`, and its `.sha256` sidecar. It also emits
-   `release-manifest.json` (tag, commit, version, sizes, and hashes) and logs,
+   `CodexBar-X.Y.Z-portable.exe`, its `.sha256` sidecar,
+   `CodexBarCLI-vX.Y.Z-windows-x64.zip`, and its `.sha256` sidecar. It also
+   emits `release-manifest.json` (tag, commit, version, sizes, and hashes)
+   and logs,
    then persists/stores the bundle as CircleCI workspace/artifacts.
 5. A human must approve the `release-approval` job after reviewing the
    manifest and artifact logs.

--- a/docs/release/ci-cd.md
+++ b/docs/release/ci-cd.md
@@ -43,6 +43,12 @@ gets the restricted `GH_TOKEN` context.
    notes/review. Winget follows only after the immutable installer URL and
    digest are stable.
 
+## Signing status
+
+The `CodexBarCLI-vX.Y.Z-windows-x64.zip` asset is currently **unsigned**. The
+SignPath workflow's upload glob (`CodexBar-*.exe`) does not include it.
+Revisit when SignPath wiring for the CLI zip lands.
+
 ## Local checks
 
 Run the focused, dependency-free helper tests and prerequisite assertions:

--- a/scripts/ci/assert-release-assets.cmd
+++ b/scripts/ci/assert-release-assets.cmd
@@ -19,6 +19,8 @@ for %%F in (
   "CodexBar-%VERSION%-Setup.exe.sha256"
   "CodexBar-%VERSION%-portable.exe"
   "CodexBar-%VERSION%-portable.exe.sha256"
+  "CodexBarCLI-v%VERSION%-windows-x64.zip"
+  "CodexBarCLI-v%VERSION%-windows-x64.zip.sha256"
 ) do (
   if not exist "%ASSETS_DIR%\%%~F" (
     echo Missing release artifact: %ASSETS_DIR%\%%~F

--- a/scripts/ci/assert-release-assets.ps1
+++ b/scripts/ci/assert-release-assets.ps1
@@ -16,7 +16,9 @@ foreach ($name in @(
     "CodexBar-$version-Setup.exe",
     "CodexBar-$version-Setup.exe.sha256",
     "CodexBar-$version-portable.exe",
-    "CodexBar-$version-portable.exe.sha256"
+    "CodexBar-$version-portable.exe.sha256",
+    "CodexBarCLI-v$version-windows-x64.zip",
+    "CodexBarCLI-v$version-windows-x64.zip.sha256"
 )) {
     $path = Join-Path $assetsDir $name
     if (-not (Test-Path -LiteralPath $path)) {

--- a/scripts/emit-release-manifest.ps1
+++ b/scripts/emit-release-manifest.ps1
@@ -40,8 +40,9 @@ foreach ($path in $expectedPaths) {
 }
 Assert-AssetMatchesSidecar (Join-Path $AssetsDir "CodexBar-$version-Setup.exe")
 Assert-AssetMatchesSidecar (Join-Path $AssetsDir "CodexBar-$version-portable.exe")
+Assert-AssetMatchesSidecar (Join-Path $AssetsDir "CodexBarCLI-v$version-windows-x64.zip")
 
-# Copy only the four publishable assets and the build logs into the persisted bundle.
+# Copy only the six publishable assets and the build logs into the persisted bundle.
 foreach ($path in $expectedPaths) {
     Copy-Item -LiteralPath $path -Destination (Join-Path $OutputDir (Split-Path $path -Leaf)) -Force
 }

--- a/scripts/publish-github-release.ps1
+++ b/scripts/publish-github-release.ps1
@@ -174,8 +174,8 @@ function Assert-ManifestAndAssets {
         throw 'Manifest is missing its assets list.'
     }
     $manifestAssets = @($manifest.assets)
-    if ($manifestAssets.Count -ne 4) {
-        throw "Manifest must contain exactly four release assets; found $($manifestAssets.Count)."
+    if ($manifestAssets.Count -ne 6) {
+        throw "Manifest must contain exactly six release assets; found $($manifestAssets.Count)."
     }
     $manifestNames = @($manifestAssets | ForEach-Object { [string]$_.name } | Sort-Object)
     if (($manifestNames -join '|') -ne ($expectedNames -join '|')) {
@@ -205,7 +205,8 @@ function Assert-ManifestAndAssets {
     }
     Assert-AssetMatchesSidecar (Join-Path $AssetsDir "CodexBar-$ExpectedVersion-Setup.exe")
     Assert-AssetMatchesSidecar (Join-Path $AssetsDir "CodexBar-$ExpectedVersion-portable.exe")
-    Write-Host '[ok] manifest, exact four asset names, SHA-256 values, and sidecars verified before API access'
+    Assert-AssetMatchesSidecar (Join-Path $AssetsDir "CodexBarCLI-v$ExpectedVersion-windows-x64.zip")
+    Write-Host '[ok] manifest, exact six asset names, SHA-256 values, and sidecars verified before API access'
 }
 
 $env:GH_TOKEN = if ($env:GH_TOKEN) { $env:GH_TOKEN } elseif ($env:gh_token) { $env:gh_token } else { '' }
@@ -276,5 +277,5 @@ foreach ($path in $assetPaths) {
     }
 }
 
-Write-Host "Draft GitHub Release $Tag contains all four verified Windows assets."
+Write-Host "Draft GitHub Release $Tag contains all six verified Windows assets."
 Write-Host 'No release publication/finalization was performed.'

--- a/scripts/release-doctor.ps1
+++ b/scripts/release-doctor.ps1
@@ -146,6 +146,7 @@ if ((Test-Path $changelogPath) -and (Select-String -Path $changelogPath -Pattern
 if (Test-Path $AssetsDir) {
     Test-AssetHash (Join-Path $AssetsDir "CodexBar-$Version-Setup.exe")
     Test-AssetHash (Join-Path $AssetsDir "CodexBar-$Version-portable.exe")
+    Test-AssetHash (Join-Path $AssetsDir "CodexBarCLI-v$Version-windows-x64.zip")
 } else {
     Write-Warn "local assets directory not found: $AssetsDir"
 }
@@ -169,7 +170,9 @@ if (-not $SkipGitHub) {
                     "CodexBar-$Version-Setup.exe",
                     "CodexBar-$Version-Setup.exe.sha256",
                     "CodexBar-$Version-portable.exe",
-                    "CodexBar-$Version-portable.exe.sha256"
+                    "CodexBar-$Version-portable.exe.sha256",
+                    "CodexBarCLI-v$Version-windows-x64.zip",
+                    "CodexBarCLI-v$Version-windows-x64.zip.sha256"
                 )) {
                     if ($assetNames -contains $name) {
                         Write-Ok "GitHub release has $name"

--- a/scripts/release-pipeline-common.ps1
+++ b/scripts/release-pipeline-common.ps1
@@ -62,7 +62,9 @@ function Get-RequiredReleaseAssets {
         "CodexBar-$Version-Setup.exe",
         "CodexBar-$Version-Setup.exe.sha256",
         "CodexBar-$Version-portable.exe",
-        "CodexBar-$Version-portable.exe.sha256"
+        "CodexBar-$Version-portable.exe.sha256",
+        "CodexBarCLI-v$Version-windows-x64.zip",
+        "CodexBarCLI-v$Version-windows-x64.zip.sha256"
     )
 }
 

--- a/scripts/release-pipeline.tests.ps1
+++ b/scripts/release-pipeline.tests.ps1
@@ -45,9 +45,11 @@ Assert-Equal (Get-ReleaseVersionFromTag 'v0.48.0') '0.48.0' 'version extraction'
 Assert-Throws { Get-ReleaseVersionFromTag 'v0.48.0+build' } 'invalid version extraction fails'
 
 $assetNames = Get-RequiredReleaseAssets '0.48.0'
-Assert-Equal $assetNames.Count 4 'exactly four release asset names'
+Assert-Equal $assetNames.Count 6 'exactly six release asset names including sidecars'
 Assert-Equal $assetNames[0] 'CodexBar-0.48.0-Setup.exe' 'installer name'
 Assert-Equal $assetNames[3] 'CodexBar-0.48.0-portable.exe.sha256' 'portable sidecar name'
+Assert-Equal $assetNames[4] 'CodexBarCLI-v0.48.0-windows-x64.zip' 'CLI archive name'
+Assert-Equal $assetNames[5] 'CodexBarCLI-v0.48.0-windows-x64.zip.sha256' 'CLI sidecar name'
 
 $testRoot = Join-Path ([IO.Path]::GetTempPath()) ('win-codexbar-release-tests-' + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Force -Path $testRoot | Out-Null

--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -476,6 +476,12 @@ try {
     Copy-Item $installer $installerAsset -Force
     Compress-Archive -Path $releaseExe -DestinationPath $cliZip -Force
 
+    $zipVerifyDir = Join-Path ([IO.Path]::GetTempPath()) ("codexbar-cli-zip-verify-" + [guid]::NewGuid().ToString('N'))
+    Expand-Archive -LiteralPath $cliZip -DestinationPath $zipVerifyDir -Force
+    $extractedCli = Join-Path $zipVerifyDir "codexbar-cli.exe"
+    if (-not (Test-Path -LiteralPath $extractedCli -PathType Leaf)) { throw "CLI zip missing codexbar-cli.exe entry: $cliZip" }
+    if ((Get-FileHash -LiteralPath $extractedCli -Algorithm SHA256).Hash -cne (Get-FileHash -LiteralPath $releaseExe -Algorithm SHA256).Hash) { throw "CLI zip entry hash mismatch: $cliZip" }
+
     foreach ($asset in @($installerAsset, $portableExe, $cliZip)) {
         $fileName = Split-Path $asset -Leaf
         $hash = (Get-FileHash -Algorithm SHA256 $asset).Hash.ToLower()

--- a/scripts/windows-release-build.ps1
+++ b/scripts/windows-release-build.ps1
@@ -464,6 +464,7 @@ try {
     $installer = Join-Path $installerOut "CodexBar-$version-Setup.exe"
     $portableExe = Join-Path $AssetsDir "CodexBar-$version-portable.exe"
     $installerAsset = Join-Path $AssetsDir "CodexBar-$version-Setup.exe"
+    $cliZip = Join-Path $AssetsDir "CodexBarCLI-v$version-windows-x64.zip"
 
     foreach ($path in @($desktopExe, $releaseExe, $installer)) {
         if (-not (Test-Path $path)) {
@@ -473,8 +474,9 @@ try {
 
     Copy-Item $desktopExe $portableExe -Force
     Copy-Item $installer $installerAsset -Force
+    Compress-Archive -Path $releaseExe -DestinationPath $cliZip -Force
 
-    foreach ($asset in @($installerAsset, $portableExe)) {
+    foreach ($asset in @($installerAsset, $portableExe, $cliZip)) {
         $fileName = Split-Path $asset -Leaf
         $hash = (Get-FileHash -Algorithm SHA256 $asset).Hash.ToLower()
         "$hash  $fileName" | Set-Content -Encoding ascii "$asset.sha256"
@@ -494,7 +496,7 @@ try {
 
     Write-Host ""
     Write-Host "Release assets:"
-    Get-ChildItem $AssetsDir -Filter "CodexBar-$version-*" |
+    Get-ChildItem $AssetsDir -Filter "CodexBar*" |
         Sort-Object Name |
         Select-Object Name, Length, LastWriteTime |
         Format-Table -AutoSize


### PR DESCRIPTION
Closes #392.

Adds `CodexBarCLI-v<version>-windows-x64.zip` + SHA-256 sidecar to release assets, matching upstream's CLI tarball convention. Updates the 4-asset release contract (builder, publisher, manifest, doctor, CI asset assertion) to a 5-asset contract. Enables third-party integrations (kandev plugin) to consume the CLI without installing the GUI.

Changes:
- `scripts/windows-release-build.ps1`: package `codexbar-cli.exe` into `CodexBarCLI-v<version>-windows-x64.zip` and emit its `.sha256` sidecar alongside installer/portable assets.
- `scripts/release-pipeline-common.ps1`: extend `Get-RequiredReleaseAssets` with the CLI zip + sidecar (source of truth for the contract).
- `scripts/emit-release-manifest.ps1`: assert + copy the new asset into the manifest bundle.
- `scripts/publish-github-release.ps1`: six-asset manifest guard + CLI sidecar verification before upload.
- `scripts/release-doctor.ps1`: local hash check + GitHub release presence check for the new asset.
- `scripts/ci/assert-release-assets.ps1` / `.cmd`: include the new asset in CI assertions.
- `.github/workflows/signpath-test.yml`: publish glob now also matches `CodexBarCLI-v<version>-*`.
- `scripts/release-pipeline.tests.ps1`: contract tests updated for the extended asset list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows releases now include a versioned CLI ZIP archive alongside the installer and portable application.
  * The CLI archive and its SHA-256 checksum are published with each GitHub release.

* **Bug Fixes**
  * Release validation now verifies all six expected Windows assets, including the CLI archive and checksum, helping detect incomplete or inconsistent releases.

* **Documentation**
  * Release documentation now describes the expanded six-asset package and CLI archive availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->