### PR TITLE
fix(http): enable reqwest http2 to avoid Cloudflare 403 on cursor.com

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3907,6 +3907,7 @@ dependencies = [
  "cookie_store",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,4 +1,4 @@
-[package]
+﻿[package]
 name = "codexbar"
 version = "0.55.0"
 edition = "2024"
@@ -20,7 +20,7 @@ default = []
 tokio = { version = "1", features = ["full"] }
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json", "cookies", "rustls-tls", "stream"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "cookies", "rustls-tls", "stream", "http2"], default-features = false }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- CodexBar builds reqwest **without the `http2` feature**, so ALPN negotiates **HTTP/1.1** for cursor.com.
- Cloudflare (in front of cursor.com) now challenges HTTP/1.1 requests that lack browser TLS fingerprints with a **403 HTML challenge page**, which `fetch_usage_summary` maps to `ProviderError::AuthRequired`.
- Result: the Cursor provider shows **"login required"** even though the `WorkosCursorSessionToken` rebuilt from the Cursor desktop app's `state.vscdb` is perfectly valid (the same token returns 200 over HTTP/2).

## Root cause verified experimentally
Using an isolated probe with the identical token and cookie header:

| reqwest features | HTTP version | result |
|---|---|---|
| `json, cookies, rustls-tls, stream` (current) | HTTP/1.1 | **403** (CF challenge HTML) |
| `json, cookies, rustls-tls, stream, http2` | HTTP/2 | **200** |

Adding a browser User-Agent to the HTTP/1.1 request does **not** help - only upgrading to HTTP/2 does.

## Fix
Add `"http2"` to the reqwest feature list in `rust/Cargo.toml` (one line). After rebuilding, `codexbar-cli usage --provider cursor` shows the account, plan and usage percentages again, and the desktop app logs `Stored cookie header to cache provider=cursor source="cursor-app"` (successful app-session fetch).

## Test plan
- [x] `cargo build --release` succeeds with the new feature
- [x] `codexbar-cli usage --provider cursor --source auto` returns 200 + parsed usage (previously 401/403)
- [x] Desktop app refresh succeeds and persists the validated app session


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Enabled HTTP/2 support for network requests.
  * Updated package metadata encoding to include a UTF-8 BOM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->