### PR TITLE
Anchor docs-only regex alternatives

### DIFF
--- a/scripts/circleci-pr-common.ps1
+++ b/scripts/circleci-pr-common.ps1
@@ -19,7 +19,7 @@ function Test-DocsOnlyDiff {
     param([AllowEmptyCollection()][string[]]$ChangedFiles)
 
     $codeFiles = @(
-        $ChangedFiles | Where-Object { $_ -and ($_ -notmatch '^(docs/.*)|(.*\.md)$') }
+        $ChangedFiles | Where-Object { $_ -and ($_ -notmatch '^(docs/.*|.*\.md)$') }
     )
     return ($codeFiles.Count -eq 0)
 }


### PR DESCRIPTION
Anchor the docs-only diff regex alternatives so both anchors bind the full ignore set (docs/** plus any *.md suffix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined documentation-only change detection while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->