### PR TITLE
fix(grok): classify Weekly/Monthly from reset cycle for pace

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
@@ -252,6 +252,19 @@ pub(crate) fn filter_hidden_codex_spark_rows(
     }
 }
 
+fn grok_aware_primary_label(
+    id: ProviderId,
+    metadata: &ProviderMetadata,
+    window: &RateWindow,
+) -> String {
+    if id == ProviderId::Grok {
+        if let Some(label) = codexbar::providers::grok::display_label(window, chrono::Utc::now()) {
+            return label.to_string();
+        }
+    }
+    metadata.session_label.to_string()
+}
+
 pub(crate) fn pace_stage_str(stage: codexbar::core::PaceStage) -> &'static str {
     use codexbar::core::PaceStage;
     match stage {
@@ -326,7 +339,7 @@ impl ProviderUsageSnapshot {
             provider_id: id.cli_name().to_string(),
             display_name: id.display_name().to_string(),
             primary: primary_snap,
-            primary_label: Some(metadata.session_label.to_string()),
+            primary_label: Some(grok_aware_primary_label(id, metadata, &usage.primary)),
             secondary: secondary_snap,
             secondary_label: usage
                 .secondary

--- a/rust/src/cli/usage.rs
+++ b/rust/src/cli/usage.rs
@@ -1,5 +1,6 @@
 //! Usage command implementation
 
+use chrono::Utc;
 use clap::Args;
 use serde::Serialize;
 
@@ -480,7 +481,7 @@ pub fn render_text_with_status(
     lines.push(render_usage_header(provider, result, status, use_color));
     append_status_line(&mut lines, status);
     append_account_lines(&mut lines, &result.usage);
-    append_usage_window_lines(&mut lines, &result.usage, &metadata, use_color);
+    append_usage_window_lines(&mut lines, provider, &result.usage, &metadata, use_color);
     append_cost_line(&mut lines, result.cost.as_ref());
 
     lines.join("\n")
@@ -550,15 +551,29 @@ fn append_account_lines(lines: &mut Vec<String>, usage: &UsageSnapshot) {
 
 fn append_usage_window_lines(
     lines: &mut Vec<String>,
+    provider: ProviderId,
     usage: &UsageSnapshot,
     metadata: &crate::core::ProviderMetadata,
     use_color: bool,
 ) {
-    append_window_line(lines, metadata.session_label, &usage.primary, use_color);
+    let primary_label = if provider == ProviderId::Grok {
+        crate::providers::grok::display_label(&usage.primary, Utc::now())
+            .unwrap_or(metadata.session_label)
+    } else {
+        metadata.session_label
+    };
+    append_window_line(lines, primary_label, &usage.primary, use_color);
     // Upstream 0.50.1 #2957: pace for the 5-hour session window.
-    if usage.primary.window_minutes == Some(crate::core::SESSION_WINDOW_MINUTES)
-        && let Some(pace) =
-            UsagePace::weekly(&usage.primary, None, crate::core::SESSION_WINDOW_MINUTES)
+    let pace_minutes = usage
+        .primary
+        .window_minutes
+        .filter(|minutes| {
+            *minutes == crate::core::SESSION_WINDOW_MINUTES
+                || *minutes == crate::core::WEEKLY_WINDOW_MINUTES
+                || *minutes >= crate::core::MONTHLY_WINDOW_MINUTES
+        });
+    if let Some(minutes) = pace_minutes
+        && let Some(pace) = UsagePace::weekly(&usage.primary, None, minutes)
     {
         lines.push(format!(
             "  Pace:    {} {}",

--- a/rust/src/providers/grok/mod.rs
+++ b/rust/src/providers/grok/mod.rs
@@ -33,7 +33,7 @@ impl GrokProvider {
             metadata: ProviderMetadata {
                 id: ProviderId::Grok,
                 display_name: "Grok",
-                session_label: "Monthly",
+                session_label: "Credits",
                 weekly_label: "On-demand",
                 supports_opus: false,
                 supports_credits: false,
@@ -436,6 +436,49 @@ struct GrokBillingSnapshot {
     resets_at: Option<DateTime<Utc>>,
 }
 
+/// Upstream `GrokProviderDescriptor.primaryLabel(duration:)`: round remaining
+/// time to days, then Weekly for 4...12 and Monthly for 20...45.
+pub fn primary_label_for_duration(seconds: f64) -> Option<&'static str> {
+    if seconds <= 3600.0 {
+        return None;
+    }
+    let days = (seconds / 86_400.0).round() as i64;
+    if (4..=12).contains(&days) {
+        Some("Weekly")
+    } else if (20..=45).contains(&days) {
+        Some("Monthly")
+    } else {
+        None
+    }
+}
+
+/// Upstream `displayLabel`: prefer an explicit duration/reset cycle, else keep
+/// Weekly near the end of an untyped credits window (#2929).
+pub fn display_label(window: &RateWindow, now: DateTime<Utc>) -> Option<&'static str> {
+    if let Some(minutes) = window.window_minutes {
+        return primary_label_for_duration(f64::from(minutes) * 60.0);
+    }
+    if let Some(resets_at) = window.resets_at {
+        if let Some(label) = primary_label_for_duration((resets_at - now).num_seconds() as f64) {
+            return Some(label);
+        }
+        return Some("Weekly");
+    }
+    None
+}
+
+fn grok_window_minutes(resets_at: Option<DateTime<Utc>>, now: DateTime<Utc>) -> Option<u32> {
+    let resets_at = resets_at?;
+    match primary_label_for_duration((resets_at - now).num_seconds() as f64) {
+        Some("Weekly") => Some(crate::core::WEEKLY_WINDOW_MINUTES),
+        Some("Monthly") => {
+            RateWindow::monthly_window_minutes(Some(resets_at)).or(Some(crate::core::MONTHLY_WINDOW_MINUTES))
+        }
+        // Untyped reset (e.g. 2 days left in SuperGrok weekly): keep weekly so pace works.
+        _ => Some(crate::core::WEEKLY_WINDOW_MINUTES),
+    }
+}
+
 fn result_from_billing(
     billing: GrokBillingSnapshot,
     source_label: &str,
@@ -443,10 +486,33 @@ fn result_from_billing(
     team_id: Option<String>,
     login_method: Option<String>,
 ) -> ProviderFetchResult {
-    // Upstream #2431 / #2566: do not infer windowMinutes from time-until-reset.
-    // A monthly quota near its reset would otherwise be misclassified as weekly.
+    result_from_billing_at(
+        billing,
+        source_label,
+        email,
+        team_id,
+        login_method,
+        Utc::now(),
+    )
+}
+
+fn result_from_billing_at(
+    billing: GrokBillingSnapshot,
+    source_label: &str,
+    email: Option<String>,
+    team_id: Option<String>,
+    login_method: Option<String>,
+    now: DateTime<Utc>,
+) -> ProviderFetchResult {
+    // Upstream docs/grok.md: live bar is Credits; Weekly/Monthly come from whether
+    // resetsAt matches a common cycle. Win-CodexBar also needs window_minutes for pace.
     let primary = match billing.used_percent {
-        Some(used_percent) => RateWindow::with_details(used_percent, None, billing.resets_at, None),
+        Some(used_percent) => RateWindow::with_details(
+            used_percent,
+            grok_window_minutes(billing.resets_at, now),
+            billing.resets_at,
+            None,
+        ),
         None => {
             let mut window = RateWindow::informational("Usage unavailable");
             window.resets_at = billing.resets_at;
@@ -794,10 +860,10 @@ mod tests {
     }
 
     #[test]
-    fn billing_snapshot_leaves_window_minutes_unset() {
-        // A monthly quota with six days left must not be reported as weekly.
-        let resets = Utc::now() + chrono::Duration::days(6);
-        let result = result_from_billing(
+    fn billing_snapshot_classifies_weekly_from_reset_distance() {
+        let now = Utc::now();
+        let resets = now + chrono::Duration::days(6);
+        let result = result_from_billing_at(
             GrokBillingSnapshot {
                 used_percent: Some(12.0),
                 resets_at: Some(resets),
@@ -806,10 +872,71 @@ mod tests {
             None,
             None,
             Some("SuperGrok".into()),
+            now,
         );
-        assert_eq!(result.usage.primary.window_minutes, None);
-        assert_eq!(result.usage.primary.resets_at, Some(resets));
-        assert_eq!(result.usage.login_method.as_deref(), Some("SuperGrok"));
+        assert_eq!(
+            result.usage.primary.window_minutes,
+            Some(crate::core::WEEKLY_WINDOW_MINUTES)
+        );
+        assert_eq!(
+            display_label(&result.usage.primary, now),
+            Some("Weekly")
+        );
+        let pace = crate::core::UsagePace::weekly(
+            &result.usage.primary,
+            Some(now),
+            crate::core::WEEKLY_WINDOW_MINUTES,
+        );
+        assert!(pace.is_some(), "weekly window + reset must yield pace");
+    }
+
+    #[test]
+    fn billing_snapshot_classifies_monthly_from_reset_distance() {
+        let now = Utc::now();
+        let resets = now + chrono::Duration::days(28);
+        let result = result_from_billing_at(
+            GrokBillingSnapshot {
+                used_percent: Some(40.0),
+                resets_at: Some(resets),
+            },
+            "cli",
+            None,
+            None,
+            Some("SuperGrok Heavy".into()),
+            now,
+        );
+        assert_eq!(display_label(&result.usage.primary, now), Some("Monthly"));
+        assert!(
+            result.usage.primary.window_minutes.unwrap() >= 27 * 24 * 60,
+            "monthly window should be a calendar month, got {:?}",
+            result.usage.primary.window_minutes
+        );
+    }
+
+    #[test]
+    fn untyped_near_reset_keeps_weekly_label_and_duration() {
+        let now = Utc::now();
+        let resets = now + chrono::Duration::days(2);
+        assert_eq!(primary_label_for_duration(2.0 * 86_400.0), None);
+        let result = result_from_billing_at(
+            GrokBillingSnapshot {
+                used_percent: Some(80.0),
+                resets_at: Some(resets),
+            },
+            "web",
+            None,
+            None,
+            Some("SuperGrok".into()),
+            now,
+        );
+        assert_eq!(
+            result.usage.primary.window_minutes,
+            Some(crate::core::WEEKLY_WINDOW_MINUTES)
+        );
+        assert_eq!(
+            display_label(&result.usage.primary, now),
+            Some("Weekly")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

grok.com SuperGrok shows a weekly limit, but Win-CodexBar left `window_minutes` unset so the card looked Monthly and pace/budgets did not compute.

Match upstream `docs/grok.md` / `GrokProviderDescriptor.primaryLabel`:

- Keep the registered bar name **Credits**.
- Label **Weekly** when remaining time rounds to 4–12 days, **Monthly** for 20–45 days.
- Set `window_minutes` from that cycle so `UsagePace` and `getPaceBudget` work.
- Near-reset untyped windows keep Weekly (upstream #2929) instead of hard-coding 7 days on CLI/OAuth monthly credits.

## Related issue

No existing Win-CodexBar issue.

## Affected areas

- [x] Tray panel
- [ ] Settings UI
- [ ] Config file / settings persistence
- [x] CLI
- [x] Provider-specific behavior
- [ ] Installer / release packaging
- [ ] Startup / background behavior
- [ ] Documentation
- [ ] Other:

## Validation

- [ ] `scripts\local-check.ps1` not run in full; hosted PR check should cover it.
- [ ] Not a release PR.
- [x] `cargo test -p codexbar billing_snapshot_classifies`
- [x] `cargo test -p codexbar untyped_near_reset_keeps_weekly`
- [x] Live `codexbar-cli diagnose -p grok --source web` reports `window_minutes: 10080` when reset is ~6 days out.
- [x] Thermo-nuclear: classification lives in the Grok module; bridge/CLI only ask Grok for the display label.

## UI / tray proof

- [x] CUA Driver could not be used; equivalent manual proof and explanation attached

CUA Driver is not available here. Manual proof is diagnose JSON (weekly window when grok.com shows Weekly SuperGrok Limit). Please confirm the tray card shows Weekly plus pace on Windows.

## Notes for reviewers

Independent of the Alibaba Token Plan weekly-only PR. Does **not** infer cadence from a hard-coded 7-day constant on every billing path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Usage displays now identify primary credits more accurately.
  - Provider-specific labels are shown when available, with clearer fallback labels otherwise.
  - Usage windows are categorized more reliably as session, weekly, or monthly based on reset timing.
  - Weekly and monthly usage pacing now appears alongside session pacing.
  - Reset times and calendar-based monthly periods are handled more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->