### PR TITLE
Fix model pricing refresh without PowerToys integration

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
+++ b/apps/desktop-tauri/src-tauri/src/auto_refresh.rs
@@ -180,11 +180,7 @@ fn next_fixed_tick(
     scheduled_at
 }
 
-fn powertoys_local_usage_provider_ids(settings: &Settings) -> Vec<String> {
-    if !settings.powertoys_status_pipe_enabled {
-        return Vec::new();
-    }
-
+fn local_usage_provider_ids(settings: &Settings) -> Vec<String> {
     settings
         .get_enabled_provider_ids()
         .into_iter()
@@ -194,7 +190,9 @@ fn powertoys_local_usage_provider_ids(settings: &Settings) -> Vec<String> {
 }
 
 pub(crate) fn schedule_refresh_enrichment(settings: &Settings) {
-    let provider_ids = powertoys_local_usage_provider_ids(settings);
+    // Unknown-model pricing is shared by Usage & Spend, not just the optional
+    // PowerToys status pipe. Refresh it even when that integration is disabled.
+    let provider_ids = local_usage_provider_ids(settings);
     if provider_ids.is_empty() {
         return;
     }
@@ -291,19 +289,38 @@ mod tests {
     }
 
     #[test]
-    fn powertoys_local_usage_refresh_only_includes_supported_enabled_providers() {
-        let mut settings = Settings::default();
-        assert!(powertoys_local_usage_provider_ids(&settings).is_empty());
+    fn local_usage_refresh_includes_codex_without_powertoys() {
+        let settings = Settings {
+            powertoys_status_pipe_enabled: false,
+            enabled_providers: ["codex".to_string(), "cursor".to_string()]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
 
-        settings.powertoys_status_pipe_enabled = true;
-        settings.enabled_providers = ["codex".to_string(), "cursor".to_string()]
-            .into_iter()
-            .collect();
+        assert_eq!(local_usage_provider_ids(&settings), vec!["codex"]);
+        assert!(!settings.powertoys_status_pipe_enabled);
+    }
 
-        assert_eq!(
-            powertoys_local_usage_provider_ids(&settings),
-            vec!["codex".to_string()]
-        );
+    #[test]
+    fn local_usage_refresh_only_includes_supported_enabled_providers() {
+        for pipe_enabled in [false, true] {
+            let mut settings = Settings {
+                powertoys_status_pipe_enabled: pipe_enabled,
+                enabled_providers: ["claude".to_string(), "cursor".to_string()]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            };
+
+            assert_eq!(local_usage_provider_ids(&settings), vec!["claude"]);
+
+            settings.enabled_providers = ["cursor".to_string()].into_iter().collect();
+            assert!(local_usage_provider_ids(&settings).is_empty());
+
+            settings.enabled_providers.clear();
+            assert!(local_usage_provider_ids(&settings).is_empty());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix dynamic model-pricing refresh being incorrectly gated behind the optional PowerToys status pipe.

`refresh_providers` schedules local usage enrichment, but `powertoys_local_usage_provider_ids` returned an empty list whenever `powertoys_status_pipe_enabled` was false (the default). That enrichment path contains the only call to `refresh_unknown_models_if_needed`, so a normal installation without PowerToys integration could never download the models.dev pricing cache. Models absent from the bundled table, such as `gpt-6-astra`, remained marked unpriced even when models.dev already supplied their prices. Refreshing Usage & Spend only rescanned usage and did not fetch the missing catalog.

- Select enabled Codex/Claude providers independently of the PowerToys setting; rename the helper to `local_usage_provider_ids`.
- Preserve existing background-task coalescing and supported/enabled-provider filtering.
- Keep the actual PowerToys pipe server opt-in; no settings or credentials are changed, and no model prices are hardcoded.
- Add regression coverage for Codex with the pipe disabled and for supported/enabled-provider filtering with the pipe both off and on.

## Related issue

No existing issue linked. Reproduced on v0.55.0; the same gate is present on current main.

## Affected areas

- [x] Provider-specific behavior: local Codex/Claude pricing enrichment
- [x] Startup / background behavior
- [x] Other: Usage & Spend pricing completeness
- No settings UI, installer, or dependency changes.

## Validation

Native Windows validation against the patched tree:

- [x] Regression RED: the two new tests failed before the fix (empty provider lists instead of Codex/Claude).
- [x] Regression GREEN: both tests pass after removing the gate.
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace --locked`: 1,760 tests passed (1,396 shared library, 1 CLI, 363 desktop).
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `pnpm test`: 291 tests passed across 47 files.
- [x] `pnpm run build`: locale check, TypeScript check, and Vite build passed.
- [x] `pnpm run tauri:build`: optimized Windows desktop executable built successfully.
- [x] Independent review: no code/spec/security blockers found.

The workspace emits an existing ignored member-profile warning; frontend tests emit existing React act/locale-test warnings. No test failures. Used the locked dependencies and pnpm 11.24.0; no lockfiles changed.

## Runtime proof

On a Windows installation with Codex enabled, `powertoys_status_pipe_enabled=false`, and no `model-pricing/models-dev-v1.json`:

1. The existing CLI reported `gpt-6-astra` in `modelPricingCompleteness.partial.unpriced_models`.
2. Launching the freshly built patched desktop app automatically created the pricing cache containing Astra.
3. The existing CLI then no longer reported Astra as unpriced; PowerToys remained disabled.

No caches were manually seeded or cleared. `codex-auto-review` remains unpriced; this change does not invent a price for unknown models.

## UI / tray proof

No UI layout/control changes. Windows computer-use was unavailable (native helper pipe missing; CUA Driver not installed), so visual UI proof was not captured. The fresh Windows executable and the cache/CLI read-back above provide functional proof of the reported pricing issue, not visual proof.

## Notes for reviewers

Local pricing enrichment now runs for enabled Codex/Claude providers even without PowerToys integration. It retains the existing single-flight guard, scan/cache logic, and pricing refresh throttles. The named-pipe server remains independently guarded in `main.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Local usage information now includes enabled Codex and Claude providers even when PowerToys status integration is unavailable or disabled.
  - Unsupported and disabled providers are excluded from local usage results, improving accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->