### PR TITLE
fix(grok): classify cadence from full billing cycle

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
@@ -252,6 +252,19 @@ pub(crate) fn filter_hidden_codex_spark_rows(
     }
 }
 
+fn grok_aware_primary_label(
+    id: ProviderId,
+    metadata: &ProviderMetadata,
+    window: &RateWindow,
+) -> String {
+    if id == ProviderId::Grok {
+        if let Some(label) = codexbar::providers::grok::display_label(window, chrono::Utc::now()) {
+            return label.to_string();
+        }
+    }
+    metadata.session_label.to_string()
+}
+
 pub(crate) fn pace_stage_str(stage: codexbar::core::PaceStage) -> &'static str {
     use codexbar::core::PaceStage;
     match stage {
@@ -326,7 +339,7 @@ impl ProviderUsageSnapshot {
             provider_id: id.cli_name().to_string(),
             display_name: id.display_name().to_string(),
             primary: primary_snap,
-            primary_label: Some(metadata.session_label.to_string()),
+            primary_label: Some(grok_aware_primary_label(id, metadata, &usage.primary)),
             secondary: secondary_snap,
             secondary_label: usage
                 .secondary

--- a/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
+++ b/apps/desktop-tauri/src-tauri/src/commands/bridge.rs
@@ -252,19 +252,6 @@ pub(crate) fn filter_hidden_codex_spark_rows(
     }
 }
 
-fn grok_aware_primary_label(
-    id: ProviderId,
-    metadata: &ProviderMetadata,
-    window: &RateWindow,
-) -> String {
-    if id == ProviderId::Grok {
-        if let Some(label) = codexbar::providers::grok::display_label(window, chrono::Utc::now()) {
-            return label.to_string();
-        }
-    }
-    metadata.session_label.to_string()
-}
-
 pub(crate) fn pace_stage_str(stage: codexbar::core::PaceStage) -> &'static str {
     use codexbar::core::PaceStage;
     match stage {
@@ -339,7 +326,12 @@ impl ProviderUsageSnapshot {
             provider_id: id.cli_name().to_string(),
             display_name: id.display_name().to_string(),
             primary: primary_snap,
-            primary_label: Some(grok_aware_primary_label(id, metadata, &usage.primary)),
+            primary_label: Some(
+                usage
+                    .primary_label
+                    .clone()
+                    .unwrap_or_else(|| metadata.session_label.to_string()),
+            ),
             secondary: secondary_snap,
             secondary_label: usage
                 .secondary

--- a/rust/src/cli/usage.rs
+++ b/rust/src/cli/usage.rs
@@ -1,5 +1,6 @@
 //! Usage command implementation
 
+use chrono::Utc;
 use clap::Args;
 use serde::Serialize;
 
@@ -480,7 +481,7 @@ pub fn render_text_with_status(
     lines.push(render_usage_header(provider, result, status, use_color));
     append_status_line(&mut lines, status);
     append_account_lines(&mut lines, &result.usage);
-    append_usage_window_lines(&mut lines, &result.usage, &metadata, use_color);
+    append_usage_window_lines(&mut lines, provider, &result.usage, &metadata, use_color);
     append_cost_line(&mut lines, result.cost.as_ref());
 
     lines.join("\n")
@@ -550,15 +551,29 @@ fn append_account_lines(lines: &mut Vec<String>, usage: &UsageSnapshot) {
 
 fn append_usage_window_lines(
     lines: &mut Vec<String>,
+    provider: ProviderId,
     usage: &UsageSnapshot,
     metadata: &crate::core::ProviderMetadata,
     use_color: bool,
 ) {
-    append_window_line(lines, metadata.session_label, &usage.primary, use_color);
+    let primary_label = if provider == ProviderId::Grok {
+        crate::providers::grok::display_label(&usage.primary, Utc::now())
+            .unwrap_or(metadata.session_label)
+    } else {
+        metadata.session_label
+    };
+    append_window_line(lines, primary_label, &usage.primary, use_color);
     // Upstream 0.50.1 #2957: pace for the 5-hour session window.
-    if usage.primary.window_minutes == Some(crate::core::SESSION_WINDOW_MINUTES)
-        && let Some(pace) =
-            UsagePace::weekly(&usage.primary, None, crate::core::SESSION_WINDOW_MINUTES)
+    let pace_minutes = usage
+        .primary
+        .window_minutes
+        .filter(|minutes| {
+            *minutes == crate::core::SESSION_WINDOW_MINUTES
+                || *minutes == crate::core::WEEKLY_WINDOW_MINUTES
+                || *minutes >= crate::core::MONTHLY_WINDOW_MINUTES
+        });
+    if let Some(minutes) = pace_minutes
+        && let Some(pace) = UsagePace::weekly(&usage.primary, None, minutes)
     {
         lines.push(format!(
             "  Pace:    {} {}",

--- a/rust/src/cli/usage.rs
+++ b/rust/src/cli/usage.rs
@@ -1,6 +1,5 @@
 //! Usage command implementation
 
-use chrono::Utc;
 use clap::Args;
 use serde::Serialize;
 
@@ -481,7 +480,7 @@ pub fn render_text_with_status(
     lines.push(render_usage_header(provider, result, status, use_color));
     append_status_line(&mut lines, status);
     append_account_lines(&mut lines, &result.usage);
-    append_usage_window_lines(&mut lines, provider, &result.usage, &metadata, use_color);
+    append_usage_window_lines(&mut lines, &result.usage, &metadata, use_color);
     append_cost_line(&mut lines, result.cost.as_ref());
 
     lines.join("\n")
@@ -551,27 +550,20 @@ fn append_account_lines(lines: &mut Vec<String>, usage: &UsageSnapshot) {
 
 fn append_usage_window_lines(
     lines: &mut Vec<String>,
-    provider: ProviderId,
     usage: &UsageSnapshot,
     metadata: &crate::core::ProviderMetadata,
     use_color: bool,
 ) {
-    let primary_label = if provider == ProviderId::Grok {
-        crate::providers::grok::display_label(&usage.primary, Utc::now())
-            .unwrap_or(metadata.session_label)
-    } else {
-        metadata.session_label
-    };
+    let primary_label = usage
+        .primary_label
+        .as_deref()
+        .unwrap_or(metadata.session_label);
     append_window_line(lines, primary_label, &usage.primary, use_color);
-    // Upstream 0.50.1 #2957: pace for the 5-hour session window.
-    let pace_minutes = usage
-        .primary
-        .window_minutes
-        .filter(|minutes| {
-            *minutes == crate::core::SESSION_WINDOW_MINUTES
-                || *minutes == crate::core::WEEKLY_WINDOW_MINUTES
-                || *minutes >= crate::core::MONTHLY_WINDOW_MINUTES
-        });
+    // Pace for primary windows whose provider published a common cadence.
+    let pace_minutes = usage.primary.window_minutes.filter(|minutes| {
+        *minutes == crate::core::SESSION_WINDOW_MINUTES
+            || *minutes >= crate::core::WEEKLY_WINDOW_MINUTES
+    });
     if let Some(minutes) = pace_minutes
         && let Some(pace) = UsagePace::weekly(&usage.primary, None, minutes)
     {
@@ -658,14 +650,18 @@ fn append_model_specific_line(
 pub fn render_brief_text(provider: ProviderId, result: &ProviderFetchResult) -> String {
     let metadata = instantiate_provider(provider).metadata().clone();
     let usage = &result.usage;
+    let primary_label = usage
+        .primary_label
+        .as_deref()
+        .unwrap_or(metadata.session_label);
     let mut parts = Vec::new();
     let reset = if usage.primary.is_informational {
-        parts.push(format!("{} unavailable", metadata.session_label));
+        parts.push(format!("{primary_label} unavailable"));
         usage.secondary.as_ref().unwrap_or(&usage.primary)
     } else {
         parts.push(format!(
             "{} {}",
-            metadata.session_label,
+            primary_label,
             format_percent(usage.primary.used_percent)
         ));
         &usage.primary
@@ -812,6 +808,19 @@ mod tests {
             output,
             "Claude: Session (5h) <1%, Weekly 100%, resets n/a, Pro"
         );
+    }
+
+    #[test]
+    fn primary_label_override_is_shared_by_full_and_brief_renderers() {
+        let result =
+            fetch_result(UsageSnapshot::new(RateWindow::new(42.0)).with_primary_label("Monthly"));
+
+        let full = render_text_with_status(ProviderId::Grok, &result, None, false);
+        let brief = render_brief_text(ProviderId::Grok, &result);
+
+        assert!(full.contains("Monthly:"));
+        assert!(brief.contains("Grok: Monthly 42%"));
+        assert!(!brief.contains("Credits 42%"));
     }
 
     #[test]

--- a/rust/src/core/usage_snapshot.rs
+++ b/rust/src/core/usage_snapshot.rs
@@ -76,6 +76,11 @@ pub struct UsageSnapshot {
     /// Primary rate window (usually session-based, e.g., 5-hour for Claude)
     pub primary: RateWindow,
 
+    /// Provider-resolved label for the primary rate window when the stable
+    /// provider metadata label is not specific enough for this snapshot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_label: Option<String>,
+
     /// Secondary rate window (usually weekly/monthly)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secondary: Option<RateWindow>,
@@ -113,6 +118,7 @@ impl UsageSnapshot {
     pub fn new(primary: RateWindow) -> Self {
         Self {
             primary,
+            primary_label: None,
             secondary: None,
             model_specific: None,
             tertiary: None,
@@ -122,6 +128,12 @@ impl UsageSnapshot {
             account_organization: None,
             login_method: None,
         }
+    }
+
+    /// Builder pattern: override the primary window label for this snapshot.
+    pub fn with_primary_label(mut self, label: impl Into<String>) -> Self {
+        self.primary_label = Some(label.into());
+        self
     }
 
     /// Builder pattern: set secondary window

--- a/rust/src/providers/grok/mod.rs
+++ b/rust/src/providers/grok/mod.rs
@@ -33,7 +33,7 @@ impl GrokProvider {
             metadata: ProviderMetadata {
                 id: ProviderId::Grok,
                 display_name: "Grok",
-                session_label: "Monthly",
+                session_label: "Credits",
                 weekly_label: "On-demand",
                 supports_opus: false,
                 supports_credits: false,
@@ -436,6 +436,49 @@ struct GrokBillingSnapshot {
     resets_at: Option<DateTime<Utc>>,
 }
 
+/// Upstream `GrokProviderDescriptor.primaryLabel(duration:)`: round remaining
+/// time to days, then Weekly for 4...12 and Monthly for 20...45.
+pub fn primary_label_for_duration(seconds: f64) -> Option<&'static str> {
+    if seconds <= 3600.0 {
+        return None;
+    }
+    let days = (seconds / 86_400.0).round() as i64;
+    if (4..=12).contains(&days) {
+        Some("Weekly")
+    } else if (20..=45).contains(&days) {
+        Some("Monthly")
+    } else {
+        None
+    }
+}
+
+/// Upstream `displayLabel`: prefer an explicit duration/reset cycle, else keep
+/// Weekly near the end of an untyped credits window (#2929).
+pub fn display_label(window: &RateWindow, now: DateTime<Utc>) -> Option<&'static str> {
+    if let Some(minutes) = window.window_minutes {
+        return primary_label_for_duration(f64::from(minutes) * 60.0);
+    }
+    if let Some(resets_at) = window.resets_at {
+        if let Some(label) = primary_label_for_duration((resets_at - now).num_seconds() as f64) {
+            return Some(label);
+        }
+        return Some("Weekly");
+    }
+    None
+}
+
+fn grok_window_minutes(resets_at: Option<DateTime<Utc>>, now: DateTime<Utc>) -> Option<u32> {
+    let resets_at = resets_at?;
+    match primary_label_for_duration((resets_at - now).num_seconds() as f64) {
+        Some("Weekly") => Some(crate::core::WEEKLY_WINDOW_MINUTES),
+        Some("Monthly") => {
+            RateWindow::monthly_window_minutes(Some(resets_at)).or(Some(crate::core::MONTHLY_WINDOW_MINUTES))
+        }
+        // Untyped reset (e.g. 2 days left in SuperGrok weekly): keep weekly so pace works.
+        _ => Some(crate::core::WEEKLY_WINDOW_MINUTES),
+    }
+}
+
 fn result_from_billing(
     billing: GrokBillingSnapshot,
     source_label: &str,
@@ -443,10 +486,33 @@ fn result_from_billing(
     team_id: Option<String>,
     login_method: Option<String>,
 ) -> ProviderFetchResult {
-    // Upstream #2431 / #2566: do not infer windowMinutes from time-until-reset.
-    // A monthly quota near its reset would otherwise be misclassified as weekly.
+    result_from_billing_at(
+        billing,
+        source_label,
+        email,
+        team_id,
+        login_method,
+        Utc::now(),
+    )
+}
+
+fn result_from_billing_at(
+    billing: GrokBillingSnapshot,
+    source_label: &str,
+    email: Option<String>,
+    team_id: Option<String>,
+    login_method: Option<String>,
+    now: DateTime<Utc>,
+) -> ProviderFetchResult {
+    // Upstream docs/grok.md: live bar is Credits; Weekly/Monthly come from whether
+    // resetsAt matches a common cycle. Win-CodexBar also needs window_minutes for pace.
     let primary = match billing.used_percent {
-        Some(used_percent) => RateWindow::with_details(used_percent, None, billing.resets_at, None),
+        Some(used_percent) => RateWindow::with_details(
+            used_percent,
+            grok_window_minutes(billing.resets_at, now),
+            billing.resets_at,
+            None,
+        ),
         None => {
             let mut window = RateWindow::informational("Usage unavailable");
             window.resets_at = billing.resets_at;
@@ -794,10 +860,10 @@ mod tests {
     }
 
     #[test]
-    fn billing_snapshot_leaves_window_minutes_unset() {
-        // A monthly quota with six days left must not be reported as weekly.
-        let resets = Utc::now() + chrono::Duration::days(6);
-        let result = result_from_billing(
+    fn billing_snapshot_classifies_weekly_from_reset_distance() {
+        let now = Utc::now();
+        let resets = now + chrono::Duration::days(6);
+        let result = result_from_billing_at(
             GrokBillingSnapshot {
                 used_percent: Some(12.0),
                 resets_at: Some(resets),
@@ -806,10 +872,71 @@ mod tests {
             None,
             None,
             Some("SuperGrok".into()),
+            now,
         );
-        assert_eq!(result.usage.primary.window_minutes, None);
-        assert_eq!(result.usage.primary.resets_at, Some(resets));
-        assert_eq!(result.usage.login_method.as_deref(), Some("SuperGrok"));
+        assert_eq!(
+            result.usage.primary.window_minutes,
+            Some(crate::core::WEEKLY_WINDOW_MINUTES)
+        );
+        assert_eq!(
+            display_label(&result.usage.primary, now),
+            Some("Weekly")
+        );
+        let pace = crate::core::UsagePace::weekly(
+            &result.usage.primary,
+            Some(now),
+            crate::core::WEEKLY_WINDOW_MINUTES,
+        );
+        assert!(pace.is_some(), "weekly window + reset must yield pace");
+    }
+
+    #[test]
+    fn billing_snapshot_classifies_monthly_from_reset_distance() {
+        let now = Utc::now();
+        let resets = now + chrono::Duration::days(28);
+        let result = result_from_billing_at(
+            GrokBillingSnapshot {
+                used_percent: Some(40.0),
+                resets_at: Some(resets),
+            },
+            "cli",
+            None,
+            None,
+            Some("SuperGrok Heavy".into()),
+            now,
+        );
+        assert_eq!(display_label(&result.usage.primary, now), Some("Monthly"));
+        assert!(
+            result.usage.primary.window_minutes.unwrap() >= 27 * 24 * 60,
+            "monthly window should be a calendar month, got {:?}",
+            result.usage.primary.window_minutes
+        );
+    }
+
+    #[test]
+    fn untyped_near_reset_keeps_weekly_label_and_duration() {
+        let now = Utc::now();
+        let resets = now + chrono::Duration::days(2);
+        assert_eq!(primary_label_for_duration(2.0 * 86_400.0), None);
+        let result = result_from_billing_at(
+            GrokBillingSnapshot {
+                used_percent: Some(80.0),
+                resets_at: Some(resets),
+            },
+            "web",
+            None,
+            None,
+            Some("SuperGrok".into()),
+            now,
+        );
+        assert_eq!(
+            result.usage.primary.window_minutes,
+            Some(crate::core::WEEKLY_WINDOW_MINUTES)
+        );
+        assert_eq!(
+            display_label(&result.usage.primary, now),
+            Some("Weekly")
+        );
     }
 
     #[test]

--- a/rust/src/providers/grok/mod.rs
+++ b/rust/src/providers/grok/mod.rs
@@ -434,48 +434,24 @@ fn text_field(value: &Value, key: &str) -> Option<String> {
 struct GrokBillingSnapshot {
     used_percent: Option<f64>,
     resets_at: Option<DateTime<Utc>>,
+    window_minutes: Option<u32>,
 }
 
-/// Upstream `GrokProviderDescriptor.primaryLabel(duration:)`: round remaining
-/// time to days, then Weekly for 4...12 and Monthly for 20...45.
-pub fn primary_label_for_duration(seconds: f64) -> Option<&'static str> {
-    if seconds <= 3600.0 {
+/// Classify Grok from the full billing-cycle duration, not time remaining.
+/// This preserves the upstream #2431/#2566 invariant that a monthly plan near
+/// its reset must not become a weekly plan.
+fn primary_label_for_cycle_minutes(minutes: u32) -> Option<&'static str> {
+    const DAY_MINUTES: u32 = 24 * 60;
+    if minutes <= 60 {
         return None;
     }
-    let days = (seconds / 86_400.0).round() as i64;
+    let days = (minutes + DAY_MINUTES / 2) / DAY_MINUTES;
     if (4..=12).contains(&days) {
         Some("Weekly")
     } else if (20..=45).contains(&days) {
         Some("Monthly")
     } else {
         None
-    }
-}
-
-/// Upstream `displayLabel`: prefer an explicit duration/reset cycle, else keep
-/// Weekly near the end of an untyped credits window (#2929).
-pub fn display_label(window: &RateWindow, now: DateTime<Utc>) -> Option<&'static str> {
-    if let Some(minutes) = window.window_minutes {
-        return primary_label_for_duration(f64::from(minutes) * 60.0);
-    }
-    if let Some(resets_at) = window.resets_at {
-        if let Some(label) = primary_label_for_duration((resets_at - now).num_seconds() as f64) {
-            return Some(label);
-        }
-        return Some("Weekly");
-    }
-    None
-}
-
-fn grok_window_minutes(resets_at: Option<DateTime<Utc>>, now: DateTime<Utc>) -> Option<u32> {
-    let resets_at = resets_at?;
-    match primary_label_for_duration((resets_at - now).num_seconds() as f64) {
-        Some("Weekly") => Some(crate::core::WEEKLY_WINDOW_MINUTES),
-        Some("Monthly") => {
-            RateWindow::monthly_window_minutes(Some(resets_at)).or(Some(crate::core::MONTHLY_WINDOW_MINUTES))
-        }
-        // Untyped reset (e.g. 2 days left in SuperGrok weekly): keep weekly so pace works.
-        _ => Some(crate::core::WEEKLY_WINDOW_MINUTES),
     }
 }
 
@@ -486,40 +462,30 @@ fn result_from_billing(
     team_id: Option<String>,
     login_method: Option<String>,
 ) -> ProviderFetchResult {
-    result_from_billing_at(
-        billing,
-        source_label,
-        email,
-        team_id,
-        login_method,
-        Utc::now(),
-    )
-}
-
-fn result_from_billing_at(
-    billing: GrokBillingSnapshot,
-    source_label: &str,
-    email: Option<String>,
-    team_id: Option<String>,
-    login_method: Option<String>,
-    now: DateTime<Utc>,
-) -> ProviderFetchResult {
-    // Upstream docs/grok.md: live bar is Credits; Weekly/Monthly come from whether
-    // resetsAt matches a common cycle. Win-CodexBar also needs window_minutes for pace.
+    // Dynamic cadence is provider-owned and comes only from a complete billing
+    // cycle. A reset timestamp alone is insufficient because monthly quotas can
+    // have only a few days remaining.
+    let primary_label = billing
+        .window_minutes
+        .and_then(primary_label_for_cycle_minutes);
     let primary = match billing.used_percent {
         Some(used_percent) => RateWindow::with_details(
             used_percent,
-            grok_window_minutes(billing.resets_at, now),
+            billing.window_minutes,
             billing.resets_at,
             None,
         ),
         None => {
             let mut window = RateWindow::informational("Usage unavailable");
             window.resets_at = billing.resets_at;
+            window.window_minutes = billing.window_minutes;
             window
         }
     };
     let mut usage = UsageSnapshot::new(primary);
+    if let Some(label) = primary_label {
+        usage = usage.with_primary_label(label);
+    }
     usage.account_email = email;
     usage.account_organization = team_id;
     usage.login_method = login_method;
@@ -598,27 +564,48 @@ fn parse_grpc_web_response(data: &[u8]) -> Result<GrokBillingSnapshot, ProviderE
         })
         .map(|field| field.value as f64);
 
+    let now = Utc::now();
     let resets_at = scan
         .varints
         .iter()
-        .filter_map(|field| {
-            // Varint timestamps are Unix seconds inside the range checked below.
-            #[allow(
-                clippy::cast_possible_wrap,
-                reason = "varint timestamps are bounded to the Unix-seconds range checked below"
-            )]
-            let seconds = field.value as i64;
-            (1_700_000_000..=2_100_000_000)
-                .contains(&field.value)
-                .then(|| Utc.timestamp_opt(seconds, 0).single())
-                .flatten()
-        })
-        .filter(|dt| *dt > Utc::now())
+        .filter_map(varint_timestamp)
+        .filter(|dt| *dt > now)
         .min();
     Ok(GrokBillingSnapshot {
         used_percent,
         resets_at,
+        window_minutes: current_period_window_minutes(&scan, now),
     })
+}
+
+fn varint_timestamp(field: &VarintField) -> Option<DateTime<Utc>> {
+    // Varint timestamps are Unix seconds inside the range checked below.
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "varint timestamps are bounded to the Unix-seconds range checked below"
+    )]
+    let seconds = field.value as i64;
+    (1_700_000_000..=2_100_000_000)
+        .contains(&field.value)
+        .then(|| Utc.timestamp_opt(seconds, 0).single())
+        .flatten()
+}
+
+fn current_period_window_minutes(scan: &ProtoScan, now: DateTime<Utc>) -> Option<u32> {
+    let timestamp_at = |path: &[u64]| {
+        scan.varints
+            .iter()
+            .find(|field| field.path.as_slice() == path)
+            .and_then(varint_timestamp)
+    };
+    let start = timestamp_at(&[1, 8, 2, 1])?;
+    let end = timestamp_at(&[1, 8, 3, 1])?;
+    if start > now || end <= now || end <= start {
+        return None;
+    }
+    u32::try_from((end - start).num_minutes())
+        .ok()
+        .filter(|minutes| *minutes > 0)
 }
 
 fn grpc_web_data_frames(data: &[u8]) -> Vec<Vec<u8>> {
@@ -657,6 +644,7 @@ struct Fixed32Field {
 }
 
 struct VarintField {
+    path: Vec<u64>,
     value: u64,
 }
 
@@ -690,7 +678,7 @@ impl ProtoScan {
         wire: u64,
     ) -> Option<usize> {
         match wire {
-            0 => self.scan_varint(data, i),
+            0 => self.scan_varint(data, i, path),
             2 => self.scan_length_delimited(data, i, path, depth),
             5 => self.scan_fixed32(data, i, path),
             1 => Some(i.saturating_add(8)),
@@ -698,9 +686,12 @@ impl ProtoScan {
         }
     }
 
-    fn scan_varint(&mut self, data: &[u8], i: usize) -> Option<usize> {
+    fn scan_varint(&mut self, data: &[u8], i: usize, path: &[u64]) -> Option<usize> {
         let (value, next) = read_varint(data, i)?;
-        self.varints.push(VarintField { value });
+        self.varints.push(VarintField {
+            path: path.to_vec(),
+            value,
+        });
         Some(next)
     }
 
@@ -860,28 +851,25 @@ mod tests {
     }
 
     #[test]
-    fn billing_snapshot_classifies_weekly_from_reset_distance() {
+    fn billing_snapshot_uses_full_weekly_cycle_for_pace() {
         let now = Utc::now();
-        let resets = now + chrono::Duration::days(6);
-        let result = result_from_billing_at(
+        let resets = now + chrono::Duration::days(2);
+        let result = result_from_billing(
             GrokBillingSnapshot {
                 used_percent: Some(12.0),
                 resets_at: Some(resets),
+                window_minutes: Some(crate::core::WEEKLY_WINDOW_MINUTES),
             },
             "web",
             None,
             None,
             Some("SuperGrok".into()),
-            now,
         );
         assert_eq!(
             result.usage.primary.window_minutes,
             Some(crate::core::WEEKLY_WINDOW_MINUTES)
         );
-        assert_eq!(
-            display_label(&result.usage.primary, now),
-            Some("Weekly")
-        );
+        assert_eq!(result.usage.primary_label.as_deref(), Some("Weekly"));
         let pace = crate::core::UsagePace::weekly(
             &result.usage.primary,
             Some(now),
@@ -891,51 +879,70 @@ mod tests {
     }
 
     #[test]
-    fn billing_snapshot_classifies_monthly_from_reset_distance() {
+    fn monthly_cycle_stays_monthly_with_six_days_remaining() {
         let now = Utc::now();
-        let resets = now + chrono::Duration::days(28);
-        let result = result_from_billing_at(
+        let resets = now + chrono::Duration::days(6);
+        let monthly_minutes = 31 * 24 * 60;
+        let result = result_from_billing(
             GrokBillingSnapshot {
                 used_percent: Some(40.0),
                 resets_at: Some(resets),
+                window_minutes: Some(monthly_minutes),
             },
             "cli",
             None,
             None,
             Some("SuperGrok Heavy".into()),
-            now,
         );
-        assert_eq!(display_label(&result.usage.primary, now), Some("Monthly"));
-        assert!(
-            result.usage.primary.window_minutes.unwrap() >= 27 * 24 * 60,
-            "monthly window should be a calendar month, got {:?}",
-            result.usage.primary.window_minutes
-        );
+        assert_eq!(result.usage.primary_label.as_deref(), Some("Monthly"));
+        assert_eq!(result.usage.primary.window_minutes, Some(monthly_minutes));
     }
 
     #[test]
-    fn untyped_near_reset_keeps_weekly_label_and_duration() {
-        let now = Utc::now();
-        let resets = now + chrono::Duration::days(2);
-        assert_eq!(primary_label_for_duration(2.0 * 86_400.0), None);
-        let result = result_from_billing_at(
+    fn reset_distance_alone_does_not_invent_a_cadence() {
+        let resets = Utc::now() + chrono::Duration::days(6);
+        let result = result_from_billing(
             GrokBillingSnapshot {
                 used_percent: Some(80.0),
                 resets_at: Some(resets),
+                window_minutes: None,
             },
             "web",
             None,
             None,
             Some("SuperGrok".into()),
-            now,
+        );
+        assert_eq!(result.usage.primary.window_minutes, None);
+        assert_eq!(result.usage.primary_label, None);
+    }
+
+    #[test]
+    fn current_period_paths_define_the_full_cycle() {
+        let now = Utc.timestamp_opt(1_800_000_000, 0).single().unwrap();
+        let start = now - chrono::Duration::days(25);
+        let end = now + chrono::Duration::days(6);
+        let scan = ProtoScan {
+            fixed32: Vec::new(),
+            varints: vec![
+                VarintField {
+                    path: vec![1, 8, 2, 1],
+                    value: u64::try_from(start.timestamp()).unwrap(),
+                },
+                VarintField {
+                    path: vec![1, 8, 3, 1],
+                    value: u64::try_from(end.timestamp()).unwrap(),
+                },
+            ],
+            order: 0,
+        };
+
+        assert_eq!(
+            current_period_window_minutes(&scan, now),
+            Some(31 * 24 * 60)
         );
         assert_eq!(
-            result.usage.primary.window_minutes,
-            Some(crate::core::WEEKLY_WINDOW_MINUTES)
-        );
-        assert_eq!(
-            display_label(&result.usage.primary, now),
-            Some("Weekly")
+            primary_label_for_cycle_minutes(current_period_window_minutes(&scan, now).unwrap()),
+            Some("Monthly")
         );
     }
 
@@ -946,6 +953,7 @@ mod tests {
             GrokBillingSnapshot {
                 used_percent: None,
                 resets_at: Some(resets),
+                window_minutes: None,
             },
             "cli",
             Some("user@example.com".into()),


### PR DESCRIPTION
Supersedes #412 because GitHub reports `maintainerCanModify=true` but authenticated maintainer writes to the contributor fork are rejected. This preserves the contributor's original Grok cadence work and applies the thermo fixes before merge.

## Thermo findings resolved

1. **No reset-distance misclassification.** Grok no longer decides Weekly/Monthly from time remaining. The gRPC protobuf scanner now retains field paths and derives the full active billing period from upstream's current-period start/end fields (`[1,8,2,1]` / `[1,8,3,1]`). A monthly cycle with only 6 days remaining therefore stays Monthly.
2. **No Grok branching in shared consumers.** Grok resolves the dynamic label inside the provider and stamps a generic optional `UsageSnapshot.primary_label`. CLI and desktop bridge simply read that generic field with the existing metadata fallback. No `if Grok` / `grok::display_label` remains in shared paths.
3. **Removed the broad fallback wrapper.** The old `grok_window_minutes` reset-distance fallback is gone. `window_minutes` exists only when the provider has full-cycle evidence; reset timestamp alone leaves cadence unset.
4. **Consumer behavior is explicit.** Full and brief CLI renderers both use the same snapshot label override. Grok's stable metadata label remains `Credits`; a proven live cycle renders `Weekly` or `Monthly`. Primary pace uses the actual published window duration, independently from presentation labeling.

## Regression coverage

- weekly full cycle still yields Weekly + pace
- 31-day monthly cycle with 6 days remaining stays Monthly
- reset distance alone cannot invent a cadence
- protobuf current-period start/end paths produce the full 31-day cycle
- generic primary-label override is honored consistently by full and brief CLI rendering

## Validation

- `cargo fmt --all --check` passed
- `git diff --check` passed
- targeted source sweep confirms no Grok-specific branching remains in shared CLI/bridge paths
- local Rust execution is unavailable on this machine because only Git's Unix `link.exe` is installed and MSVC `cl.exe`/linker are absent; protected CircleCI Windows is the authoritative compile/test gate

The original contributor commit is preserved underneath the separate NessZerra thermo-fix commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Usage displays now use provider-supplied labels for primary limits when available.
  - Full and brief usage views consistently show the correct primary limit label.
  - Pace calculations now support session-based, weekly, and longer billing periods.
  - Grok usage now identifies primary limits as “Credits” and more accurately reflects weekly or monthly billing windows.
  - Billing period timing and reset information are now handled more accurately, including periods close to reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->