### PR TITLE
Fix dark theme select popups

### DIFF
--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -5326,15 +5326,17 @@ html:has(.menu-surface--tray) {
   background-repeat: no-repeat;
   background-position: right 10px center;
   line-height: 20px;
-  color-scheme: light;
 }
-.select option {
-  color: #000;
-  background: #fff;
+[data-theme="dark"] .select {
+  color-scheme: dark;
 }
-.select option:checked {
-  color: #000;
-  background: #dceeff;
+[data-theme="dark"] .select option {
+  color: var(--text-primary);
+  background: var(--app-bg);
+}
+[data-theme="dark"] .select option:checked {
+  color: #fff;
+  background: var(--accent);
 }
 .text-input {
   padding: 0 10px;
@@ -5350,6 +5352,9 @@ html:has(.menu-surface--tray) {
   text-align: center;
   font-variant-numeric: tabular-nums;
   line-height: 20px;
+}
+[data-theme="light"] .select {
+  color-scheme: light;
 }
 [data-theme="light"] .select,
 [data-theme="light"] .number-input,

--- a/apps/desktop-tauri/src/styles.css
+++ b/apps/desktop-tauri/src/styles.css
@@ -5327,14 +5327,20 @@ html:has(.menu-surface--tray) {
   background-position: right 10px center;
   line-height: 20px;
 }
-[data-theme="dark"] .select {
+[data-theme="dark"] .select,
+[data-theme="dark"] .provider-detail-select,
+[data-theme="dark"] .settings-select {
   color-scheme: dark;
 }
-[data-theme="dark"] .select option {
+[data-theme="dark"] .select option,
+[data-theme="dark"] .provider-detail-select option,
+[data-theme="dark"] .settings-select option {
   color: var(--text-primary);
   background: var(--app-bg);
 }
-[data-theme="dark"] .select option:checked {
+[data-theme="dark"] .select option:checked,
+[data-theme="dark"] .provider-detail-select option:checked,
+[data-theme="dark"] .settings-select option:checked {
   color: #fff;
   background: var(--accent);
 }
@@ -5353,7 +5359,9 @@ html:has(.menu-surface--tray) {
   font-variant-numeric: tabular-nums;
   line-height: 20px;
 }
-[data-theme="light"] .select {
+[data-theme="light"] .select,
+[data-theme="light"] .provider-detail-select,
+[data-theme="light"] .settings-select {
   color-scheme: light;
 }
 [data-theme="light"] .select,
@@ -5363,11 +5371,15 @@ html:has(.menu-surface--tray) {
   border: 1px solid rgba(0, 0, 0, 0.12);
   box-shadow: none;
 }
-[data-theme="light"] .select option {
+[data-theme="light"] .select option,
+[data-theme="light"] .provider-detail-select option,
+[data-theme="light"] .settings-select option {
   background: #fff;
   color: var(--text-primary);
 }
-[data-theme="light"] .select option:checked {
+[data-theme="light"] .select option:checked,
+[data-theme="light"] .provider-detail-select option:checked,
+[data-theme="light"] .settings-select option:checked {
   background: var(--accent);
   color: #fff;
 }


### PR DESCRIPTION
## Summary

- stop forcing the shared native select control into the light color scheme
- apply explicit dark native select/option colors under the dark theme
- preserve the existing light popup behavior with an explicit light color scheme

Fixes #470

## Validation

- reproduced on the exact shipped v0.56.8 Windows build with CUA: the dark Settings surface opened the native select popup with a white background and low-contrast option text
- pnpm --dir apps/desktop-tauri test: 59 files, 343 tests passed
- pnpm --dir apps/desktop-tauri run build: passed, including locale drift check and TypeScript build
- git diff --check: passed
- fresh pnpm --dir apps/desktop-tauri run tauri:build:debug was attempted for post-fix CUA proof. The frontend build completes, but Rust dependency build scripts fail because this machine resolves link.exe to C:\Program Files\Git\usr\bin\link.exe instead of the MSVC linker. A fresh desktop binary could therefore not be produced locally for post-fix CUA capture.

## UI proof note

The pre-fix native WebView2 popup was captured on Windows. The fix is limited to the theme-specific CSS controlling that same native select. Hosted Windows CI should provide the fresh build gate; post-fix native-popup CUA is the only local check blocked by the machine linker configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved dark-theme styling for select controls, including provider and settings selectors, with darker option backgrounds and clearer selected-option accents.
  - Preserved the light-theme appearance, including white option backgrounds, across select controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->