### PR TITLE
Reap child when capture_output errors in CommandRunner::run

### DIFF
--- a/rust/src/host/command_runner.rs
+++ b/rust/src/host/command_runner.rs
@@ -156,7 +156,13 @@ impl CommandRunner {
         Self::send_initial_input(&mut child, input, options.initial_delay, deadline);
 
         // Capture output
-        let (output, stderr, timed_out) = self.capture_output(&mut child, options, deadline)?;
+        let (output, stderr, timed_out) = match self.capture_output(&mut child, options, deadline) {
+            Ok(captured) => captured,
+            Err(e) => {
+                let _exit_code = Self::finish_child(&mut child);
+                return Err(e);
+            }
+        };
 
         let exit_code = Self::finish_child(&mut child);
 


### PR DESCRIPTION
Closes #400.

The early `?` on `capture_output` in `CommandRunner::run` propagated errors immediately, dropping the `Child` without `kill()`/`wait()` — a zombie on Unix until parent exit. Now routes the error through `finish_child` (the same kill+wait+recover teardown used by every other path since #398/#399) before propagating.

Verification: `cargo build`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (1365 passed) all green on a clean origin/main + this patch. Note: the current repo checkout carries unrelated concurrent WIP in `rust/src/logging.rs` that fails to compile on its own; it is not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of output-capture failures by safely cleaning up the running process before reporting an error.
  * Preserved existing behavior for successful command execution and output capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->