### PR TITLE
fix(opencodego): keep API percent in 0..=100 units

### DIFF
--- a/rust/src/providers/opencodego/usage_api.rs
+++ b/rust/src/providers/opencodego/usage_api.rs
@@ -99,7 +99,7 @@ fn api_window(
     now: DateTime<Utc>,
 ) -> Option<(f64, DateTime<Utc>)> {
     let object = names.iter().find_map(|name| usage.get(*name))?;
-    let mut percent = [
+    let percent = [
         "percent",
         "usagePercent",
         "usedPercent",
@@ -114,10 +114,10 @@ fn api_window(
                 .or_else(|| value.as_str().and_then(|text| text.trim().parse().ok()))
         })
     })?;
-    if (0.0..=1.0).contains(&percent) {
-        percent *= 100.0;
-    }
-    percent = percent.clamp(0.0, 100.0);
+    // GET /zen/go/v1/usage returns whole percentages in 0..=100 (including exact
+    // 1% / 0.5%). Do not treat values in (0, 1] as 0..=1 fractions: that turns
+    // a real 1% into a false 100% exhausted state (win-fork #247 / upstream #3216).
+    let percent = percent.clamp(0.0, 100.0);
     let reset = [
         "resetInSec",
         "resetInSeconds",
@@ -170,5 +170,37 @@ mod tests {
         assert!((snapshot.primary.used_percent - 12.0).abs() < 0.001);
         assert!((snapshot.secondary.as_ref().unwrap().used_percent - 8.0).abs() < 0.001);
         assert!((snapshot.tertiary.as_ref().unwrap().used_percent - 35.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn preserves_whole_percent_units_including_exact_one() {
+        let now = DateTime::parse_from_rfc3339("2026-08-31T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        // Live Go API shape: percent is already 0..=100. Exact 1 must stay 1%.
+        let text = r#"{"usage":{"rolling":{"status":"ok","percent":1,"resetsAt":"2026-08-31T17:12:09.085Z"},"weekly":{"status":"ok","percent":0,"resetsAt":"2026-09-07T00:00:00.085Z"},"monthly":{"status":"ok","percent":23,"resetsAt":"2026-09-20T04:39:33.085Z"}}}"#;
+        let snapshot = parse_usage_text(text, now).unwrap();
+        assert!(
+            (snapshot.primary.used_percent - 1.0).abs() < 0.001,
+            "rolling 1% must not be rescaled to 100%, got {}",
+            snapshot.primary.used_percent
+        );
+        assert!((snapshot.secondary.as_ref().unwrap().used_percent - 0.0).abs() < 0.001);
+        assert!((snapshot.tertiary.as_ref().unwrap().used_percent - 23.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn preserves_sub_one_percent_without_fraction_rescale() {
+        let now = DateTime::parse_from_rfc3339("2026-08-31T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let text = r#"{"usage":{"rolling":{"percent":0.5,"resetsAt":"2026-08-31T17:00:00Z"},"weekly":{"percent":100,"resetsAt":"2026-09-07T00:00:00Z"}}}"#;
+        let snapshot = parse_usage_text(text, now).unwrap();
+        assert!(
+            (snapshot.primary.used_percent - 0.5).abs() < 0.001,
+            "0.5% must stay 0.5, got {}",
+            snapshot.primary.used_percent
+        );
+        assert!((snapshot.secondary.as_ref().unwrap().used_percent - 100.0).abs() < 0.001);
     }
 }


### PR DESCRIPTION
﻿## Summary
- OpenCode Go `GET /zen/go/v1/usage` returns whole percentages (`percent: 1` means 1%).
- `usage_api.rs` still rescaled values in `(0, 1]` as fractions, so a real **1%** rolling window became a false **100% / Exhausted**.
- Same class of bug as #247 (web path was fixed earlier; API bearer path was not). Matches upstream CodexBar #3216.

## Test plan
- [x] Added regression tests for `percent: 1`, `0.5`, and full `100`
- [ ] `cargo test --lib providers::opencodego::usage_api`
- [ ] Live: `codexbar-cli usage -p opencodego` matches `https://opencode.ai/zen/go/v1/usage` and the Go dashboard when rolling is exactly 1%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OpenCode Go usage percentage reporting.
  * Usage values are now interpreted and displayed accurately, including exact whole-number values such as 1% and fractional values such as 0.5%.
  * Prevented percentage values from being incorrectly rescaled, improving accuracy for all supported usage levels.

* **Tests**
  * Added coverage for whole-number and fractional usage percentages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->