### PR TITLE
Optimize hosted CI usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,11 +212,13 @@ workflows:
           filters: *release-tag-filter
 
   pr-check:
+    # Semantic CI boundary: release-integration micro PRs target port/upstream-*.
+    # A micro-named head aimed directly at main still receives full hosted CI.
+    # Guard the PR-only value behind event.name so push pipelines compile safely.
+    when: pipeline.event.name == "push" or (pipeline.event.name == "pull_request" and not (pipeline.event.github.pull_request.base.ref starts-with "port/upstream-"))
     jobs:
       - pr-check:
           filters:
             tags:
               ignore:
                 - /^v[0-9]+\.[0-9]+\.[0-9]+$/
-            branches:
-              only: /.*/

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,19 +1,20 @@
 # CI — Win-CodexBar
 
-Win-CodexBar has two deliberately separate hosted CI responsibilities:
+Win-CodexBar separates primary validation, reserve validation, and interaction policy:
 
-- **CircleCI** hosts the primary PR/push validation path: the `pr-check`
-  job/workflow in `.circleci/config.yml` runs the full local-check slice on
-  CircleCI's hosted Windows executor for every branch pipeline that passes
-  its gates.
-- The **Blacksmith GitHub Actions** PR check
-  (`.github/workflows/pr-check.yml`) is a manual-dispatch-only fallback: its
-  `on:` block holds `workflow_dispatch` only, so it no longer schedules
-  automatically and is run by hand only for Blacksmith diagnostics.
+- **CircleCI Windows** is the primary PR/push validation path. Its `pr-check`
+  job/workflow in `.circleci/config.yml` runs the canonical local-check CI slice.
+- **Blacksmith Windows** is manual reserve CI only. `.github/workflows/pr-check.yml`
+  has `workflow_dispatch` only and uses the repo-proven 4-vCPU Windows runner.
+  Use it for an independent Windows second opinion when CircleCI is degraded or a
+  high-risk native change merits extra evidence.
+- The lightweight **interaction guard** runs automatically on GitHub's standard
+  `ubuntu-latest` runner for untrusted authors. This public repository gets that
+  standard GitHub-hosted compute without consuming the Blacksmith allowance.
 
-These responsibilities do not overlap: the CircleCI PR check replaces the
-former Blacksmith PR/push gate (see ADR 0005). Its build job has no GitHub
-write credential; only the post-approval release publisher receives the
+The primary and reserve Windows jobs deliberately execute the same
+`scripts/local-check.ps1 -Slice ci` contract. Neither build job receives a GitHub
+write credential; only the approval-gated CircleCI release publisher receives its
 restricted `GH_TOKEN` context.
 
 ## CircleCI hosted PR check (primary PR/push gate)
