### PR TITLE
fix(chutes): keep usage percent in 0..=100 units

### DIFF
--- a/rust/src/providers/chutes/mod.rs
+++ b/rust/src/providers/chutes/mod.rs
@@ -152,9 +152,16 @@ fn percent_from_object(map: &serde_json::Map<String, Value>) -> Option<f64> {
         "percent_used",
         "percentUsed",
     ] {
-        if let Some(v) = map.get(key).and_then(Value::as_f64) {
-            return Some(if v <= 1.0 { v * 100.0 } else { v });
-        }
+        let Some(v) = map.get(key).and_then(Value::as_f64) else {
+            continue;
+        };
+        // Chutes usage/quota payloads (GET /users/me/subscription_usage, and
+        // whatever `collect_windows` recurses into) carry whole percent values
+        // in 0..=100 — no documented field is a 0..=1 fraction. Rescaling
+        // 0..=1 as fractions turned a real 1% into a false 100% exhausted
+        // state (#408; same class as #247 / upstream #3216, fixed for
+        // opencodego in #407).
+        return Some(v.clamp(0.0, 100.0));
     }
     let used = first_f64(map, &["used", "usage", "current_usage", "currentUsage"]);
     let limit = first_f64(

--- a/rust/src/providers/chutes/mod.rs
+++ b/rust/src/providers/chutes/mod.rs
@@ -361,4 +361,28 @@ mod tests {
             Some(Utc.with_ymd_and_hms(2026, 8, 1, 0, 0, 0).unwrap())
         );
     }
+
+    #[test]
+    fn usage_percent_one_stays_one() {
+        let snapshot = snapshot_from_usage(&serde_json::json!({
+            "quotas": [{"usage_percent": 1, "limit": 100}]
+        }));
+        assert_eq!(snapshot.primary.used_percent, 1.0);
+    }
+
+    #[test]
+    fn usage_percent_half_stays_half() {
+        let snapshot = snapshot_from_usage(&serde_json::json!({
+            "quotas": [{"usage_percent": 0.5, "limit": 100}]
+        }));
+        assert_eq!(snapshot.primary.used_percent, 0.5);
+    }
+
+    #[test]
+    fn usage_percent_hundred_stays_hundred() {
+        let snapshot = snapshot_from_usage(&serde_json::json!({
+            "quotas": [{"usage_percent": 100, "limit": 100}]
+        }));
+        assert_eq!(snapshot.primary.used_percent, 100.0);
+    }
 }


### PR DESCRIPTION
## Why

`percent_from_object` in `rust/src/providers/chutes/mod.rs` applied an ambiguous fraction heuristic: any value `<= 1.0` found under the `usage_percent` / `usagePercent` / `percent_used` / `percentUsed` keys was rescaled by 100. A real whole **1%** satisfied `v <= 1.0` and became a false **100%** exhausted state; a real 0.5% became 50%. This is the same bug class already fixed for the OpenCode Go API path in #407 (and #247 / upstream steipete/CodexBar#3216 before that).

Fixes #408.

### Unit-contract evidence

- The Chutes OpenAPI spec (`https://api.chutes.ai/openapi.json`) defines `GET /users/me/subscription_usage` but leaves its 200 response schema empty (`{}`); no schema in `components/schemas` contains a percent-named field. The official docs (`https://chutes.ai/docs/api-reference/users`, `https://chutes.ai/llms-full.txt`) likewise document no percent field for any usage/quota endpoint.
- The best available redacted live payload (sigmanor/vscode-chutes-quota#5, 2026-04, corroborated by steipete/CodexBar#176) shows the documented shape carries only counts: `"four_hour": {"usage": 0.86, "cap": 4.17, "remaining": 3.31, "reset_at": ...}` (USD-denominated usage vs cap) — no percent keys at all.
- Conclusion: no Chutes field is documented as a 0..=1 fraction, so the whole-percentage interpretation is the best-supported contract. Because `percent_from_object` is reached via `collect_windows`, which recursively scans arbitrary nested JSON, the key list may fire on payloads the docs never mention; the comment at the parse site states this explicitly. Values are now clamped to `0..=100` instead of rescaled.

## Scope

- `rust/src/providers/chutes/mod.rs` only: dropped the `if v <= 1.0 { v * 100.0 }` rescale in `percent_from_object`, replaced with `v.clamp(0.0, 100.0)` plus a unit-contract comment citing #408 / #407 / #247 / upstream #3216. Kept the existing four-key scan unchanged.
- Added three regression tests in the existing `mod tests`: `usage_percent` of `1` stays 1, `0.5` stays 0.5, `100` stays 100 (nested inside a quota object, matching existing test style).
- No new dependencies, no cross-provider changes.

## Tradeoffs

- Public evidence for the unit contract is indirect (empty response schema; redacted third-party payload; no official percent-field docs). If Chutes ever ships a genuinely fractional field under one of these keys, it will now be read as a whole percent and clamped — accepted, because the previous heuristic was strictly worse (false 100% on a real 1%) and matches the precedent set in #407.

## Blast Radius

- Single provider module; only the Chutes provider's percent extraction changes. The used/limit ratio fallback path is untouched. Other providers unaffected. No UI, tray, or shell changes; no schema/DTO changes.

## Verification

- `cargo test --manifest-path rust/Cargo.toml --lib providers::chutes` — all 7 chutes tests pass, including the 3 new regression tests (test-first: they were committed failing, with `1 → 100` and `0.5 → 50` reproducing the bug before the fix).
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` — exit 0, no warnings.
- `cargo fmt --all` applied; `git diff --stat` shows only `rust/src/providers/chutes/mod.rs` (+13/−3 across both commits).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Chutes usage percentage handling so values are interpreted consistently on a 0–100 scale.
  * Usage percentages are now safely limited to the valid 0–100 range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->