### PR TITLE
fix(http): enable reqwest http2 without manifest BOM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3907,6 +3907,7 @@ dependencies = [
  "cookie_store",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,4 +1,4 @@
-[package]
+﻿[package]
 name = "codexbar"
 version = "0.55.0"
 edition = "2024"
@@ -20,7 +20,7 @@ default = []
 tokio = { version = "1", features = ["full"] }
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json", "cookies", "rustls-tls", "stream"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "cookies", "rustls-tls", "stream", "http2"], default-features = false }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,4 +1,4 @@
-﻿[package]
+[package]
 name = "codexbar"
 version = "0.55.0"
 edition = "2024"


### PR DESCRIPTION
Supersedes #414 because GitHub allowed maintainer edits in metadata but rejected direct writes to the contributor fork with HTTP 403.

This preserves the contributor's HTTP/2 change and applies the thermo fix before merge:

- enables reqwest `http2` exactly as #414 proposed
- keeps the expected single `h2` lockfile dependency
- strips the accidental UTF-8 BOM from `rust/Cargo.toml`
- keeps the transport note explicit: Cargo features are crate-wide, so HTTP/2 negotiation is available to every reqwest client, not Cursor only

Validation:

- BOM verified absent after repair
- `git diff --check` passes
- local `cargo check --workspace` is blocked by this machine's known MSVC-path issue (`Git/usr/bin/link.exe` wins over the Microsoft linker), not by this change
- protected CircleCI is the authoritative Windows compile/test gate

Original author commit is preserved in this branch; the repair is a separate NessZerra commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled HTTP/2 support for network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->