@@ -33,36 +34,49 @@ pnpm --dir apps/desktop-tauri test
 pnpm --dir apps/desktop-tauri run build
 ```
 
-Auto-cancel of superseded pushes is a CircleCI **project setting** ("Auto-cancel
-redundant workflows", Project Settings → Advanced), not GitHub `concurrency`
-YAML — the CircleCI job has none.
+Auto-cancel of superseded non-default-branch work is a CircleCI **project setting**
+("Auto-cancel redundant workflows", Project Settings -> Advanced), not GitHub
+`concurrency` YAML. It is enabled for this project.
 
-### Interaction guard — `.github/workflows/interaction-guard.yml`
+CircleCI trigger configuration also lives outside this repository. The verified
+2026-09-05 setup has one enabled GitHub App trigger with explicit rules for PR
+opened/reopened/synchronize events and default-branch pushes only. Tag pushes are
+excluded because `.github/workflows/release.yml` deliberately triggers the release
+pipeline through the CircleCI API. Do not add overlapping subset triggers or tag
+rules; those create duplicate validation/release pipelines.
 
-The interaction guard remains on `blacksmith-2vcpu-ubuntu-2404` with its
-existing `contents: read`, `issues: write`, and `pull-requests: write`
-permissions. It is unrelated to release publication.
+Porting micro-review CI is enforced semantically in `.circleci/config.yml`: a PR
+whose **base/target** branch is `port/upstream-*` does not create the `pr-check`
+workflow. A `port/micro-*` head opened directly to `main` still receives the full
+hosted Windows gate. This uses CircleCI's GitHub App PR base-ref pipeline value,
+not a head-branch naming bypass.
+
+### Interaction guard - `.github/workflows/interaction-guard.yml`
+
+The interaction guard runs on GitHub's standard `ubuntu-latest`, not Blacksmith.
+It keeps `contents: read`, `issues: write`, and `pull-requests: write` permissions
+and skips maintainer-authored events before a runner starts. This preserves the
+Blacksmith pool for manual Windows fallback.
 
 ## GitHub Actions budget mode
 
-Only the interaction guard carries the `if: vars.CI_BUDGET_MODE != 'off'`
-gate now; it runs when the variable is unset (`normal`), `normal`, or
-`thin`, and skips only when it is `off`. This gate does not disable
-CircleCI releases.
+Both the interaction guard and manual Blacksmith reserve job honor
+`vars.CI_BUDGET_MODE != 'off'`. `off` is the emergency stop for GitHub Actions
+CI helpers; it does not disable CircleCI releases.
 
-Set `CI_BUDGET_MODE` in **Settings → Secrets and variables → Actions →
+Set `CI_BUDGET_MODE` in **Settings -> Secrets and variables -> Actions ->
 Variables**. Do not hard-code it in a workflow.
 
-| Mode   | Interaction guard | Circle release |
-|--------|-------------------|----------------|
-| normal | runs              | tag-triggered  |
-| thin   | runs              | tag-triggered  |
-| off    | skip              | tag-triggered  |
+| Mode | Interaction guard | Blacksmith reserve | Circle release |
+|------|-------------------|-------------------|----------------|
+| normal | runs when needed | manual only | tag-triggered |
+| thin | runs when needed | manual only | tag-triggered |
+| off | skip | skip | tag-triggered |
 
-The Blacksmith Pool minutes intent was roughly **60% Win-CodexBar**,
-**30% linear-cli**, and **10% buffer**; that allocation is historical for this
-repo — Win-CodexBar no longer draws on the pool. CircleCI credits are separate
-and must be budgeted in CircleCI.
+Blacksmith's allowance is now a reserve, not a recurring Win-CodexBar cost. The
+interaction guard uses free standard GitHub-hosted public-repo compute; the
+Blacksmith Windows workflow runs only when a maintainer deliberately dispatches
+it. CircleCI credits/OSS allowance are budgeted independently.
 
 ## CircleCI release pipeline
 
@@ -92,37 +106,44 @@ Both jobs use CircleCI's hosted Windows executor (`circleci/windows@5.0`).
 
 ### CircleCI project and context setup
 
-These steps require repository/CircleCI administrator access and are not
-automated by this repository:
+Provider settings are not stored in `.circleci/config.yml`. Verified on 2026-09-05:
 
-1. Add the canonical GitHub project `nesszer/Win-CodexBar` to the CircleCI
-   organization and enable `.circleci/config.yml`.
-2. Create a restricted context named `github-release-publisher`, scoped only to
+1. **Project Setup** has one enabled GitHub App trigger on the primary pipeline,
+   limited to PR opened/reopened/synchronize plus default-branch pushes;
+   overlapping subset/tag triggers were removed.
+2. **Advanced -> Auto-cancel redundant workflows** is enabled.
+3. Keep the restricted context named `github-release-publisher`, scoped only to
    this project (and the release job if organization policy supports expression
-   restrictions). Add `GH_TOKEN` as a secret; never add it as a project
-   variable or to the build job.
-3. Use a fine-grained GitHub token for only this repository with **Contents:
-   read and write** (release asset API access). Do not grant **Workflows**
-   permission; no workflow file is changed by the publisher.
-4. Protect the `v*` tag namespace with a GitHub ruleset/tag protection policy
-   that permits only authorized release maintainers to create canonical
-   `vX.Y.Z` tags. Protect `main` and require the `ci/circleci: pr-check`
-   status check.
-5. Configure CircleCI notifications and a spending/credit alert appropriate to
-   the organization. Do not approve a release until the build artifacts and
-   manifest have been reviewed.
+   restrictions). Add `GH_TOKEN` as a secret; never add it as a project variable
+   or to the build job.
+4. Use a fine-grained GitHub token for only this repository with **Contents: read
+   and write**. Do not grant **Workflows** permission.
+5. Protect the `v*` tag namespace with a GitHub ruleset/tag protection policy that
+   permits only authorized release maintainers to create canonical `vX.Y.Z` tags.
+   Protect `main` and require the `ci/circleci: pr-check` status check.
+6. Configure CircleCI notifications and a spending/credit alert appropriate to the
+   organization. Do not approve a release until artifacts and manifest are
+   reviewed.
 
 The GitHub token is intentionally not available to checkout, preflight,
 prerequisite provisioning, release-doctor, build, smoke, or artifact steps.
-CircleCI project setup and GitHub tag/context/ruleset changes are the current
-manual setup scope.
+CircleCI trigger cleanup and auto-cancel are already applied. GitHub `main`
+protection and future context/tag-policy changes remain repository-admin scope.
 
 ## Cost, retry, and rollback behavior
-CircleCI Windows credits are now the recurring PR cost (spent against the
-open-source allowance; see ADR 0005), plus release builds for protected
-semver tags and the short approval/publish job. Blacksmith minutes remain
-relevant only for the interaction guard and manual-dispatch diagnostics.
-Do not use CircleCI for ad-hoc release testing outside its gated triggers.
+
+CircleCI Windows is the recurring integration cost. The config avoids that compute
+for PRs targeting `port/upstream-*`; behavioral micro PRs rely on focused local
+evidence. A micro-named PR targeting `main` still runs the full hosted gate. The
+full job is also used for ordinary PRs and `main` validation. CircleCI's medium
+Windows executor is already its smallest managed Windows resource class, so the
+main savings levers are clean trigger topology, compile-time filtering, cache reuse,
+and auto-cancel.
+
+Blacksmith Windows is manual reserve only. Keep the proven 4-vCPU Windows runner
+for reliability. A 2-vCPU experiment was cancelled while queued before it could
+prove equivalent availability. Do not make Blacksmith an automatic second copy of
+CircleCI; if CircleCI is healthy, one hosted Windows gate is enough.
 
 Reruns are safe: the build is tied to the immutable SHA from the tag and
 produces a fresh temporary WorkRoot. If publication stops after some uploads,

--- a/.github/workflows/interaction-guard.yml
+++ b/.github/workflows/interaction-guard.yml
@@ -13,15 +13,16 @@ permissions:
 
 jobs:
   guard:
-    # Skip maintainer-authored events entirely: no runner spin-up, no
-    # billed minutes. The guard only exists for untrusted authors.
-    # The association list must match trustedAssociations in
-    # .github/scripts/interaction-guard.mjs.
+    # Skip maintainer-authored events entirely: no runner spin-up. The guard only
+    # exists for untrusted authors. Keep this tiny Node policy job on GitHub's
+    # standard Ubuntu runner, which is free for this public repository, so the
+    # Blacksmith allowance stays reserved for manual Windows backup CI.
     if: >-
       vars.CI_BUDGET_MODE != 'off' &&
       !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
         github.event.pull_request.author_association || github.event.issue.author_association)
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - run: node .github/scripts/interaction-guard.mjs

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,14 +1,14 @@
-name: PR check
+name: PR check (Blacksmith backup)
 
-# Manual-only historical fallback: the hosted PR check moved to CircleCI
-# (ADR 0005). This workflow no longer schedules on push or pull_request;
-# run it by hand for Blacksmith diagnostics. The job body is kept intact
-# for that purpose.
+# Manual-only reserve CI. CircleCI is the primary hosted PR gate (ADR 0005).
+# Keep Blacksmith off automatic push/PR triggers so its Windows allowance is
+# reserved for explicit second-opinion/fallback runs when CircleCI is degraded
+# or a high-risk Windows-native change merits independent confirmation.
 on:
   workflow_dispatch:
 
 concurrency:
-  group: pr-check-${{ github.ref }}
+  group: blacksmith-pr-check-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -16,9 +16,13 @@ env:
 
 jobs:
   pr-check:
-    name: Local check
+    name: Local check (Blacksmith reserve)
     if: vars.CI_BUDGET_MODE != 'off'
+    # Reserve reliability over theoretical savings: this repo has a proven
+    # Blacksmith 4-vCPU Windows path; a 2-vCPU dispatch queued instead of
+    # provisioning during the 2026-09-05 audit. Keep reserve CI dependable.
     runs-on: blacksmith-4vcpu-windows-2025
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v4
@@ -38,20 +42,22 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      # Read the exact pnpm version from the product package.json instead of
+      # drifting on a floating major. Blacksmith transparently accelerates the
+      # supported Actions cache path used by setup-node.
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11
+          package_json_file: apps/desktop-tauri/package.json
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.18.0
           cache: pnpm
           cache-dependency-path: apps/desktop-tauri/pnpm-lock.yaml
 
-      # Canonical check source of truth: the same slice the CircleCI
-      # pr-check job runs (fmt/clippy/test, frontend install/test/build,
-      # interaction-guard script tests). No duplicated inline steps here.
+      # Same canonical slice as CircleCI. The backup intentionally does not run
+      # installer/release packaging, keeping manual diagnostic runs bounded.
       - name: Run local-check ci slice
         run: powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/local-check.ps1 -Slice ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 - `rust/src/cli/` — CLI subcommands (`codexbar` binary)
 - `scripts/` — `dev.ps1`, `local-check.ps1`, release and smoke scripts
 - `docs/` — Windows port docs (`ARCHITECTURE`, `CLI`, `CONFIGURATION`, `PROVIDERS`, `BUILDING`, `COOKIES`, `WINDOWS_PROOF`, ADRs). Upstream macOS docs are read-only reference only.
-- `.github/workflows/` — `pr-check.yml` (hosted gate), `interaction-guard.yml`
+- `.circleci/config.yml` — primary hosted Windows PR/push gate; `.github/workflows/pr-check.yml` — manual Blacksmith Windows reserve; `.github/workflows/interaction-guard.yml` — lightweight GitHub-hosted policy guard.
 
 ## Development Commands
 
@@ -103,13 +103,13 @@ pnpm run tauri:build
 - `apps/desktop-tauri/src-tauri/src/surface_target.rs` — proof / settings tab whitelist
 - `apps/desktop-tauri/src-tauri/tauri.conf.json` — active Tauri config
 - `scripts/local-check.ps1` — local CI slice
-- `.github/workflows/pr-check.yml` — hosted PR gate
+- `.circleci/config.yml` — primary hosted PR/push gate; `.github/workflows/pr-check.yml` — manual Blacksmith reserve
 - `CONTEXT.md` — CI budget glossary (Blacksmith pool / `CI_BUDGET_MODE`)
 
 ## Runtime/Tooling Preferences
 
-- Package manager: **pnpm@10.18.1** (`packageManager` in `apps/desktop-tauri/package.json` + lockfile). Do not introduce npm or yarn lockfiles.
-- Node: CI uses Node 20; no `.nvmrc` in repo — prefer Node 20 locally for parity.
+- Package manager: **pnpm@11.24.0** (`packageManager` in `apps/desktop-tauri/package.json` + lockfile). Do not introduce npm or yarn lockfiles.
+- Node: CircleCI pins **Node 24.18.0**; no `.nvmrc` in repo. Prefer Node 24.18.0 locally for hosted parity.
 - Rust: edition **2024**, stable toolchain; CI target `x86_64-pc-windows-msvc`. No committed `rust-toolchain.toml` / `rustfmt.toml` / `clippy.toml` — defaults plus CI flags (`clippy -- -D warnings`).
 - Tray / DPAPI / browser-cookie behavior: validate on **Windows-native** hosts. WSL/Linux is insufficient for those paths.
 - **CUA (computer-use) for UI proof** — see [Testing & QA](#testing--qa). Project: [trycua/cua](https://github.com/trycua/cua). On this machine the Windows driver is typically `%LOCALAPPDATA%\Programs\Cua\cua-driver\bin\cua-driver.exe`.
@@ -119,8 +119,8 @@ pnpm run tauri:build
 
 - Rust: prefer focused `#[cfg(test)]` unit tests near the changed module. Run both manifests after Rust changes.
 - Frontend: Vitest 3 + jsdom + Testing Library. From `apps/desktop-tauri`: `pnpm test` (`src/**/*.{test,spec}.{ts,tsx}`).
