### PR TITLE
Point updater release URLs at nesszer releases

### DIFF
--- a/rust/src/updater.rs
+++ b/rust/src/updater.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::watch;
 
-const GITHUB_REPO: &str = "Finesssee/Win-CodexBar";
+const GITHUB_REPO: &str = "nesszer/Win-CodexBar";
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// State of the update download process
@@ -720,7 +720,7 @@ mod tests {
     fn prefers_installer_asset_for_auto_update() {
         let release = GitHubRelease {
             tag_name: "v1.2.6".to_string(),
-            html_url: "https://github.com/Finesssee/Win-CodexBar/releases/tag/v1.2.6".to_string(),
+            html_url: "https://github.com/nesszer/Win-CodexBar/releases/tag/v1.2.6".to_string(),
             body: None,
             assets: vec![
                 GitHubAsset {
@@ -756,7 +756,7 @@ mod tests {
     fn falls_back_to_manual_release_when_only_portable_exe_exists() {
         let release = GitHubRelease {
             tag_name: "v1.2.6".to_string(),
-            html_url: "https://github.com/Finesssee/Win-CodexBar/releases/tag/v1.2.6".to_string(),
+            html_url: "https://github.com/nesszer/Win-CodexBar/releases/tag/v1.2.6".to_string(),
             body: None,
             assets: vec![GitHubAsset {
                 name: "codexbar.exe".to_string(),
@@ -771,7 +771,7 @@ mod tests {
 
         assert_eq!(
             update.download_url,
-            "https://github.com/Finesssee/Win-CodexBar/releases/tag/v1.2.6"
+            "https://github.com/nesszer/Win-CodexBar/releases/tag/v1.2.6"
         );
         assert!(!update.supports_auto_apply());
     }


### PR DESCRIPTION
## Summary

Point the in-app updater's release endpoints at the `nesszer/Win-CodexBar` GitHub releases. PR #402 (merged) intentionally left the updater URLs on `Finesssee/Win-CodexBar` pending verification; this PR flips them after verifying nesszer releases exist with matching assets.

`Finesssee/Win-CodexBar` now redirects to `nesszer/Win-CodexBar` (`gh api repos/Finesssee/Win-CodexBar --jq .full_name` → `nesszer/Win-CodexBar`), so both repos serve identical releases — this change makes the canonical repo explicit instead of relying on the redirect.

**Winget identity note:** `PackageIdentifier` remains `Finesssee.Win-CodexBar`; untouched. Installer metadata (`rust/Cargo.toml:8` repository field, `rust/installer/codexbar.iss:27-29`, `rust/wix/main.wxs:168`) intentionally unchanged — those do not feed updater network calls.

## Step 1 verification evidence (read-only network)

### Update-check endpoint resolves on nesszer

```
$ gh api repos/nesszer/Win-CodexBar/releases/latest --jq .tag_name
v0.55.0
```

### nesszer releases (latest 10)

```
$ gh release list --repo nesszer/Win-CodexBar --limit 10
v0.55.0	Latest	v0.55.0	2026-08-24T22:34:12Z
Win-CodexBar 0.54.0		v0.54.0	2026-08-22T14:55:42Z
Win-CodexBar 0.53.0		v0.53.0	2026-08-19T12:52:42Z
Win-CodexBar 0.48.0		v0.48.0	2026-08-09T09:18:40Z
Win-CodexBar 0.47.0		v0.47.0	2026-08-04T13:04:24Z
Win-CodexBar 0.46.0		v0.46.0	2026-07-30T05:46:51Z
Win-CodexBar v0.45.3		v0.45.3	2026-07-29T02:43:50Z
Win-CodexBar v0.45.2		v0.45.2	2026-07-21T03:39:22Z
Win-CodexBar v0.43.0		v0.43.0	2026-07-17T06:42:20Z
Win-CodexBar v0.42.0		v0.42.0	2026-07-12T05:34:10Z
```

### Latest nesszer release assets match what the updater constructs/downloads

Updater asset matcher (`rust/src/updater.rs:191-194`): name ends with `-setup.exe` or `.msi` (case-insensitive). Release tags yield versions via `remote_version_from_tag` (strips leading `v`).

```
$ gh release view v0.55.0 --repo nesszer/Win-CodexBar --json tagName,assets,url --jq '{tagName: .tagName, url: .url, assets: [.assets[] | {name: .name, digest: .digest}]}'
{"assets":[
  {"digest":"sha256:783f5b397f2e49a74f441f1425cf570b44d3bb06e33e4d7f8cec81ed3dee557f","name":"CodexBar-0.55.0-portable.exe"},
  {"digest":"sha256:8215183adf7b197874a63965a536d5418b19616f3c24dfa1f697af9df23a9518","name":"CodexBar-0.55.0-portable.exe.sha256"},
  {"digest":"sha256:9e511820b86557263617875b9aac196900eb9318bbb70c3d9eeede1035bf9ab7","name":"CodexBar-0.55.0-Setup.exe"},
  {"digest":"sha256:4a63b204480ce005d192f98cf1bb167303018c48dcb4d0ce5efbcb0cdf2f88e2","name":"CodexBar-0.55.0-Setup.exe.sha256"}],
 "tagName":"v0.55.0",
 "url":"https://github.com/nesszer/Win-CodexBar/releases/tag/v0.55.0"}
```

- `CodexBar-0.55.0-Setup.exe` matches `is_installer_asset_name` (ends `-Setup.exe`) → `UpdateDelivery::Installer` (auto-download + auto-apply path).
- Asset `digest` fields are `sha256:<64-hex>` → parsed by `parse_sha256_digest` for download hash verification.
- Tag `v0.55.0` → version `0.55.0` = current crate version (`rust/Cargo.toml`), so the updater resolves "latest" cleanly.

### Finesssee comparison (naming convention identical)

```
$ gh release list --repo Finesssee/Win-CodexBar --limit 5
v0.55.0	Latest	v0.55.0	2026-08-24T22:34:12Z
Win-CodexBar 0.54.0		v0.54.0	2026-08-22T14:55:42Z
Win-CodexBar 0.53.0		v0.53.0	2026-08-19T12:52:42Z
Win-CodexBar 0.48.0		v0.48.0	2026-08-09T09:18:40Z
Win-CodexBar 0.47.0		v0.47.0	2026-08-04T13:04:24Z
```

Same tags, same timestamps, same asset names (`CodexBar-0.55.0-portable.exe`, `CodexBar-0.55.0-portable.exe.sha256`, `CodexBar-0.55.0-Setup.exe`, `CodexBar-0.55.0-Setup.exe.sha256`) — the Finesssee name resolves to the same underlying repo (`full_name: nesszer/Win-CodexBar`), so the naming convention is unchanged and the flip is asset-compatible.

## Diff summary

Single commit, 1 file, 4 lines (updater network paths + matching test fixtures only):

- `rust/src/updater.rs:10` — `GITHUB_REPO` constant `"Finesssee/Win-CodexBar"` → `"nesszer/Win-CodexBar"` (feeds both `release_url` channels: stable `releases/latest` and beta `releases`, `updater.rs:116-126`).
- `rust/src/updater.rs:723,759,774` — test fixture `html_url` / expected download URL strings updated to match.

URL construction style preserved (`format!("https://api.github.com/repos/{}/releases...", GITHUB_REPO)`). No other Finesssee references touched: `rust/Cargo.toml:8` (manifest `repository` metadata, not updater network), `rust/installer/codexbar.iss:27-29`, `rust/wix/main.wxs:168` (installer metadata), `rust/CHANGELOG.md` (historical links), `apps/desktop-tauri` `validate_external_url` tests (generic URL validation, not updater).

## Test results

```
$ cargo fmt --all   (no output — clean)

$ cargo test --manifest-path rust/Cargo.toml
test result: ok. 213 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.05s
... (full run) ...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

$ cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 08s
```

`cargo test --manifest-path apps/desktop-tauri/src-tauri/Cargo.toml` + clippy not run separately: the Tauri shell consumes `codexbar::updater` via `codexbar::updater::check_for_updates_with_channel` etc. and contains no URL literals of its own (`grep Finesssee apps/desktop-tauri` → only generic `validate_external_url` tests, unaffected); updater code compiles/tests in the `rust` crate already covered above.

## Commit

`552129e40` — "Point updater release URLs at nesszer releases"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated application update checks to use the correct release repository.
  * Corrected expected release links for update verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->