### PR TITLE
Stabilize Windows CI baseline

### DIFF
--- a/rust/src/host/command_runner.rs
+++ b/rust/src/host/command_runner.rs
@@ -159,12 +159,16 @@ impl CommandRunner {
         let (output, stderr, timed_out) = match self.capture_output(&mut child, options, deadline) {
             Ok(captured) => captured,
             Err(e) => {
-                let _exit_code = Self::finish_child(&mut child);
+                let _exit_code = Self::terminate_child(&mut child);
                 return Err(e);
             }
         };
 
-        let exit_code = Self::finish_child(&mut child);
+        let exit_code = if timed_out {
+            Self::terminate_child(&mut child)
+        } else {
+            Self::finish_child_after_eof(&mut child)
+        };
 
         Ok(CommandResult {
             text: output,
@@ -268,11 +272,12 @@ impl CommandRunner {
     /// Windows is the motivating case: PowerShell tears down its console
     /// handles slightly before the process object transitions to signaled, so
     /// a single `try_wait` right after capture sees `Ok(None)` even though the
-    /// process exited successfully milliseconds later. Waiting (instead of
-    /// immediately killing) preserves the real exit code.
-    const EXIT_GRACE_PERIOD: Duration = Duration::from_millis(250);
+    /// process exited successfully shortly afterward. Hosted Windows runners
+    /// have occasionally exceeded 250 ms here; keep the wait bounded but long
+    /// enough to preserve the real exit code instead of killing a clean exit.
+    const EXIT_GRACE_PERIOD: Duration = Duration::from_secs(1);
 
-    fn finish_child(child: &mut Child) -> Option<i32> {
+    fn finish_child_after_eof(child: &mut Child) -> Option<i32> {
         let mut remaining = Self::EXIT_GRACE_PERIOD;
         loop {
             match child.try_wait() {
@@ -287,10 +292,13 @@ impl CommandRunner {
             std::thread::sleep(step);
             remaining -= step;
         }
-        // Teardown after timeout/capture or a transient try_wait error
-        // (e.g. ECHILD/handle race). If the process already exited, kill
-        // fails and `wait` still yields the true exit status; when the kill
-        // lands, the code is ours and already reported separately.
+        Self::terminate_child(child)
+    }
+
+    /// Terminate a command whose capture ended because of timeout/error.
+    /// Do not apply the clean-EOF grace here: the command has already exceeded
+    /// its execution contract and should be torn down immediately.
+    fn terminate_child(child: &mut Child) -> Option<i32> {
         let killed = child.kill().is_ok();
         let reaped = child.wait().ok();
         if killed {
@@ -581,7 +589,7 @@ mod tests {
                 "-NoProfile".to_string(),
                 "-NonInteractive".to_string(),
                 "-Command".to_string(),
-                "Start-Sleep -Seconds 5".to_string(),
+                "Start-Sleep -Seconds 30".to_string(),
             ],
             ..CommandOptions::default()
         };

--- a/rust/src/providers/crof/mod.rs
+++ b/rust/src/providers/crof/mod.rs
@@ -52,7 +52,11 @@ impl CrofProvider {
     }
 
     fn api_key(api_key: Option<&str>) -> Result<String, ProviderError> {
-        super_key(api_key, CROF_CREDENTIAL_TARGET, &["CROF_API_KEY", "CROFAI_API_KEY"])
+        super_key(
+            api_key,
+            CROF_CREDENTIAL_TARGET,
+            &["CROF_API_KEY", "CROFAI_API_KEY"],
+        )
     }
 
     async fn fetch_api(&self, api_key: &str) -> Result<UsageSnapshot, ProviderError> {
@@ -73,7 +77,8 @@ impl CrofProvider {
         if status == reqwest::StatusCode::FORBIDDEN {
             if body.contains("cloudflare") || body.contains("Error 1010") {
                 return Err(ProviderError::Other(
-                    "Crof usage API blocked by Cloudflare (1010). Retry from the desktop app.".into(),
+                    "Crof usage API blocked by Cloudflare (1010). Retry from the desktop app."
+                        .into(),
                 ));
             }
             return Err(ProviderError::AuthRequired);
@@ -84,9 +89,8 @@ impl CrofProvider {
             )));
         }
 
-        let usage: CrofUsageResponse = serde_json::from_str(&body).map_err(|e| {
-            ProviderError::Parse(format!("Failed to parse Crof usage: {e}"))
-        })?;
+        let usage: CrofUsageResponse = serde_json::from_str(&body)
+            .map_err(|e| ProviderError::Parse(format!("Failed to parse Crof usage: {e}")))?;
         Ok(snapshot_from_usage(&usage))
     }
 }


### PR DESCRIPTION
## Summary

- format the merged Crof provider so `cargo fmt --all --check` is green
- preserve real Windows/PowerShell exit codes with a bounded 1-second grace **only after clean stdout/stderr EOF**
- separate timeout/error teardown from clean-exit teardown: timed-out/error commands now kill/reap immediately instead of entering the clean-exit grace loop
- keep the timeout regression meaningful: a command that would naturally run 30 seconds has a 100 ms timeout and must return in under 2 seconds

## Why

Hosted Windows exposed two different process states that had been conflated:

1. clean stream EOF can precede the Windows process object becoming signaled, so an immediate kill can lose the real exit code;
2. an actual command timeout has already exceeded its execution contract and must not wait through that clean-exit grace.

The implementation now represents those states directly with `finish_child_after_eof` versus `terminate_child` rather than weakening the timeout test to tolerate multi-second teardown.

## Validation

- `cargo fmt --all --check` passed locally
- `git diff --check` passed
- CircleCI `ci/circleci: pr-check` passed on the corrected PR, including the previously flaky Windows process tests and restored `<2s` timeout assertion
- CodeRabbit passed

## Scope

No CI topology/policy changes are included here. Those remain isolated in stacked PR #416.