-- **Hosted PR check** (when `vars.CI_BUDGET_MODE != 'off'`): `cargo fmt --check`, clippy both crates with `-D warnings`, cargo test both crates, `pnpm --dir apps/desktop-tauri test`, `pnpm --dir apps/desktop-tauri run build` on Blacksmith Windows. Budget details: `CONTEXT.md`, ADRs under `docs/adr/`.
-- **Local mirror**: `.\scripts\local-check.ps1` (default Rust + Tauri + Frontend). Does not run full installer / smoke unless you pass the matching flags.
+- **Hosted PR check**: CircleCI Windows is primary and runs `scripts/local-check.ps1 -Slice ci` for ordinary/canonical PRs and `main`; micro PRs targeting `port/upstream-*` intentionally skip hosted Windows compute; a micro-named PR targeting `main` does not. `.github/workflows/pr-check.yml` is manual Blacksmith Windows reserve only. Budget details: `CONTEXT.md`, `.github/CI.md`, and ADRs under `docs/adr/`.
+- **Hosted mirror**: `.\scripts\local-check.ps1 -Slice ci`. The default no-parameter developer slice remains available and does not run full installer/smoke unless requested.
 - Parser / fetcher changes: add deterministic samples or fixtures where practical.
 - No coverage thresholds are configured — do not invent any.
 
