### PR TITLE
fix(ollama): try every browser before giving up on cookie import

### DIFF
--- a/rust/src/providers/ollama/cookies.rs
+++ b/rust/src/providers/ollama/cookies.rs
@@ -153,16 +153,35 @@ pub(super) fn resolve_browser_cookie_header(
         return Ok(Some(cached.cookie_header));
     }
 
-    match crate::providers::browser_cookies_for_domain(OLLAMA_COOKIE_DOMAIN) {
-        Ok(cookies) => {
-            let url = Url::parse("https://ollama.com/settings")
-                .map_err(|e| ProviderError::Other(e.to_string()))?;
-            Ok(ollama_cookie_header_for_url(&cookies, &url)
-                .filter(|h| has_recognized_ollama_session_cookie(h)))
-        }
-        Err(ProviderError::NoCookies) => Ok(None),
-        Err(err) => Err(err),
-    }
+    let url = Url::parse("https://ollama.com/settings")
+        .map_err(|e| ProviderError::Other(e.to_string()))?;
+
+    // Upstream Win-CodexBar #426: the generic `browser_cookies_for_domain` helper
+    // stops at the FIRST installed browser that has *any* cookies for the domain,
+    // even if those cookies are stale/irrelevant (e.g. a consent or CDN cookie left
+    // behind in Chrome/Edge from a one-off visit) and don't include a recognized
+    // Ollama session cookie. That starves out a later browser (often Brave) that
+    // actually holds the logged-in session. Walk every detected browser ourselves
+    // and keep going until one yields a header with a recognized session cookie.
+    use crate::browser::cookies::CookieExtractor;
+    use crate::browser::detection::BrowserDetector;
+
+    let cookie_sets = BrowserDetector::detect_all()
+        .into_iter()
+        .filter_map(|browser| {
+            CookieExtractor::extract_for_domain(&browser, OLLAMA_COOKIE_DOMAIN).ok()
+        });
+    Ok(first_recognized_cookie_header(cookie_sets, &url))
+}
+
+/// Return the header for the first cookie set (in order) that contains a
+/// recognized Ollama session cookie for `url`, skipping sets that decrypt
+/// fine but carry no usable session (see `resolve_browser_cookie_header`).
+fn first_recognized_cookie_header(
+    mut cookie_sets: impl Iterator<Item = Vec<Cookie>>,
+    url: &Url,
+) -> Option<String> {
+    cookie_sets.find_map(|cookies| ollama_cookie_header_for_url(&cookies, url))
 }
 
 pub(super) fn should_attach_ollama_cookie(url: &Url) -> bool {
@@ -283,6 +302,62 @@ mod tests {
             normalize_cookie_header("-b \"__Secure-session=abc123\""),
             Some("__Secure-session=abc123".to_string())
         );
+    }
+
+    #[test]
+    fn first_recognized_cookie_header_skips_browsers_without_a_session_cookie() {
+        // Regression for #426: an earlier-priority browser (e.g. Chrome/Edge)
+        // may hold only stale/irrelevant ollama.com cookies (analytics,
+        // consent) with no session cookie at all. The old
+        // `browser_cookies_for_domain` helper stopped at that first non-empty
+        // result and never reached a later browser (e.g. Brave) that actually
+        // holds the logged-in session.
+        let irrelevant_only = vec![Cookie {
+            name: "aid".to_string(),
+            value: "device-id".to_string(),
+            domain: "ollama.com".to_string(),
+            path: "/".to_string(),
+            expires: None,
+            is_secure: true,
+            is_http_only: false,
+        }];
+        let real_session = vec![Cookie {
+            name: OLLAMA_SESSION_COOKIE_NAME.to_string(),
+            value: "abc123".to_string(),
+            domain: "ollama.com".to_string(),
+            path: "/".to_string(),
+            expires: None,
+            is_secure: true,
+            is_http_only: true,
+        }];
+
+        let url = Url::parse("https://ollama.com/settings").unwrap();
+        let header =
+            first_recognized_cookie_header(vec![irrelevant_only, real_session].into_iter(), &url);
+
+        assert_eq!(
+            header.as_deref(),
+            Some("__Secure-session=abc123"),
+            "should skip the first (irrelevant) cookie set and use the second (real session)"
+        );
+    }
+
+    #[test]
+    fn first_recognized_cookie_header_none_when_no_set_has_a_session_cookie() {
+        let only_irrelevant = vec![Cookie {
+            name: "aid".to_string(),
+            value: "device-id".to_string(),
+            domain: "ollama.com".to_string(),
+            path: "/".to_string(),
+            expires: None,
+            is_secure: true,
+            is_http_only: false,
+        }];
+
+        let url = Url::parse("https://ollama.com/settings").unwrap();
+        let header = first_recognized_cookie_header(vec![only_irrelevant].into_iter(), &url);
+
+        assert_eq!(header, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #426.

Auto/Web cookie import for Ollama used `browser_cookies_for_domain`, which stops at the **first installed browser** that returns any cookies for `ollama.com` — even when those cookies are stale/irrelevant (e.g. an analytics or consent cookie left over from a one-off visit in Chrome/Edge) and carry no recognized session cookie. That starves out a later browser (often the one actually signed in, e.g. Brave) and the fetch fails with `No cookies available for web API`, even though a valid, logged-in session is sitting right there on disk.

## Fix

`resolve_browser_cookie_header` now walks every detected browser and keeps going until one yields a header containing a recognized Ollama session cookie, instead of stopping at the first non-empty result. The selection logic is extracted into a small pure helper (`first_recognized_cookie_header`) so it's testable without real browser I/O.

## Verified

- Reproduced the exact bug against a real multi-browser Windows machine: Chrome/Edge held only unrelated `ollama.com` cookies, Brave held the real `__Secure-session`, and the old code returned `NoCookies` while stopping at Chrome.
- With the fix, `codexbar diagnose -p ollama` returns real, cookie-scraped usage data end-to-end.
- Added a focused unit test reproducing the regression (first cookie set irrelevant-only, second set has the real session → header comes from the second set).

## Test plan

```
cargo test --manifest-path rust/Cargo.toml providers::ollama
cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
cargo fmt --manifest-path rust/Cargo.toml -- --check
```
All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L23pzyCfMvfbMQwnHXmKCp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Ollama browser cookie detection by checking all available browsers and selecting a valid session cookie when present.
  - Prevents irrelevant cookie sets from stopping cookie resolution prematurely.
  - Returns no result when no recognized session cookie is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->