### PR TITLE
Fix finish_child Err arm to fall through to teardown

### DIFF
--- a/rust/src/host/command_runner.rs
+++ b/rust/src/host/command_runner.rs
@@ -272,7 +272,7 @@ impl CommandRunner {
             match child.try_wait() {
                 Ok(Some(status)) => return status.code(),
                 Ok(None) => {}
-                Err(_) => return None,
+                Err(_) => break,
             }
             if remaining.is_zero() {
                 break;
@@ -281,10 +281,10 @@ impl CommandRunner {
             std::thread::sleep(step);
             remaining -= step;
         }
-        // Teardown after timeout/capture. If the process exited between the
-        // grace loop and kill (kill fails on an already-dead process), `wait`
-        // still yields the true exit status; when the kill lands, the code is
-        // ours and already reported separately.
+        // Teardown after timeout/capture or a transient try_wait error
+        // (e.g. ECHILD/handle race). If the process already exited, kill
+        // fails and `wait` still yields the true exit status; when the kill
+        // lands, the code is ours and already reported separately.
         let killed = child.kill().is_ok();
         let reaped = child.wait().ok();
         if killed {


### PR DESCRIPTION
Follow-up to #398. The Err arm in finish_child's poll loop early-returned None before the teardown block, so a transient try_wait error (e.g. ECHILD) skipped kill+wait - leaving the child unreaped (zombie on Unix) and reporting a false discovery failure. Now falls through to the same kill+wait+recover teardown as grace expiry. Closes the last error-path gap from the #396 review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command cleanup when checking a process’s exit status encounters a temporary error.
  * Ensured teardown proceeds reliably instead of ending without an exit code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->