### PR TITLE
Port v0.57.0: normalize reserve telemetry pricing alias

### DIFF
--- a/rust/src/core/cost_pricing.rs
+++ b/rust/src/core/cost_pricing.rs
@@ -620,9 +620,16 @@ impl CostUsagePricing {
             return Self::CODEX_UNATTRIBUTED_MODEL.to_string();
         }
 
-        // Remove "openai/" prefix
-        if let Some(rest) = trimmed.strip_prefix("openai/") {
+        // Remove the provider-qualified OpenAI prefix.
+        if let Some((prefix, rest)) = trimmed.split_once('/')
+            && prefix.eq_ignore_ascii_case("openai")
+        {
             trimmed = rest.to_string();
+        }
+
+        // Codex uses this alias for the Luna reserve quota bucket.
+        if trimmed.eq_ignore_ascii_case("gpt-reserve") {
+            return "gpt-5.6-luna".to_string();
         }
 
         // Check if base model (without -codex suffix) exists in pricing

--- a/rust/src/core/cost_pricing_tests.rs
+++ b/rust/src/core/cost_pricing_tests.rs
@@ -20,6 +20,30 @@ fn test_normalize_codex_model() {
         CostUsagePricing::normalize_codex_model("unknown"),
         CostUsagePricing::CODEX_UNATTRIBUTED_MODEL
     );
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model("gpt-reserve"),
+        "gpt-5.6-luna"
+    );
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model(" GPT-RESERVE "),
+        "gpt-5.6-luna"
+    );
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model("openai/gpt-reserve"),
+        "gpt-5.6-luna"
+    );
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model("OPENAI/GPT-RESERVE"),
+        "gpt-5.6-luna"
+    );
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model("gpt-reserve-preview"),
+        "gpt-reserve-preview"
+    );
+    assert_eq!(
+        CostUsagePricing::normalize_codex_model("my-gpt-reserve"),
+        "my-gpt-reserve"
+    );
 }
 
 #[test]
@@ -165,6 +189,22 @@ fn test_gpt56_standard_pricing() {
     ] {
         let cost = CostUsagePricing::codex_cost_usd(model, 1_000, 400, 1_000);
         assert!((cost.unwrap() - expected).abs() < 1e-10, "{model}");
+    }
+}
+
+#[test]
+fn gpt_reserve_alias_uses_luna_pricing() {
+    let luna =
+        CostUsagePricing::codex_cost_usd("gpt-5.6-luna", 1_000, 400, 1_000).expect("Luna pricing");
+    for model in [
+        "gpt-reserve",
+        " GPT-RESERVE ",
+        "openai/gpt-reserve",
+        "OPENAI/GPT-RESERVE",
+    ] {
+        let reserve =
+            CostUsagePricing::codex_cost_usd(model, 1_000, 400, 1_000).expect("reserve pricing");
+        assert!((reserve - luna).abs() < 1e-10, "{model}");
     }
 }
 


### PR DESCRIPTION
## What this ports

Ports upstream commit `57ddfdbf70f2de23c1b5bd8fdb3c660944a22b4a` from `steipete/CodexBar` for the reserve telemetry pricing alias.

The local Rust equivalent normalizes the exact `gpt-reserve` alias to `gpt-5.6-luna`, including trimmed, provider-qualified, and case-insensitive input forms. The shared normalizer is used by both fresh usage and cached pricing paths.

## Scope

Changed files:

- `rust/src/core/cost_pricing.rs`
- `rust/src/core/cost_pricing_tests.rs`

The port intentionally excludes upstream Swift generated pricing, parser/cache, UI, documentation, and changelog surfaces that do not map to this local Rust implementation.

This PR is stacked after the numeric parsing lane in PR #489:

- Base: `port/micro-0.57.0-opencodex-numeric`
- Head: `port/micro-0.57.0-reserve-pricing`

## Validation

- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- Focused Rust test attempted: `core::cost_pricing::tests::gpt_reserve_alias_uses_luna_pricing`
- Focused test was blocked before test execution by the local linker environment: Rust resolved `link.exe` to Git `usr/bin/link.exe`, which rejected MSVC linker arguments with `link: extra operand`.

Oracle reviewed the implementation and approved staging, commit, push, and this stacked PR. The PR remains open for review; no merge is requested by this porting step.
