### PR TITLE
fix(providers): Alibaba weekly-only Token Plan and Grok SuperGrok pace

### DIFF
--- a/rust/src/providers/alibabatokenplan/mod.rs
+++ b/rust/src/providers/alibabatokenplan/mod.rs
@@ -319,18 +319,29 @@ impl AlibabaTokenPlanProvider {
                 ),
             )
         });
-        let primary = five_hour.or(legacy).ok_or_else(|| {
-            ProviderError::Parse("Alibaba Token Plan quota totals missing".into())
-        })?;
-        let mut usage = UsageSnapshot::new(primary);
-
-        if let Some(weekly_percent) = snapshot.weekly_used_percent {
-            usage = usage.with_secondary(RateWindow::with_details(
-                weekly_percent,
+        let weekly = snapshot.weekly_used_percent.map(|percent| {
+            RateWindow::with_details(
+                percent,
                 Some(WEEKLY_MINUTES),
                 snapshot.weekly_resets_at,
-                quota_detail_percent(weekly_percent, snapshot.weekly_total_quota),
-            ));
+                quota_detail_percent(percent, snapshot.weekly_total_quota),
+            )
+        });
+        // Prefer the 5-hour window, then the Team/legacy credit envelope. Personal/Solo
+        // payloads sometimes expose only `per1WeekPercentage`; promote that window to
+        // primary instead of failing the whole fetch.
+        let (primary, secondary) = match (five_hour.or(legacy), weekly) {
+            (Some(primary), secondary) => (primary, secondary),
+            (None, Some(weekly)) => (weekly, None),
+            (None, None) => {
+                return Err(ProviderError::Parse(
+                    "Alibaba Token Plan quota totals missing".into(),
+                ));
+            }
+        };
+        let mut usage = UsageSnapshot::new(primary);
+        if let Some(secondary) = secondary {
+            usage = usage.with_secondary(secondary);
         }
 
         if let Some(plan) = snapshot.plan_name.filter(|plan| !plan.trim().is_empty()) {

--- a/rust/src/providers/alibabatokenplan/personal.rs
+++ b/rust/src/providers/alibabatokenplan/personal.rs
@@ -542,4 +542,43 @@ mod tests {
         );
         assert_eq!(usage_snap.login_method.as_deref(), Some("Pro"));
     }
+
+    #[test]
+    fn weekly_only_personal_payload_promotes_weekly_window() {
+        let usage = serde_json::json!({
+            "code": "200",
+            "data": {
+                "DataV2": {
+                    "ret": [{}],
+                    "data": {
+                        "msg": "",
+                        "code": "SUCCESS",
+                        "data": {
+                            "per1WeekResetTime": 1788640320000_i64,
+                            "per1WeekPercentage": 0.4145182484706
+                        },
+                        "success": true
+                    }
+                },
+                "success": true,
+                "httpStatus": 200,
+                "errorCode": "",
+                "api": "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/usage",
+                "errorMsg": ""
+            },
+            "successResponse": true
+        });
+
+        let snapshot = parse_personal_usage(usage.to_string().as_bytes(), None, None).unwrap();
+        assert!(snapshot.five_hour_used_percent.is_none());
+        assert!((snapshot.weekly_used_percent.unwrap() - 41.45182484706).abs() < 1e-9);
+        assert!(snapshot.weekly_resets_at.is_some());
+
+        let usage_snap: UsageSnapshot =
+            AlibabaTokenPlanProvider::snapshot_to_usage(snapshot).unwrap();
+        assert!((usage_snap.primary.used_percent - 41.45182484706).abs() < 1e-9);
+        assert_eq!(usage_snap.primary.window_minutes, Some(10080));
+        assert!(usage_snap.secondary.is_none());
+        assert_eq!(usage_snap.login_method.as_deref(), Some("Personal"));
+    }
 }