@@ -164,7 +164,7 @@ Then follow post-install instructions (permissions / accessibility as prompted).
   - Commands run (`cargo test`, `pnpm test`, `.\scripts\local-check.ps1`, etc.)
   - Screenshots / GIFs for UI changes (Windows)
   - Linked issue / reference when relevant
-- Hosted PR check exists (`.github/workflows/pr-check.yml`); still run and report the local slice. Do not claim there is no CI.
+- Hosted PR check exists: `ci/circleci: pr-check` is the primary Windows gate; `.github/workflows/pr-check.yml` is manual Blacksmith backup. Porting micro PRs targeting `port/upstream-*` use focused local evidence and intentionally skip automatic hosted Windows CI; `main`-bound PRs always get the hosted gate.
 - UI / tray / settings / float-bar / visual PRs: **CUA Driver proof is the default** ([trycua/cua](https://github.com/trycua/cua)) after a **fresh local rebuild** — see [UI validation with CUA](#ui-validation-with-cua-trycuacua). If CUA cannot be used, explain why and attach equivalent manual proof (PR template checkboxes).
 - Before non-trivial merge: thermo-nuclear structure review when the project process requires it.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,117 +1,50 @@
-# Shared CI Budget glossary
+# Shared CI budget glossary
 
-This glossary is shared with the sister repo (`linear-cli`) so operators can
-reason about CI spend across both projects with one vocabulary.
+This glossary is shared with the sister repo (`linear-cli`) so operators can reason about CI spend across both projects with one vocabulary.
+
+Detailed Win-CodexBar CI topology, trigger configuration, cache policy, release flow, and operator setup belong in [`.github/CI.md`](.github/CI.md). This file intentionally stays small so shared budget language does not become a second CI manual.
+
+## Win-CodexBar compute roles
+
+- **CircleCI Windows** — primary hosted PR/`main` integration gate and release builder.
+- **Blacksmith Windows** — manual reserve/second-opinion CI only.
+- **GitHub-hosted Ubuntu** — lightweight interaction guard for untrusted authors.
+
+The primary and reserve Windows jobs use the same canonical `scripts/local-check.ps1 -Slice ci` contract. See `.github/CI.md` for the exact trigger and runner rules.
 
 ## Blacksmith Pool
 
-The shared Blacksmith free-tier minute pool that both Win-CodexBar and the
-sister repo (`linear-cli`) draw from. All `blacksmith-*` runners bill against
-this one pool. The intent-share (60%) and $0 spend alert are defined against
-the combined draw on this pool, not per repo.
+The Blacksmith allowance is shared with `linear-cli`. For Win-CodexBar it is reserve capacity rather than recurring PR compute. Do not automatically run Blacksmith beside a healthy CircleCI run.
 
-**Retired for Win-CodexBar (2026-08):** the shared pool is exhausted, so this
-repo's jobs no longer draw on it; the hosted PR check now runs on CircleCI
-Windows (see "Hosted PR check (CircleCI)" below). The definitions here remain
-for the sister repo and as pool history.
+The historical cross-repo intent split was roughly **60% Win-CodexBar / 30% linear-cli / 10% buffer**. Treat that as budget history, not a reason to schedule duplicate validation.
 
 ## CI budget mode
 
-A repository variable `CI_BUDGET_MODE` controls how much CI runs per change.
-It is intentionally coarse: `normal`, `thin`, or `off`.
+`CI_BUDGET_MODE` is the coarse emergency control. Supported values are `normal`, `thin`, and `off`; unset/empty means `normal`.
 
-| Mode   | PR check (CircleCI) | Interaction guard | Release                          |
-|--------|----------|--------------------|----------------------------------|
-| normal | runs     | runs               | local (Win-CodexBar only)        |
-| thin   | runs     | runs               | local (Win-CodexBar only)        |
-| off    | **skip** | **skip**           | local (Win-CodexBar only)        |
+| Mode | CircleCI PR check | Interaction guard | Blacksmith reserve | Release |
+| --- | --- | --- | --- | --- |
+| `normal` | runs when in scope | runs when needed | manual only | tag-triggered CircleCI |
+| `thin` | runs when in scope | runs when needed | manual only | tag-triggered CircleCI |
+| `off` | skip | skip | skip | tag-triggered CircleCI |
 
-> Note: Win-CodexBar's Release is **always local** (no release workflow on
-> Blacksmith). The sister repo `linear-cli` has a Blacksmith dispatch-only
-> release workflow, so its Release column differs by design. Budget mode does
-> not gate Win-CodexBar's local release — it is operator-driven regardless of
-> mode.
+`thin` currently has the same single hosted Windows integration job as `normal`; there is no matrix left to trim. Porting micro PRs save compute through their semantic integration-branch topology instead. See `.github/CI.md` and `docs/PORTING.md`.
 
-- `normal` — default. Unset is treated as `normal`.
-- `thin` — Win-CodexBar's PR check survives `thin`: it is the single hosted
-  Windows job (now CircleCI; Blacksmith is retired for this repo), so it still
-  runs. The
-  sister repo (`linear-cli`) skips its PR check entirely under `thin`
-  (`if: mode != 'off' && mode != 'thin'`); its default PR check is already a
-  single Linux-only job, so there is no matrix to trim — `thin` simply drops
-  the whole job.
-- `off` — emergency stop. Both the PR check and the interaction guard skip.
-  Use this when the bill approaches the `$0 spend` alert threshold or when a
-  runaway workflow is burning minutes.
+Set the variable in provider settings, not source code:
 
-Set it in both CI surfaces, not in code:
+- CircleCI: Project Settings -> Environment Variables -> `CI_BUDGET_MODE`
+- GitHub Actions: Settings -> Secrets and variables -> Actions -> Variables
 
-- **CircleCI** (the hosted `pr-check` job): CircleCI Project Settings →
-  Environment Variables → `CI_BUDGET_MODE`. The job's budget guard reads it as
-  `$env:CI_BUDGET_MODE`; unset/empty is treated as `normal`. CircleCI's
-  GitHub App integration does not build fork-PR pipelines, so fork-PR
-  changes need the manual same-repo branch fallback (see "Hosted PR check
-  (CircleCI)"); `CI_BUDGET_MODE` applies whenever a pipeline actually runs.
-- **GitHub Actions** (`interaction-guard.yml` unchanged; `pr-check.yml` now a
-  manual-dispatch-only fallback with no automatic push/PR scheduling):
-  Settings → Secrets and variables → Actions → Variables; the workflows read
-  it as `vars.CI_BUDGET_MODE`.
-
-## Hosted PR check (CircleCI)
-
-As of 2026-08, Win-CodexBar's hosted PR/push gate is the `pr-check` job in
-`.circleci/config.yml` (workflow `pr-check`): a single CircleCI Windows job on
-the `circleci/windows@5.0` executor (`win/default`, `size: medium`). One
-fused step provisions the toolchain and delegates the checks to
-`scripts/local-check.ps1 -Slice ci` (the GitHub-workflow mirror; see "Local
-check slice" below). Early gates reproduce the GitHub workflow's trigger
-contract and log why they skip, then call `circleci-agent step halt` to stop
-the job before any cache or toolchain spend: budget `off`, non-PR branch
-pushes (PRs and `main`/`master` pushes run), and docs-only diffs
-(`docs/**`, `**/*.md`, `CONTEXT.md`, `.github/CI.md`; fails open if the
-base revision cannot be determined). The workflow ignores release tags
-(`/^v[0-9]+\.[0-9]+\.[0-9]+$/`), so it never double-runs with the tag-gated
-`release` workflow. The repository stays public, so the job spends CircleCI's
-Free Plan open-source allowance: open-source builds are not subject to the
-Free Plan's 30,000-credit personal-usage block and keep running even when a
-personal credit balance is exhausted
-(https://circleci.com/docs/guides/plans-pricing/credits). CircleCI's OSS
-program also documents a monthly allowance for macOS/Windows OSS builds, so
-budget the thin slice's Windows credits on the CircleCI plan, not the retired
-Blacksmith intent share.
-
-The required branch/PR status check for `main` is `ci/circleci: pr-check`
-(the CircleCI `pr-check` job), not a Blacksmith check.
-
-## Intent share (60/30/10)
-
-The Blacksmith Pool minutes intent was divided roughly **60% Win-CodexBar**,
-**30% linear-cli**, and **10% buffer**. That allocation is historical for this
-repo: Win-CodexBar's hosted PR check is now a single CircleCI Windows job (the
-Blacksmith runner is retired for this repo), so this repo no longer draws on
-the pool; release builds stay local.
-
-## Blacksmith billing note
-
-**Retired for this repo (2026-08):** the shared Blacksmith pool is exhausted,
-so Win-CodexBar's hosted PR check no longer draws on it; it runs on CircleCI
-Windows instead (see "Hosted PR check (CircleCI)"). The notes below are kept
-as pool history.
-
-On the Blacksmith free tier, **Windows minutes bill at 2x** (one Windows
-minute consumes two free-tier minutes). `blacksmith-4vcpu-windows-2025` is a
-Windows Server 2025 runner with VS Build Tools available, so Rust + Tauri
-builds work without extra setup. The PR check is a thin slice (fmt + clippy +
-test) and never runs `tauri:build` release, installer packaging, smoke
-install, or upload.
+Budget mode does not disable the protected release-tag pipeline.
 
 ## Local check slice
 
-The hosted PR check runs `scripts/local-check.ps1 -Slice ci`, which mirrors
-`.github/workflows/pr-check.yml` step for step: workspace-wide
-`cargo fmt --check` and `cargo clippy -D warnings`, workspace `cargo test`,
-and the frontend `pnpm install --frozen-lockfile`, `pnpm test`, and `tsc
---noEmit` (via `pnpm run build`), plus the interaction-guard script tests.
-The script's default (no-parameter) slice is unchanged for developers. The
-PR check deliberately excludes `tauri:build` release, the installer, smoke
-install, and release upload — those stay on the local Windows release path.
+The hosted Windows contract is:
+
+```powershell
+.\scripts\local-check.ps1 -Slice ci
+```
+
+It covers formatting, Clippy, Rust tests, frozen frontend install, frontend tests/build, and interaction-guard tests. Installer/release packaging and UI proof remain separate responsibilities.
+
+For UI, tray, settings, and float-bar changes, CI is not sufficient: use a fresh Windows build plus CUA (or documented equivalent manual proof) as required by `AGENTS.md`.

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -10,9 +10,10 @@ wire-shape source**, not code to cherry-pick.
 | Item | Value |
 |------|--------|
 | Upstream repo | `steipete/CodexBar` |
-| Last landed baseline | **v0.54.0** (`1181138ac`) |
-| Current port branch | **v0.54.0** |
-| PR naming | One PR per upstream release: `Port upstream CodexBar X.Y.Z` |
+| Last landed baseline | **v0.55.0** (`061593c`) |
+| Current port base | `main` at Win-CodexBar **0.55.0** |
+| Canonical PR | One final PR per upstream release: `Port upstream CodexBar X.Y.Z` |
+| Review topology | Behavioral micro PRs -> release integration branch -> canonical PR -> `main` |
 
 Version bumps of *this* repo are a **separate later step**. A port PR lands
 behavior; it does not have to ship a release tag.
@@ -73,16 +74,48 @@ guess-port. Example from the 0.47.0 pass: Claude cold-boot items
 (`#2493` / `#2494`) were deferred — not portable as written, not silently
 half-implemented.
 
-### 3. Split into workstreams
+### 3. Split into behavioral micro PRs
 
-Group PORT items into independent commits / mini-PRs on the port branch:
+Prefer many small review PRs, but stop at a complete behavioral boundary. A micro
+PR should be independently understandable, testable, and revertible. Do not split
+a parser, its fixture, and its regression test into separate ceremonial PRs.
 
-- One provider or one vertical feature per commit when practical
-- Shared infrastructure (factory, icons, settings schema) lands with the first
-  consumer that needs it, or as its own scoped commit if several consumers share
-  it
-- Keep SKIP / DEFER notes in the final PR body — do not open empty stub modules
-  “for later”
+For upstream `X.Y.Z`:
+
+1. Create a release integration branch: `port/upstream-X.Y.Z`.
+2. Create each workstream on `port/micro-X.Y.Z-<slug>` and open that PR **into
+   `port/upstream-X.Y.Z`**, not `main`.
+3. One provider or one vertical feature per micro PR when practical. Include the
+   implementation, fixtures, tests, and directly required shared plumbing in the
+   same review unit.
+4. Shared infrastructure used by several workstreams can be its own micro PR when
+   that makes later PRs smaller and independently reviewable.
+5. Merge reviewed micro PRs into the release integration branch. Do **not** open
+   the canonical PR to `main` until the release audit is complete and the branch
+   is ready for full integration validation.
+6. Open one canonical `Port upstream CodexBar X.Y.Z` PR from
+   `port/upstream-X.Y.Z` to `main`. It should contain no surprise work; its job is
+   to prove the release-wide PORT / SKIP / DEFER audit and integration result.
+7. Keep SKIP / DEFER notes in that canonical PR body. Do not open empty stub
+   modules "for later".
+
+#### CI budget rule for micro PRs
+
+Hosted CI and review granularity are intentionally different:
+
+- Micro PRs targeting `port/upstream-*` are filtered out at CircleCI workflow
+  compilation time, before Windows compute starts. The decision uses the PR base/target
+  branch, not the head-branch name; a `port/micro-*` head opened directly to `main`
+  still receives the full hosted gate. Their required evidence is focused local tests
+  plus any broader local gate justified by the change.
+- High-risk Windows-native micro PRs may use the manual Blacksmith backup workflow
+  as a deliberate second opinion, but it is not automatic.
+- The canonical `port/upstream-X.Y.Z` -> `main` PR receives the full CircleCI
+  Windows gate. Run full local checks, CUA for UI-affecting work, and thermo review
+  before relying on hosted CI.
+- CircleCI Project Settings should have **Auto-cancel redundant workflows** enabled
+  so superseded non-default-branch runs stop consuming credits.
+- Do not use `[skip ci]` to bypass the canonical release PR gate.
 
 ### 4. Port fixtures from exact wire shapes
 
@@ -127,22 +160,30 @@ If the port changes any of those surfaces:
 
 Details: root [AGENTS.md](../AGENTS.md) (Testing & QA) and the PR template.
 
-### 7. Gate before PR
+### 7. Gate before review
+
+For every micro PR, run the focused tests that prove its behavior. Add broader local
+checks when the work touches shared infrastructure, account state, persistence, or
+Windows-native behavior.
 
 ```powershell
-# Repo gate
-.\scripts\local-check.ps1
-
-# Focused provider / parser tests (example)
+# Focused provider / parser examples
 cargo test -p codexbar notion
 cargo test -p codexbar xai
 
-# CLI smoke (adjust -p ids)
+# CLI smoke examples
 cargo run -p codexbar -- usage -p notion -v
 cargo run -p codexbar -- config providers
 ```
 
-UI-affecting work: CUA (or documented manual) proof on top of the above.
+Before opening the canonical release PR to `main`, run the full local mirror:
+
+```powershell
+.\scripts\local-check.ps1 -Slice ci
+```
+
+Run the normal developer gate as well when the host supports its shell-dependent
+checks. UI-affecting work requires CUA (or documented equivalent manual proof).
 
 ### 8. PR body and follow-ups
 
@@ -164,7 +205,10 @@ port PR unless that is an explicit separate decision. Port first; release later.
 | Rule | Detail |
 |------|--------|
 | No upstream interaction | No issues/PRs/comments on `steipete/CodexBar` |
-| Commit scope | One workstream per commit; message prefix `Port upstream X.Y.Z: …` |
+| Review scope | One complete behavior per micro PR; branch `port/micro-X.Y.Z-<slug>` |
+| Canonical scope | One release-wide PR from `port/upstream-X.Y.Z` to `main` |
+| Commit scope | One workstream per commit; message prefix `Port upstream X.Y.Z: ...` |
+| Hosted CI | Micro branches skip automatic CircleCI; canonical release PR gets full CircleCI; Blacksmith is manual reserve |
 | Source pin | Always `vX.Y.Z` tag URLs / compare range — never `main` |
 | Locales | Add keys in existing catalog style; machine translation allowed |
 | Ambiguity | **DEFER-with-evidence** > guess-port |

--- a/scripts/gh-safe.sh
+++ b/scripts/gh-safe.sh
@@ -54,6 +54,21 @@ if [[ "$verify_kind" != repo ]]; then
   ((${#gh_args[@]} >= 3)) || { echo "Forwarded command must carry its object as the third token (gh <object> <verb> <number>)." >&2; exit 3; }
   [[ "${gh_args[2]}" == "$target" ]] || { echo "Forwarded command object '${gh_args[2]:-}' is not the verified target '$target'." >&2; exit 3; }
 fi
+api_passthrough=0
+if [[ "$verify_kind" == repo && "${gh_args[0]}" == api ]]; then
+  ((${#gh_args[@]} >= 2)) || { echo 'gh api requires a repository-scoped REST path.' >&2; exit 3; }
+  api_path="${gh_args[1]}"
+  expected_api_prefix="repos/$repo/"
+  shopt -s nocasematch
+  [[ "$api_path" == "$expected_api_prefix"* ]] || {
+    shopt -u nocasematch
+    echo "Repository API write path '$api_path' is outside '$expected_api_prefix'." >&2
+    exit 3
+  }
+  shopt -u nocasematch
+  [[ "$api_path" != *'..'* ]] || { echo "Repository API write path may not contain '..'." >&2; exit 3; }
+  api_passthrough=1
+fi
 
 case "$verify_kind" in
   repo)
@@ -81,8 +96,15 @@ echo "Verified GitHub write target: $verified_url"
 if ((what_if == 1)); then
   printf 'WhatIf: gh'
   printf ' %q' "${gh_args[@]}"
-  printf ' --repo %q\n' "$repo"
+  if ((api_passthrough == 0)); then
+    printf ' --repo %q' "$repo"
+  fi
+  printf '\n'
   exit 0
 fi
 
-gh "${gh_args[@]}" --repo "$repo"
+if ((api_passthrough == 1)); then
+  gh "${gh_args[@]}"
+else
+  gh "${gh_args[@]}" --repo "$repo"
+fi

--- a/scripts/gh-safe.tests.sh
+++ b/scripts/gh-safe.tests.sh
@@ -23,7 +23,9 @@ elif [[ "${1:-}" == pr && "${2:-}" == view ]]; then
 elif [[ "${1:-}" == issue && "${2:-}" == view ]]; then
   printf '%s\n' 'https://github.com/nesszer/Win-CodexBar/issues/123'
 elif [[ "${1:-}" == api ]]; then
-  printf '%s\n' 'https://github.com/nesszer/Win-CodexBar/releases/tag/v1.2.3'
+  if [[ "${2:-}" == repos/nesszer/Win-CodexBar/releases/tags/v1.2.3 ]]; then
+    printf '%s\n' 'https://github.com/nesszer/Win-CodexBar/releases/tag/v1.2.3'
+  fi
 fi
 EOF
 chmod +x "$test_root/bin/gh"
@@ -70,6 +72,13 @@ expect_fail bash "$repo_root/scripts/gh-safe.sh" \
 FAKE_GH_MODE=cross expect_fail bash "$repo_root/scripts/gh-safe.sh" \
   --repo nesszer/Win-CodexBar --verify-kind repo --what-if -- \
   pr create --title test --body test
+expect_fail bash "$repo_root/scripts/gh-safe.sh" \
+  --repo nesszer/Win-CodexBar --verify-kind repo --what-if -- \
+  api repos/steipete/CodexBar/branches/main/protection -X PUT -f test=true
+
+expect_fail bash "$repo_root/scripts/gh-safe.sh" \
+  --repo nesszer/Win-CodexBar --verify-kind repo --what-if -- \
+  api graphql -f query=test
 
 : > "$log"
 bash "$repo_root/scripts/gh-safe.sh" \
@@ -81,6 +90,21 @@ grep -Fq 'pr comment 361 --body test --repo nesszer/Win-CodexBar' "$log" || {
   cat "$log" >&2
   exit 1
 }
+: > "$log"
+bash "$repo_root/scripts/gh-safe.sh" \
+  --repo nesszer/Win-CodexBar --verify-kind repo -- \
+  api repos/nesszer/Win-CodexBar/branches/main/protection -X PUT -f test=true >/dev/null
+
+grep -Fq 'api repos/nesszer/Win-CodexBar/branches/main/protection -X PUT -f test=true' "$log" || {
+  echo 'Safe wrapper did not preserve the verified repository-scoped API path.' >&2
+  cat "$log" >&2
+  exit 1
+}
+if grep -Fq -- '--repo nesszer/Win-CodexBar' "$log"; then
+  echo 'Safe wrapper incorrectly appended --repo to gh api.' >&2
+  cat "$log" >&2
+  exit 1
+fi
 : > "$log"
 bash "$repo_root/scripts/gh-safe.sh" \
   --repo nesszer/Win-CodexBar --verify-kind issue --target 123 --what-if -- \


### PR DESCRIPTION
## Summary

Make CircleCI the single automatic Windows workhorse and preserve Blacksmith as deliberate reserve capacity, with the thermo findings resolved at the correct layers.

- CircleCI Windows remains the primary hosted integration gate
- Blacksmith Windows remains `workflow_dispatch`-only reserve CI on the proven 4-vCPU runner
- the lightweight interaction guard moves to standard GitHub-hosted `ubuntu-latest`
- Blacksmith backup Node/pnpm now follows the repo pins and runs the same `local-check.ps1 -Slice ci` contract
- porting micro-review CI is decided from the **PR base/target branch** at CircleCI config-compilation time: PRs into `port/upstream-*` skip Windows compute; a `port/micro-*` head aimed at `main` still receives full CI
- detailed CI operations stay in `.github/CI.md`; `CONTEXT.md` is reduced back to a shared budget glossary

## CircleCI provider configuration fixed

Authenticated CircleCI inspection found four overlapping triggers on the same pipeline. Those were the real cause of duplicate pipelines.

The provider configuration is now:

- exactly **one enabled GitHub App trigger**
- PR events: `opened`, `reopened`, `synchronize`
- push events: default branch only
- tag events: excluded from the VCS trigger because `.github/workflows/release.yml` explicitly starts the CircleCI release pipeline
- `enable_auto_cancel_redundant_workflows = true`

The three duplicate subset triggers were removed. The temporary repo-side same-SHA dedup state machine was deleted entirely, so intentional retries of the same SHA are not suppressed and normal CI no longer makes extra CircleCI API calls.

## CI budget behavior

CircleCI's managed Windows `medium` class is already its minimum Windows resource class, so savings come from fewer jobs rather than shrinking the executor.

For the upstream port workflow:

```text
port/micro-X.Y.Z-* -> PR base port/upstream-X.Y.Z -> no automatic hosted Windows workflow
port/upstream-X.Y.Z -> PR base main              -> full CircleCI Windows gate
any micro-named PR -> PR base main               -> full CircleCI Windows gate
main push                                         -> full CircleCI Windows gate
```

Blacksmith remains a manual second opinion/fallback, not an automatic duplicate.

## Validation

- authenticated CircleCI API: one trigger remains with only PR lifecycle + default-branch push rules
- CircleCI project setting: auto-cancel enabled
- official CircleCI CLI: `.circleci/config.yml` valid
- `scripts/circleci-pr.tests.ps1`: passed
- `.github/scripts/interaction-guard.test.mjs`: 9/9 passed
- actionlint: changed GitHub workflows passed
- `git diff --check`: passed
- latest #416 synchronize event created exactly one new CircleCI pipeline
- CircleCI `ci/circleci: pr-check`: passed on the corrected #416
- CodeRabbit passed
- Blacksmith reserve provisioning/toolchain/cache path was previously verified; the redundant proof run was cancelled after primary CI passed to preserve reserve usage

## Repository protection applied

GitHub `main` branch protection is now enabled with strict required status check `ci/circleci: pr-check`. No extra review/admin restrictions were added. The repo write-safety wrapper now supports only verified, repository-scoped REST writes and rejects other-repo or GraphQL passthrough; its shell regression tests are part of the green hosted CI slice.

PR #415 is merged, and this PR has been restacked/retargeted directly onto protected `main` with a fresh required CircleCI pass.