### PR TITLE
fix(alibabatokenplan): promote weekly-only Personal usage to primary

### DIFF
--- a/rust/src/providers/alibabatokenplan/mod.rs
+++ b/rust/src/providers/alibabatokenplan/mod.rs
@@ -319,18 +319,29 @@ impl AlibabaTokenPlanProvider {
                 ),
             )
         });
-        let primary = five_hour.or(legacy).ok_or_else(|| {
-            ProviderError::Parse("Alibaba Token Plan quota totals missing".into())
-        })?;
-        let mut usage = UsageSnapshot::new(primary);
-
-        if let Some(weekly_percent) = snapshot.weekly_used_percent {
-            usage = usage.with_secondary(RateWindow::with_details(
-                weekly_percent,
+        let weekly = snapshot.weekly_used_percent.map(|percent| {
+            RateWindow::with_details(
+                percent,
                 Some(WEEKLY_MINUTES),
                 snapshot.weekly_resets_at,
-                quota_detail_percent(weekly_percent, snapshot.weekly_total_quota),
-            ));
+                quota_detail_percent(percent, snapshot.weekly_total_quota),
+            )
+        });
+        // Prefer the 5-hour window, then the Team/legacy credit envelope. Personal/Solo
+        // payloads sometimes expose only `per1WeekPercentage`; promote that window to
+        // primary instead of failing the whole fetch.
+        let (primary, secondary) = match (five_hour.or(legacy), weekly) {
+            (Some(primary), secondary) => (primary, secondary),
+            (None, Some(weekly)) => (weekly, None),
+            (None, None) => {
+                return Err(ProviderError::Parse(
+                    "Alibaba Token Plan quota totals missing".into(),
+                ));
+            }
+        };
+        let mut usage = UsageSnapshot::new(primary);
+        if let Some(secondary) = secondary {
+            usage = usage.with_secondary(secondary);
         }
 
         if let Some(plan) = snapshot.plan_name.filter(|plan| !plan.trim().is_empty()) {

--- a/rust/src/providers/alibabatokenplan/personal.rs
+++ b/rust/src/providers/alibabatokenplan/personal.rs
@@ -542,4 +542,43 @@ mod tests {
         );
         assert_eq!(usage_snap.login_method.as_deref(), Some("Pro"));
     }
+
+    #[test]
+    fn weekly_only_personal_payload_promotes_weekly_window() {
+        let usage = serde_json::json!({
+            "code": "200",
+            "data": {
+                "DataV2": {
+                    "ret": [{}],
+                    "data": {
+                        "msg": "",
+                        "code": "SUCCESS",
+                        "data": {
+                            "per1WeekResetTime": 1788640320000_i64,
+                            "per1WeekPercentage": 0.4145182484706
+                        },
+                        "success": true
+                    }
+                },
+                "success": true,
+                "httpStatus": 200,
+                "errorCode": "",
+                "api": "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/usage",
+                "errorMsg": ""
+            },
+            "successResponse": true
+        });
+
+        let snapshot = parse_personal_usage(usage.to_string().as_bytes(), None, None).unwrap();
+        assert!(snapshot.five_hour_used_percent.is_none());
+        assert!((snapshot.weekly_used_percent.unwrap() - 41.45182484706).abs() < 1e-9);
+        assert!(snapshot.weekly_resets_at.is_some());
+
+        let usage_snap: UsageSnapshot =
+            AlibabaTokenPlanProvider::snapshot_to_usage(snapshot).unwrap();
+        assert!((usage_snap.primary.used_percent - 41.45182484706).abs() < 1e-9);
+        assert_eq!(usage_snap.primary.window_minutes, Some(10080));
+        assert!(usage_snap.secondary.is_none());
+        assert_eq!(usage_snap.login_method.as_deref(), Some("Personal"));
+    }
 }


### PR DESCRIPTION
## Summary

Bailian Personal/Solo can return a successful `usage` envelope with only `per1WeekPercentage` (no `per5HourPercentage`). `snapshot_to_usage` required a 5-hour or Team/legacy credit window as primary, so the fetch failed with `Alibaba Token Plan quota totals missing` even though weekly quota was present.

Promote the weekly window to primary when that is the only usage window, matching Qwen Cloud.

Related upstream discussion of weekly-only Token Plan windows: https://github.com/steipete/CodexBar/issues/3020

## Related issue

No existing Win-CodexBar issue.

## Affected areas

- [x] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [x] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

- [ ] `scripts\local-check.ps1` not run in full; hosted PR check should cover it.
- [ ] Not a release PR.
- [x] Focused tests: `cargo test -p codexbar weekly_only_personal_payload`
- [x] Live `codexbar-cli diagnose -p alibabatokenplan --source web` no longer parse-fails on a weekly-only Personal payload.
- [x] Thermo-nuclear: provider-local only; Team / 5h+weekly Personal fixtures unchanged.

## UI / tray proof

- [x] CUA Driver could not be used; equivalent manual proof and explanation attached

CUA Driver is not available here. Manual proof is the diagnose path above. Please confirm the tray card shows the weekly bar on Windows.

## Notes for reviewers

Independent of the Grok cadence PR. Existing 5-hour + weekly Personal fixture still expects 5h primary and weekly secondary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed usage reporting for accounts that provide only weekly quota data.
  * Weekly usage is now displayed as the primary usage window when five-hour and legacy quota data are unavailable.
  * Preserved existing prioritization when five-hour or legacy quota information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->