--- a/rust/src/providers/grok/mod.rs
+++ b/rust/src/providers/grok/mod.rs
@@ -33,7 +33,7 @@ impl GrokProvider {
             metadata: ProviderMetadata {
                 id: ProviderId::Grok,
                 display_name: "Grok",
-                session_label: "Monthly",
+                session_label: "Weekly",
                 weekly_label: "On-demand",
                 supports_opus: false,
                 supports_credits: false,
@@ -443,10 +443,17 @@ fn result_from_billing(
     team_id: Option<String>,
     login_method: Option<String>,
 ) -> ProviderFetchResult {
-    // Upstream #2431 / #2566: do not infer windowMinutes from time-until-reset.
-    // A monthly quota near its reset would otherwise be misclassified as weekly.
+    // grok.com SuperGrok quota is a 7-day rolling limit. Leaving window_minutes
+    // unset hid pace/budgets (UsagePace and getPaceBudget need a duration) and
+    // labeled the card Monthly. Do not infer cadence from time-until-reset.
+    const GROK_WEEKLY_MINUTES: u32 = 7 * 24 * 60;
     let primary = match billing.used_percent {
-        Some(used_percent) => RateWindow::with_details(used_percent, None, billing.resets_at, None),
+        Some(used_percent) => RateWindow::with_details(
+            used_percent,
+            Some(GROK_WEEKLY_MINUTES),
+            billing.resets_at,
+            None,
+        ),
         None => {
             let mut window = RateWindow::informational("Usage unavailable");
             window.resets_at = billing.resets_at;
@@ -794,8 +801,7 @@ mod tests {
     }
 
     #[test]
-    fn billing_snapshot_leaves_window_minutes_unset() {
-        // A monthly quota with six days left must not be reported as weekly.
+    fn billing_snapshot_marks_supergrok_as_weekly() {
         let resets = Utc::now() + chrono::Duration::days(6);
         let result = result_from_billing(
             GrokBillingSnapshot {
@@ -807,9 +813,11 @@ mod tests {
             None,
             Some("SuperGrok".into()),
         );
-        assert_eq!(result.usage.primary.window_minutes, None);
+        assert_eq!(result.usage.primary.window_minutes, Some(7 * 24 * 60));
         assert_eq!(result.usage.primary.resets_at, Some(resets));
         assert_eq!(result.usage.login_method.as_deref(), Some("SuperGrok"));
+        let pace = crate::core::UsagePace::weekly(&result.usage.primary, None, 7 * 24 * 60);
+        assert!(pace.is_some(), "weekly window + reset must yield pace");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two provider usage-window fixes observed on a live Windows install of Win-CodexBar against Bailian Personal/Solo and grok.com SuperGrok.

1. **Alibaba Token Plan (Personal/Solo)** — Bailian can return a successful `usage` envelope with only `per1WeekPercentage` (no `per5HourPercentage`). `snapshot_to_usage` previously required a 5-hour or Team/legacy credit window as primary, so the fetch failed with `Alibaba Token Plan quota totals missing` even though weekly quota was present. Mirror Qwen Cloud: if only the weekly window exists, promote it to primary.

2. **Grok SuperGrok** — grok.com shows **Weekly SuperGrok Limit**. CodexBar left `window_minutes` unset (to avoid inferring cadence from time-until-reset), so the card was labeled Monthly and `UsagePace` / `getPaceBudget` produced no pace. Set SuperGrok billing to a 7-day window (`10080` minutes) without inferring from reset remaining.

Related upstream discussion of weekly-only Token Plan windows: https://github.com/steipete/CodexBar/issues/3020

## Related issue

No existing Win-CodexBar issue. This is the Windows-side gap vs the weekly-only Token Plan shape described in steipete/CodexBar#3020, plus Grok SuperGrok weekly pace.

## Affected areas

- [x] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [x] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

- [ ] `powershell.exe -ExecutionPolicy Bypass -NoProfile -File scripts\local-check.ps1` — not run in full (hosted PR check should cover it). Focused tests below.
- [ ] Full `local-check.ps1 -All` not run (not a release PR).
- [ ] Installer/release scripts not applicable.
- [x] Thermo-nuclear pass on this diff: provider-local only, no shared factory/settings changes, no secrets, tests sit next to the parsers, Grok does not infer cadence from remaining time.
- [x] Other:
  - `cargo test -p codexbar weekly_only_personal_payload`
  - `cargo test -p codexbar billing_snapshot_marks_supergrok_as_weekly`
  - Live `codexbar-cli diagnose -p alibabatokenplan --source web` → weekly primary, no parse error
  - Live `codexbar-cli diagnose -p grok --source web` → `window_minutes: 10080`

## UI / tray proof

- [ ] Not applicable
- [ ] CUA Driver visual proof attached
- [x] CUA Driver could not be used; equivalent manual proof and explanation attached

CUA Driver is not available in this contributor environment. Manual proof is the diagnose JSON above (Alibaba weekly-only no longer fails; Grok reports a 7-day window matching grok.com Weekly SuperGrok Limit). Please re-check the tray cards on a Windows host: Alibaba Token Plan should show the weekly bar; Grok should show Weekly plus pace.

## Notes for reviewers

- CONTRIBUTING asks for one behavior per PR. These are two independent provider fixes in one branch because they were validated together on the same Windows install. Happy to split if preferred.
- Grok still does **not** classify monthly vs weekly from time-until-reset; SuperGrok's grok.com billing surface is weekly.
- Alibaba Team / 5-hour+weekly Personal paths are unchanged (existing fixture still expects 5h primary + weekly secondary).